### PR TITLE
Beamline completion estimates

### DIFF
--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -1,0 +1,5 @@
+
+# Beamline in Dataset
+
+This document focuses on what would be required to complete the rollout of Instrument 2.0 (aka Beamline) in Mantid, in it's current state. Since Dataset can and will support all Geometry, we can use these estimates to inform the rollout strategy and effort for Geometry in Dataset.
+

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -1,5 +1,94 @@
 
 # Beamline in Dataset
 
-This document focuses on what would be required to complete the rollout of Instrument 2.0 (aka Beamline) in Mantid, in it's current state. Since Dataset can and will support all Geometry, we can use these estimates to inform the rollout strategy and effort for Geometry in Dataset.
+The purpose of this document is ultimately to determine how we will properly support Instrument 2.0 (a.k.a Beamine) in Dataset and what the cost will be. **The best way to understand what will be needed for Dataset is first to map out how the remaining rollout would be done ouside of dataset**. Since Dataset can and will support all Geometry, we can use these estimates to inform the rollout strategy and effort for Geometry in Dataset.
+
+## Phases
+
+What is presented here are phases that would need to be completed against Mantid (v.3.14) to get to a point that the Dataset like Beamline types (`DetectorInfo`, `ComponentInfo`, `SpectrumInfo`) could be used without the need whatsoever for `Instrument 1.0`
+
+### Phase 1 - Push Instrument 1.0 to IO aspects only
+
+1. Build new `BeamlineParameterMap` working off component indexes. This would not need to wrap existing `ParameterMap` to support `makeLegacyParameterMap`, but the point of this is to get away from `ComponentIDs`
+1. Replace the `ParameterMap` calls with the above, use `ComponentInfo::indexOfAny` to replace the common `ICompAssembly::getComponentByName()` -> `IComponent::getComponentID()` -> `ComponentInfo::indexOf()` call pattern
+1. Using above, strip aspects all aspects like getComponentID() out of interfaces. In fact, ComponentID would not be allowed to feature as part of function signatures. Involves changing `IComponent` so probably quite involved.
+1. For InstrumentActor, this would be the prime place to use the BeamlineParameterMap (https://github.com/mantidproject/mantid/blob/master/qt/widgets/instrumentview/src/InstrumentActor.cpp#L1108)
+1. We do not need to consider major IO changes as part of this phase. Even makeLegacyParameterMap remains roughly the same
+1. Additional time would be needed to remove other non-ComponentID, Instrument 1.0, types from interfaces (`Detector*`) for example
+
+### Phase 2 - Saving
+
+This is the primary reason the base instrument (instrument 1.0) is still required.
+
+**Options**
+
+a. Break with old file format. 
+  - This would be the simplest from a coding perspective, 
+  - Offers best performance benefits as no special Instrument::makeLegacyParameterMap() required
+  - Only `NexusGeometry` would be suitable for this, this cannot be done with IDFs as Instruments are non-serializeable to IDFs. Probably the limiting factor with this approach.
+  - Could break a large number of system test even if above point not considered. 
+b. Keep a “base” `ComponentInfo/DetectorInfo`. `ComponentInfo/DetectorInfo` would have optional links to a base `ComponentInfo`. 
+  - Avoid changes to file format, **but a lot messier with the need for null checking.** 
+  - Memory overhead for geometry up to 2x greater
+  - Would likely be faster than current Instrument::makeLegacyParameterMap()
+c. Store the delta at the point of writing in `ComponentInfo/DetectorInfo` in a `std::unordered_map<size_t, V3D>` and `std::unordered_map<size_t, Quat>`
+  - Smaller memory overhead than above.
+  - Performance probably the same as the current Instrument::makeLegacyParameterMap(), not advantage 
+  - Write performance would suffer for all geometry operations
+
+### Phase 3: Solve Physical Instrument Issue
+
+Parameter map is shared with Neutronic One. Base Instrument is shared. Currently we handle this via a lazy visit in the `InstrumentView`, that means keeping things as Instrument 1.0. The physical instrument is immutable from the IDF as returned as const ref `Instrument::getPhysicalInstrument()`. In any event, this is ONLY used for instrument view visualisation. 
+
+**Options**
+a. Changing the current setup to be a eager conversion for the cases where a physical instrument existed. 
+  - There are relatively few cases where separate geometries are really needed. Does not affect all instruments.
+  - Allows complete elimination of the physicalInstrument. No need for `ExperimentInfo::getPhysicalInstrument`
+  - The cost in time and memory overhead would occur as part of all data reduction for the affected instruments. Whether the instrument was being visualised or not.
+b. Lazy Physical Instrument Loading.
+  - Essentially pass the specification for getting the instrument from disk, but don't do that at all until required in the `InstrumentView`.
+c. Optional `physical_position`, `physical_rotation` in ComponentInfo, DetectorInfo
+  - Bakes workaround to creating legacy files formats into the data structures, so don't like this much
+
+
+  
+
+
+
+2. Remove Instrument 1.0 entirely
+- Remove Instrument Visitor compatibility mode, 
+	- Do away with builders or constructional objects entirely (new ones may be required), but to stop using Instrument/IComponent etc as an intermediary
+		- Early rollout of this to NexusGeometryParser would be a good proof of concept since Instrument 1.0 has no place their and is simply being used as a builder
+	- We need a converter Instrument 2.0 -> Instrument 1.0 for purposes of maintaining our python exports till such a time they can be eliminated (see below).
+- remove from ExperimentInfo setInstrument/getInstrument. These would be replaced with something like `std::pair<uptr<const DetectorInfo>, uptr<const ComponentInfo>>` Note that getInstrument is exposed to python and would have to remain intact.
+
+
+Excluded/Orphaned:
+
+Saving/Loading format changes.
+    - No legacy parameter map (diffs for positions/rotations) in new style, write straight as NexusGeometry much like `ExportGeometry`
+    - Still need to load old-style files. 
+	- format may be different ParameterMap::saveNexus - Doesn't have to change but DS group are advising on a preferred way of storing information. i.e not in NXNote [here](https://github.com/mantidproject/mantid/issues/23804)
+
+Notes:
+
+
+- ComponentIDs are not written to or read disk, and cannot be since they are simply the address of the in-memory component
+- Important to separate the need for storage of arbitrary parameters against a component and the copy hack employed by Instrument 1.0 to store a modified geometry via parameters of a ParameterMap. The former is still very important.
+
+
+Questions:
+
+- How to handle the Physical Instrument. Parameter map is shared with Neutronic One. Base Instrument is shared. 
+	- Currently we handle this via a lazy visit in the InstrumentView, that means keeping things as Instrument 1.0.
+	- Suggested approach 1. In line with the policy not using Instrument 1.0 outside loading and removing Instrument 1.0 from all signatures, we changing the current setup to be a eager conversion for the cases where a physical instrument existed. 
+		- There are relatively few cases where this is really happening
+		- Allows complete elimination of the physicalInstrument
+		- The cost in time and memory overhead would occur as part of all data reduction, whether the instrument was being visualised or not.
+	- Suggested approach 2. Lazy Physical Instrument Loading.
+		- The physical instrument is immutable from the IDF as returned as const ref Instrument::getPhysicalInstrument(). In any event, this is ONLY used for instrument view visualisation. 
+        - Suggested approach 3. Optional physical_position, physical_rotation in ComponentInfo, DetectorInfo
+	- Suggested approach 4. Use new-style ParameterMap
+
+
 

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -1,7 +1,7 @@
 
 # Beamline in Dataset
 
-The purpose of this document is ultimately to determine how we will properly support Instrument 2.0 (a.k.a Beamine) in Dataset and what the cost will be. **The best way to understand what will be needed for Dataset is first to map out how the remaining rollout would be done ouside of dataset**. Since Dataset can and will support all Geometry, we can use these estimates to inform the rollout strategy and effort for Geometry in Dataset.
+The purpose of this document is ultimately to determine how we will properly support Instrument 2.0 (a.k.a Beamine) in Dataset and what the cost will be. **The best way to understand what will be needed for Dataset is first to map out how the remaining rollout would be done outside of dataset, against existing Workspace**. Since Dataset can and will support all Geometry, we can use these estimates to inform the rollout strategy and effort for Geometry in Dataset.
 
 ## Phases
 
@@ -27,14 +27,17 @@ a. Break with old file format.
   - Offers best performance benefits as no special Instrument::makeLegacyParameterMap() required
   - Only `NexusGeometry` would be suitable for this, this cannot be done with IDFs as Instruments are non-serializeable to IDFs. Probably the limiting factor with this approach.
   - Could break a large number of system test even if above point not considered. 
+  
 b. Keep a “base” `ComponentInfo/DetectorInfo`. `ComponentInfo/DetectorInfo` would have optional links to a base `ComponentInfo`. 
   - Avoid changes to file format, **but a lot messier with the need for null checking.** 
-  - Memory overhead for geometry up to 2x greater
+  - Memory overhead greater, though only base positions and rotations need to be stored
   - Would likely be faster than current Instrument::makeLegacyParameterMap()
+  
 c. Store the delta at the point of writing in `ComponentInfo/DetectorInfo` in a `std::unordered_map<size_t, V3D>` and `std::unordered_map<size_t, Quat>`
   - Smaller memory overhead than above.
   - Performance probably the same as the current Instrument::makeLegacyParameterMap(), not advantage 
   - Write performance would suffer for all geometry operations
+  - As above bakes "work around" for legacy file problem into data type. However much easier to remove and separate than above solution
 
 ### Phase 3: Solve Physical Instrument Issue
 
@@ -45,50 +48,48 @@ a. Changing the current setup to be a eager conversion for the cases where a phy
   - There are relatively few cases where separate geometries are really needed. Does not affect all instruments.
   - Allows complete elimination of the physicalInstrument. No need for `ExperimentInfo::getPhysicalInstrument`
   - The cost in time and memory overhead would occur as part of all data reduction for the affected instruments. Whether the instrument was being visualised or not.
+  
 b. Lazy Physical Instrument Loading.
   - Essentially pass the specification for getting the instrument from disk, but don't do that at all until required in the `InstrumentView`.
-c. Optional `physical_position`, `physical_rotation` in ComponentInfo, DetectorInfo
-  - Bakes workaround to creating legacy files formats into the data structures, so don't like this much
-
-
   
+c. Optional `physical_position`, `physical_rotation` in ComponentInfo, DetectorInfo
+  - Bakes workaround to creating legacy files formats into the data structures, so don't like this a lot
 
+### Phase 4: Remove Instrument 1.0 (almost) entirely
 
+1. Remove Instrument Visitor compatibility mode, 
+  - Do away with builders or constructional objects entirely (new ones may be required), but to stop using `Instrument/IComponent` etc as an intermediary
+    - Early rollout of this to `NexusGeometryParser` would be a good proof of concept since Instrument 1.0 has no place their and is simply being used as a builder
+  - We need a converter Instrument 2.0 -> Instrument 1.0 for purposes of maintaining our python exports till such a time they can be eliminated (see below).
+- remove from `ExperimentInfo` `setInstrument/getInstrument`. These would be replaced with something like `std::pair<uptr<const DetectorInfo>, uptr<const ComponentInfo>>` Note that `ExperimentInfo::getInstrument` is exposed to python and would have to remain intact.
 
-2. Remove Instrument 1.0 entirely
-- Remove Instrument Visitor compatibility mode, 
-	- Do away with builders or constructional objects entirely (new ones may be required), but to stop using Instrument/IComponent etc as an intermediary
-		- Early rollout of this to NexusGeometryParser would be a good proof of concept since Instrument 1.0 has no place their and is simply being used as a builder
-	- We need a converter Instrument 2.0 -> Instrument 1.0 for purposes of maintaining our python exports till such a time they can be eliminated (see below).
-- remove from ExperimentInfo setInstrument/getInstrument. These would be replaced with something like `std::pair<uptr<const DetectorInfo>, uptr<const ComponentInfo>>` Note that getInstrument is exposed to python and would have to remain intact.
+### Phase 5: Remove backwards compatibility. i.e. No Instrument Exports
 
+This is a breaking change so would have to happen at some controlled point.
+1. Remove API
+1. Update internal scripts and algorithms
+1. Amensty for scripts to update
+1. Document and publicise to community removal
 
-Excluded/Orphaned:
-
-Saving/Loading format changes.
-    - No legacy parameter map (diffs for positions/rotations) in new style, write straight as NexusGeometry much like `ExportGeometry`
-    - Still need to load old-style files. 
-	- format may be different ParameterMap::saveNexus - Doesn't have to change but DS group are advising on a preferred way of storing information. i.e not in NXNote [here](https://github.com/mantidproject/mantid/issues/23804)
-
-Notes:
-
+## Notes
 
 - ComponentIDs are not written to or read disk, and cannot be since they are simply the address of the in-memory component
 - Important to separate the need for storage of arbitrary parameters against a component and the copy hack employed by Instrument 1.0 to store a modified geometry via parameters of a ParameterMap. The former is still very important.
 
+## Effort
 
-Questions:
+Effort estimtates based on above considerations
 
-- How to handle the Physical Instrument. Parameter map is shared with Neutronic One. Base Instrument is shared. 
-	- Currently we handle this via a lazy visit in the InstrumentView, that means keeping things as Instrument 1.0.
-	- Suggested approach 1. In line with the policy not using Instrument 1.0 outside loading and removing Instrument 1.0 from all signatures, we changing the current setup to be a eager conversion for the cases where a physical instrument existed. 
-		- There are relatively few cases where this is really happening
-		- Allows complete elimination of the physicalInstrument
-		- The cost in time and memory overhead would occur as part of all data reduction, whether the instrument was being visualised or not.
-	- Suggested approach 2. Lazy Physical Instrument Loading.
-		- The physical instrument is immutable from the IDF as returned as const ref Instrument::getPhysicalInstrument(). In any event, this is ONLY used for instrument view visualisation. 
-        - Suggested approach 3. Optional physical_position, physical_rotation in ComponentInfo, DetectorInfo
-	- Suggested approach 4. Use new-style ParameterMap
+| Phase  | Lower Estimate (Weeks) | Upper Estimate (Weeks) | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| 1  | 4  | 12 | Changing signatures will be the largest effort and unknown |
+| 2(b)  | 1 | 3 | Relatively well understood. Does not require removing base instrument |
+| 3(c)  | 1 | 3 | Solution similar to the above, but fields are optional |
+| 4 |  12 | 32 | Almost total removal as set out in above plan |
+| 5 | 6 | 14 | Complete removal and clean-up |
+| **Total Weeks** | 24 | 64 | | 
+
+**Mapping to Dataset, it is suggested that the above form only the base part of the estimate** The above solutions do not factor in any change or new file format. It may reasonably take 6+ months to design and, implement and optimise a file format and reading/writing functionality.
 
 
 

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -104,7 +104,8 @@ Here are some key differences as relating to the Geometry:
 * No ParameterMap
   - Exact solution(s) not yet apparent, but there are several options. Given that a number of parameters are linked to the instrument and not individual components, this might affect how things are done
 * No `ComponentID` by design. Infact, there may be no requirement for unique identification of `Components` at all.
-* No CSG shapes. Dataset will record information as close as possible to the on-disk Nexus Geometry format specification for meshes and cylinders
+
+- No CSG shapes. Dataset will record information as close as possible to the on-disk Nexus Geometry format specification for meshes and cylinders
 
 Another key difference with the phases for non-dataset approach is that the approach concludes with the complete removal of `Instrument 1.0` but not `Workspace 1.0`. The current preferred rollout for `Dataset` is to develop alongside the existing codebase, and not to consider removal of legacy data structures i.e. Workspace until `Dataset` usage has acted as a full replacement. We would simultaneously depecate then remove `Workspace 1.0`, `Algorithms 1.0`, `Instrument 1.0`, `ExperimentInfo`. 
 
@@ -112,13 +113,13 @@ The net result of these differences is that the activities and timescales differ
 
 ### Activity 1 - Functional wrappers to Dataset for Geometry
 
-Need to provide classes `ComponentInfo` and `Shape` that wrap `Dataset`. These classes should point to a `Dataset` containing all required information. 
+Need to provide a `ComponentInfo` like class that wrap `Dataset` (`ComponentTreeView` as suggested name). These class should point to a `Dataset` containing all required information. 
 
-Note that the on-the-fly `Shape` requirement is new to Mantid, and would take some time to figure out and optimise. Much of the functionality can probably be ported from `NexusGeometryParser`
+Desirable eventual goals for `Dataset` include storing `Shape` in OFF-like `variable` arrays with on-the-fly interpretation. This would take some time to figure out and optimise and would break compatibility across Mantid. Thefore this is not the desired rollout approach. `Dataset` will support a `variable` of type `Geometry::IObject` as the initial aim.   
 
 ### Activity 2 - Saving Loading
 
-As described above, no need to preserve compatibility with existing intermediate formats as far as the total `Dataset` is concerned. Time would need to be invested to trial and optimise these. Requirements for end-users should also be considered, for example if `Dataset` libraries are used outside of Mantid. Note that `Saving` and `Loading` and format specifics must not be mixed into the `Dataset` library. All information, including shape could be preserved via a generic load/save for Dataset.
+There are no special requirements for loading and saving for `Geometry` of `Dataset` above general `Dataset` that are not already under consideration as part of he the wider Nexus Geometry initiative. There is already a need to save Instrument Geometry out to the new-style nexus format.
 
 ### Activity 3 - Serialization/De-serialization NexusGeometry
 
@@ -142,7 +143,9 @@ Should be relatively straight forward given wide spread use of `ComponentInfo`. 
 
 ### Notes
 
-This is slightly beyond the remit of the discussion here, but one concern with the `Dataset` rollout plan is the surge in technical debt. Conceptional understanding for a time will be problematic as there will be two very different ways of supporting data reduction. The size of the codebase will also increase significantly for a time. It may be many years before the codebase can be collapsed. 
+* As part of an overall `Dataset` policy, initial rollout will not attempt to replace auxillary Objects such as `Run`, `Sample`, `Object`, the latter of which is relevant for geometry. 
+* Note that `Saving` and `Loading` and format specifics must not be mixed into the `Dataset` library.
+* This is slightly beyond the remit of the discussion here, but one concern with the `Dataset` rollout plan is the surge in technical debt. Conceptional understanding for a time will be problematic as there will be two very different ways of supporting data reduction. The size of the codebase will also increase significantly for a time. It may be many years before the codebase can be collapsed. 
 
 ### Dataset Geometry Estimates
 
@@ -150,13 +153,13 @@ Effort based on above consideration. **Note when comparing with Workspace 1.0 es
 
 | Activity  | Lower Estimate (Weeks) | Upper Estimate (Weeks) |  Notes |
 | ------------- | ------------- | ------------- |------------- |
-| 1  | 2  | 8 | ComponentInfo done in Mantid already. Shape support would be new. |
-| 2  | 1 | 2 | Only saving shapes considered over and above general Dataset saving concerns. Would be generic otherwise. |
+| 1  | 1  | 3 | ComponentInfo done in Mantid already |
+| 2  | 0 | 0 | No special considerations here. See discussion. |
 | 3  | 2 | 8 |  |
 | 4  | 1 | 2 |  |
 | 5  | 1 | 2 |  |
 | 6  | 1 | 2 |  |
-| **Total Weeks** | 8 | 24 | | 
+| **Total Weeks** | 6 | 17 | | 
 
 
 

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -145,7 +145,7 @@ Effort based on above consideration. **Note when comparing with Workspace 1.0 es
 | 2  | 4 | 12 | Looking at xarray implementation may help |
 | 3  | 2 | 12 |  |
 | 4  | 1 | 2 |  |
-| 4  | 1 | 2 |  |
+| 5  | 1 | 2 |  |
 | **Total Weeks** | 10 | 36 | | 
 
 

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -151,12 +151,12 @@ Effort based on above consideration. **Note when comparing with Workspace 1.0 es
 | Activity  | Lower Estimate (Weeks) | Upper Estimate (Weeks) |  Notes |
 | ------------- | ------------- | ------------- |------------- |
 | 1  | 2  | 8 | ComponentInfo done in Mantid already. Shape support would be new. |
-| 2  | 1 | 8 | Looking at xarray implementation may help |
+| 2  | 1 | 2 | Only saving shapes considered over and above general Dataset saving concerns. Would be generic otherwise. |
 | 3  | 2 | 8 |  |
 | 4  | 1 | 2 |  |
 | 5  | 1 | 2 |  |
 | 6  | 1 | 2 |  |
-| **Total Weeks** | 8 | 30 | | 
+| **Total Weeks** | 8 | 24 | | 
 
 
 

--- a/doc/beamline_completion.md
+++ b/doc/beamline_completion.md
@@ -104,18 +104,21 @@ Here are some key differences as relating to the Geometry:
 * No ParameterMap
   - Exact solution(s) not yet apparent, but there are several options. Given that a number of parameters are linked to the instrument and not individual components, this might affect how things are done
 * No `ComponentID` by design. Infact, there may be no requirement for unique identification of `Components` at all.
+* No CSG shapes. Dataset will record information as close as possible to the on-disk Nexus Geometry format specification for meshes and cylinders
 
-Another key difference with the phases for non-dataset approach is that the approach concludes with the complete removal of `Instrument 1.0` but not `Workspace 1.0`. The current preferred rollout for `Dataset` is to develop alongside the existing codebase, and not to consider removal of legacy data structures i.e. Workspace until `Dataset` usage has acted as a full replacement. We would simultaneously remove `Workspace 1.0`, `Algorithms 1.0`, `Instrument 1.0`, `ExperimentInfo`. 
+Another key difference with the phases for non-dataset approach is that the approach concludes with the complete removal of `Instrument 1.0` but not `Workspace 1.0`. The current preferred rollout for `Dataset` is to develop alongside the existing codebase, and not to consider removal of legacy data structures i.e. Workspace until `Dataset` usage has acted as a full replacement. We would simultaneously depecate then remove `Workspace 1.0`, `Algorithms 1.0`, `Instrument 1.0`, `ExperimentInfo`. 
 
 The net result of these differences is that the activities and timescales differ from those presented in the above section. We refer to these as activities rather than phases, since the order of the activities is not known and possibly not interdependent.
 
 ### Activity 1 - Functional wrappers to Dataset for Geometry
 
-Need to provide classes of the form `SpectrumInfo`, `ComponentInfo` and `DetectorInfo` that wrap `Dataset`. These classes should point to a `Dataset` containing all required information. Note that `ComponentInfo` and `DetectorInfo` are inter-dependent, a higher-level grouping may be required. `SpectrumInfo` uses `DetectorInfo`. We would need to consider time spent to reproduce functional and performance testing.
+Need to provide classes `ComponentInfo` and `Shape` that wrap `Dataset`. These classes should point to a `Dataset` containing all required information. 
+
+Note that the on-the-fly `Shape` requirement is new to Mantid, and would take some time to figure out and optimise. Much of the functionality can probably be ported from `NexusGeometryParser`
 
 ### Activity 2 - Saving Loading
 
-As described above, no need to preserve compatibility with existing intermediate formats as far as the total `Dataset` is concerned. Time would need to be invested to trial and optimise these. Requirements for end-users should also be considered, for example if `Dataset` libraries are used outside of Mantid. Note that `Saving` and `Loading` and format specifics must not be mixed into the `Dataset` library. 
+As described above, no need to preserve compatibility with existing intermediate formats as far as the total `Dataset` is concerned. Time would need to be invested to trial and optimise these. Requirements for end-users should also be considered, for example if `Dataset` libraries are used outside of Mantid. Note that `Saving` and `Loading` and format specifics must not be mixed into the `Dataset` library. All information, including shape could be preserved via a generic load/save for Dataset.
 
 ### Activity 3 - Serialization/De-serialization NexusGeometry
 
@@ -131,6 +134,12 @@ This is a relatively minor consideration. Favoured approaches are to either lazy
 
 Probably should research and provide best practice for storing ParameterMap equivlent information
 
+### Activity 6 - Make InstrumentView compatible
+
+Should be relatively straight forward given wide spread use of `ComponentInfo`. Only complexities are:
+- Parameters displayed from ParameterMap
+- Any use of DetectorInfo (think there are a few) which would need to go via `DataSetView`
+
 ### Notes
 
 This is slightly beyond the remit of the discussion here, but one concern with the `Dataset` rollout plan is the surge in technical debt. Conceptional understanding for a time will be problematic as there will be two very different ways of supporting data reduction. The size of the codebase will also increase significantly for a time. It may be many years before the codebase can be collapsed. 
@@ -141,12 +150,13 @@ Effort based on above consideration. **Note when comparing with Workspace 1.0 es
 
 | Activity  | Lower Estimate (Weeks) | Upper Estimate (Weeks) |  Notes |
 | ------------- | ------------- | ------------- |------------- |
-| 1  | 2  | 8 | Mantid already provides a good template for this. Work may be rapid |
-| 2  | 4 | 12 | Looking at xarray implementation may help |
-| 3  | 2 | 12 |  |
+| 1  | 2  | 8 | ComponentInfo done in Mantid already. Shape support would be new. |
+| 2  | 1 | 8 | Looking at xarray implementation may help |
+| 3  | 2 | 8 |  |
 | 4  | 1 | 2 |  |
 | 5  | 1 | 2 |  |
-| **Total Weeks** | 10 | 36 | | 
+| 6  | 1 | 2 |  |
+| **Total Weeks** | 8 | 30 | | 
 
 
 


### PR DESCRIPTION
The purpose of the document is to feed into the larger `Dataset` design. This should help inform the effort required for **Geometry** aspects of `Dataset` to be provided.

The approach taken here is to measure steps required for rollout to Mantid with minimal interface changes to provide a base estimate. List and count form estimation. Other known steps can be added to the base estimate.