### PR TITLE
Add reshape for Variable

### DIFF
--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -250,6 +250,9 @@ public:
 
   std::unique_ptr<VariableConcept>
   reshape(const Dimensions &dims) const override {
+    if (this->dimensions().volume() != dims.volume())
+      throw std::runtime_error(
+          "Cannot reshape to dimensions with different volume");
     return std::make_unique<ViewModel<decltype(getReshaped(dims))>>(
         dims, getReshaped(dims));
   }
@@ -463,9 +466,6 @@ public:
   }
   VariableView<const value_type>
   getReshaped(const Dimensions &dims) const override {
-    if (this->dimensions().volume() != dims.volume())
-      throw std::runtime_error(
-          "Cannot reshape to dimensions with different volume");
     return makeVariableView(m_model.data(), 0, dims, dims);
   }
 
@@ -587,9 +587,6 @@ public:
 
   VariableView<const value_type>
   getReshaped(const Dimensions &dims) const override {
-    if (this->dimensions().volume() != dims.volume())
-      throw std::runtime_error(
-          "Cannot reshape to dimensions with different volume");
     return {m_model, dims};
   }
 

--- a/src/variable.h
+++ b/src/variable.h
@@ -303,7 +303,9 @@ public:
     return ConstVariableSlice(*this, dim, begin, end);
   }
 
-  ConstVariableSlice reshape(const Dimensions &dims) const;
+  // Note the return type. Reshaping a non-contiguous slice cannot return a
+  // slice in general so we must return a copy of the data.
+  Variable reshape(const Dimensions &dims) const;
 
   const std::string &name() const { return m_variable->name(); }
   void setName(const std::string &) {

--- a/src/variable.h
+++ b/src/variable.h
@@ -43,6 +43,10 @@ public:
   virtual std::unique_ptr<VariableConcept>
   makeView(const Dim dim, const gsl::index begin,
            const gsl::index end = -1) = 0;
+
+  virtual std::unique_ptr<VariableConcept>
+  reshape(const Dimensions &dims) const = 0;
+
   virtual bool operator==(const VariableConcept &other) const = 0;
 
   virtual bool isContiguous() const = 0;
@@ -230,6 +234,8 @@ public:
   VariableSlice operator()(const Dim dim, const gsl::index begin,
                            const gsl::index end = -1);
 
+  ConstVariableSlice reshape(const Dimensions &dims) const;
+
   template <class... Tags> friend class LinearView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
@@ -278,7 +284,11 @@ class ConstVariableSlice {
 public:
   explicit ConstVariableSlice(const Variable &variable)
       : m_variable(&variable) {}
+  ConstVariableSlice(const Variable &variable, const Dimensions &dims)
+      : m_variable(&variable), m_view(variable.data().reshape(dims)) {}
   ConstVariableSlice(const ConstVariableSlice &other) = default;
+  ConstVariableSlice(const ConstVariableSlice &other, const Dimensions &dims)
+      : m_variable(other.m_variable), m_view(other.data().reshape(dims)) {}
   ConstVariableSlice(const Variable &variable, const Dim dim,
                      const gsl::index begin, const gsl::index end = -1)
       : m_variable(&variable),
@@ -292,6 +302,8 @@ public:
                                 const gsl::index end = -1) const {
     return ConstVariableSlice(*this, dim, begin, end);
   }
+
+  ConstVariableSlice reshape(const Dimensions &dims) const;
 
   const std::string &name() const { return m_variable->name(); }
   void setName(const std::string &) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -946,7 +946,7 @@ TEST(VariableSlice, slice_assign_from_variable) {
 TEST(VariableSlice, slice_binary_operations) {
   auto v = makeVariable<Data::Value>({{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
   // Note: There does not seem to be a way to test whether this is using the
-  // operators that onvert the second argument to Variable (it should not), or
+  // operators that convert the second argument to Variable (it should not), or
   // keep it as a view. See variable_benchmark.cpp for an attempt to verify
   // this.
   auto sum = v(Dim::X, 0) + v(Dim::X, 1);
@@ -955,4 +955,24 @@ TEST(VariableSlice, slice_binary_operations) {
   EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 7}));
   EXPECT_TRUE(equals(difference.get<const Data::Value>(), {-1, -1}));
   EXPECT_TRUE(equals(product.get<const Data::Value>(), {2, 12}));
+}
+
+TEST(Variable, reshape) {
+  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  auto view = var.reshape({Dim::Row, 6});
+  ASSERT_EQ(view.size(), 6);
+  ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
+  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+
+  auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
+  ASSERT_EQ(view2.size(), 6);
+  ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
+  EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+}
+
+TEST(Variable, reshape_and_slice) {
+  Variable var(Data::Value{}, {Dim::Spectrum, 100});
+  Variable center =
+      var.reshape({{Dim::X, 10}, {Dim::Y, 10}})(Dim::X, 2, 8)(Dim::Y, 2, 8)
+          .reshape({Dim::Spectrum, 36});
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -970,9 +970,25 @@ TEST(Variable, reshape) {
   EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
+TEST(Variable, reshape_fail) {
+  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  EXPECT_THROW_MSG(var.reshape({Dim::Row, 5}), std::runtime_error,
+                   "Cannot reshape to dimensions with different volume");
+}
+
 TEST(Variable, reshape_and_slice) {
-  Variable var(Data::Value{}, {Dim::Spectrum, 100});
+  Variable var(Data::Value{}, {Dim::Spectrum, 16},
+               {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+
+  auto slice =
+      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
+  EXPECT_TRUE(equals(slice.get<const Data::Value>(), {6, 7, 10, 11}));
+
   Variable center =
-      var.reshape({{Dim::X, 10}, {Dim::Y, 10}})(Dim::X, 2, 8)(Dim::Y, 2, 8)
-          .reshape({Dim::Spectrum, 36});
+      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
+          .reshape({Dim::Spectrum, 4});
+
+  ASSERT_EQ(center.size(), 4);
+  ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
+  EXPECT_TRUE(equals(center.get<const Data::Value>(), {6, 7, 10, 11}));
 }


### PR DESCRIPTION
Similar to `numpy`'s `reshape` this is returning a view, not a copy.

Adding non-const versions is left as an easy getting-started task for new developers.