### PR TITLE
Prevent views of temporaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ include( GoogleBenchmark )
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --save-temps -march=native -fno-omit-frame-pointer")
 
+# See https://github.com/pybind/pybind11/issues/1604
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
+endif()
+
 option(WITH_ASAN "Enable address sanitizer" OFF)
 if(WITH_ASAN)
   message(STATUS "Enabling address sanitizer")

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -421,6 +421,7 @@ static void BM_Dataset_EventWorkspace_copy_and_write(benchmark::State &state) {
   for (auto _ : state) {
     auto copy(d);
     auto eventLists = copy.get<Data::Events>();
+    static_cast<void>(eventLists);
   }
   state.SetItemsProcessed(state.iterations());
 }

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -373,9 +373,11 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::init(&detail::makeVariable<Data::Variance>))
       .def(py::init<const VariableSlice &>())
       .def_property_readonly("tag", &Variable::tag)
-      .def_property("name", &Variable::name, &Variable::setName)
+      .def_property("name", [](const Variable &self) { return self.name(); },
+                    &Variable::setName)
       .def_property_readonly("is_coord", &Variable::isCoord)
-      .def_property_readonly("dimensions", &Variable::dimensions)
+      .def_property_readonly(
+          "dimensions", [](const Variable &self) { return self.dimensions(); })
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self *= py::self, py::call_guard<py::gil_scoped_release>());

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -409,38 +409,36 @@ template <class T1, class T2> T1 &assign(T1 &dataset, const T2 &other) {
   return dataset;
 }
 
-DatasetSlice &DatasetSlice::assign(const Dataset &other) {
-  return ::assign(*this, other);
-}
-DatasetSlice &DatasetSlice::assign(const ConstDatasetSlice &other) {
-  return ::assign(*this, other);
+void DatasetSlice::assign(const Dataset &other) { ::assign(*this, other); }
+void DatasetSlice::assign(const ConstDatasetSlice &other) {
+  ::assign(*this, other);
 }
 
-DatasetSlice &DatasetSlice::operator+=(const Dataset &other) {
-  return binary_op_equals(
-      [](VariableSlice &a, const Variable &b) { return a += b; }, *this, other);
+void DatasetSlice::operator+=(const Dataset &other) {
+  binary_op_equals([](VariableSlice &a, const Variable &b) { return a += b; },
+                   *this, other);
 }
-DatasetSlice &DatasetSlice::operator+=(const ConstDatasetSlice &other) {
-  return binary_op_equals(
+void DatasetSlice::operator+=(const ConstDatasetSlice &other) {
+  binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
       *this, other);
 }
 
-DatasetSlice &DatasetSlice::operator-=(const Dataset &other) {
-  return binary_op_equals(
-      [](VariableSlice &a, const Variable &b) { return a -= b; }, *this, other);
+void DatasetSlice::operator-=(const Dataset &other) {
+  binary_op_equals([](VariableSlice &a, const Variable &b) { return a -= b; },
+                   *this, other);
 }
-DatasetSlice &DatasetSlice::operator-=(const ConstDatasetSlice &other) {
-  return binary_op_equals(
+void DatasetSlice::operator-=(const ConstDatasetSlice &other) {
+  binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
 
-DatasetSlice &DatasetSlice::operator*=(const Dataset &other) {
-  return times_equals(*this, other);
+void DatasetSlice::operator*=(const Dataset &other) {
+  times_equals(*this, other);
 }
-DatasetSlice &DatasetSlice::operator*=(const ConstDatasetSlice &other) {
-  return times_equals(*this, other);
+void DatasetSlice::operator*=(const ConstDatasetSlice &other) {
+  times_equals(*this, other);
 }
 
 Dataset operator+(Dataset a, const Dataset &b) { return a += b; }

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -17,30 +17,30 @@ Dataset::Dataset(const ConstDatasetSlice &view) {
     insert(var);
 }
 
-ConstDatasetSlice Dataset::operator[](const std::string &name) const {
+ConstDatasetSlice Dataset::operator[](const std::string &name) const & {
   return ConstDatasetSlice(*this, name);
 }
 
-DatasetSlice Dataset::operator[](const std::string &name) {
+DatasetSlice Dataset::operator[](const std::string &name) & {
   return DatasetSlice(*this, name);
 }
 
 ConstDatasetSlice Dataset::operator()(const Dim dim, const gsl::index begin,
-                                      const gsl::index end) const {
+                                      const gsl::index end) const & {
   return ConstDatasetSlice(*this)(dim, begin, end);
 }
 
 DatasetSlice Dataset::operator()(const Dim dim, const gsl::index begin,
-                                 const gsl::index end) {
+                                 const gsl::index end) & {
   return DatasetSlice(*this)(dim, begin, end);
 }
 
 ConstVariableSlice Dataset::operator()(const Tag tag,
-                                       const std::string &name) const {
+                                       const std::string &name) const & {
   return ConstVariableSlice(m_variables[find(tag, name)]);
 }
 
-VariableSlice Dataset::operator()(const Tag tag, const std::string &name) {
+VariableSlice Dataset::operator()(const Tag tag, const std::string &name) & {
   return VariableSlice(m_variables[find(tag, name)]);
 }
 

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -409,36 +409,38 @@ template <class T1, class T2> T1 &assign(T1 &dataset, const T2 &other) {
   return dataset;
 }
 
-void DatasetSlice::assign(const Dataset &other) { ::assign(*this, other); }
-void DatasetSlice::assign(const ConstDatasetSlice &other) {
-  ::assign(*this, other);
+DatasetSlice DatasetSlice::assign(const Dataset &other) {
+  return ::assign(*this, other);
+}
+DatasetSlice DatasetSlice::assign(const ConstDatasetSlice &other) {
+  return ::assign(*this, other);
 }
 
-void DatasetSlice::operator+=(const Dataset &other) {
-  binary_op_equals([](VariableSlice &a, const Variable &b) { return a += b; },
-                   *this, other);
+DatasetSlice DatasetSlice::operator+=(const Dataset &other) {
+  return binary_op_equals(
+      [](VariableSlice &a, const Variable &b) { return a += b; }, *this, other);
 }
-void DatasetSlice::operator+=(const ConstDatasetSlice &other) {
-  binary_op_equals(
+DatasetSlice DatasetSlice::operator+=(const ConstDatasetSlice &other) {
+  return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
       *this, other);
 }
 
-void DatasetSlice::operator-=(const Dataset &other) {
-  binary_op_equals([](VariableSlice &a, const Variable &b) { return a -= b; },
-                   *this, other);
+DatasetSlice DatasetSlice::operator-=(const Dataset &other) {
+  return binary_op_equals(
+      [](VariableSlice &a, const Variable &b) { return a -= b; }, *this, other);
 }
-void DatasetSlice::operator-=(const ConstDatasetSlice &other) {
-  binary_op_equals(
+DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) {
+  return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
 
-void DatasetSlice::operator*=(const Dataset &other) {
-  times_equals(*this, other);
+DatasetSlice DatasetSlice::operator*=(const Dataset &other) {
+  return times_equals(*this, other);
 }
-void DatasetSlice::operator*=(const ConstDatasetSlice &other) {
-  times_equals(*this, other);
+DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) {
+  return times_equals(*this, other);
 }
 
 Dataset operator+(Dataset a, const Dataset &b) { return a += b; }

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -368,14 +368,15 @@ public:
     return boost::make_transform_iterator(m_indices.end(), IterAccess{*this});
   }
 
-  DatasetSlice &assign(const Dataset &other);
-  DatasetSlice &assign(const ConstDatasetSlice &other);
-  DatasetSlice &operator+=(const Dataset &other);
-  DatasetSlice &operator+=(const ConstDatasetSlice &other);
-  DatasetSlice &operator-=(const Dataset &other);
-  DatasetSlice &operator-=(const ConstDatasetSlice &other);
-  DatasetSlice &operator*=(const Dataset &other);
-  DatasetSlice &operator*=(const ConstDatasetSlice &other);
+  // Returning void to avoid potentially returning references to temporaries.
+  void assign(const Dataset &other);
+  void assign(const ConstDatasetSlice &other);
+  void operator+=(const Dataset &other);
+  void operator+=(const ConstDatasetSlice &other);
+  void operator-=(const Dataset &other);
+  void operator-=(const ConstDatasetSlice &other);
+  void operator*=(const Dataset &other);
+  void operator*=(const ConstDatasetSlice &other);
 
   VariableSlice operator()(const Tag tag, const std::string &name = "");
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -38,22 +38,39 @@ public:
   Dataset(const ConstDatasetSlice &view);
 
   gsl::index size() const { return m_variables.size(); }
-  ConstVariableSlice operator[](const gsl::index i) const {
+
+  // ATTENTION: It is really important to delete any function returning a
+  // (Const)VariableSlice or (Const)DatasetSlice for rvalue Dataset. Otherwise
+  // the resulting slice will point to free'ed memory.
+  ConstVariableSlice operator[](const gsl::index i) const && = delete;
+  ConstVariableSlice operator[](const gsl::index i) const & {
     return ConstVariableSlice{m_variables[i]};
   }
-  VariableSlice operator[](const gsl::index i) {
+  VariableSlice operator[](const gsl::index i) && = delete;
+  VariableSlice operator[](const gsl::index i) & {
     return VariableSlice{m_variables[i]};
   }
-  ConstDatasetSlice operator[](const std::string &name) const;
-  DatasetSlice operator[](const std::string &name);
+  ConstDatasetSlice operator[](const std::string &name) const && = delete;
+  ConstDatasetSlice operator[](const std::string &name) const &;
+  DatasetSlice operator[](const std::string &name) && = delete;
+  DatasetSlice operator[](const std::string &name) &;
   ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,
-                               const gsl::index end = -1) const;
+                               const gsl::index end = -1) const && = delete;
+  ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,
+                               const gsl::index end = -1) const &;
   DatasetSlice operator()(const Dim dim, const gsl::index begin,
-                          const gsl::index end = -1);
-  ConstVariableSlice operator()(const Tag tag,
-                                const std::string &name = std::string{}) const;
+                          const gsl::index end = -1) && = delete;
+  DatasetSlice operator()(const Dim dim, const gsl::index begin,
+                          const gsl::index end = -1) &;
+  ConstVariableSlice
+  operator()(const Tag tag,
+             const std::string &name = std::string{}) const && = delete;
+  ConstVariableSlice
+  operator()(const Tag tag, const std::string &name = std::string{}) const &;
   VariableSlice operator()(const Tag tag,
-                           const std::string &name = std::string{});
+                           const std::string &name = std::string{}) && = delete;
+  VariableSlice operator()(const Tag tag,
+                           const std::string &name = std::string{}) &;
 
   // The iterators (and in fact all other public accessors to variables in
   // Dataset) return *views* and *not* a `Variable &`. This is necessary to
@@ -62,16 +79,20 @@ public:
   // dimensions of a variable (which could lead to inconsistent dimension
   // extents in the dataset). By exposing variables via views we are limiting
   // modifications to those that cannot break guarantees given by dataset.
-  auto begin() const {
+  auto begin() const && = delete;
+  auto begin() const & {
     return boost::make_transform_iterator(m_variables.begin(), makeConstSlice);
   }
-  auto end() const {
+  auto end() const && = delete;
+  auto end() const & {
     return boost::make_transform_iterator(m_variables.end(), makeConstSlice);
   }
-  auto begin() {
+  auto begin() && = delete;
+  auto begin() & {
     return boost::make_transform_iterator(m_variables.begin(), makeSlice);
   }
-  auto end() {
+  auto end() && = delete;
+  auto end() & {
     return boost::make_transform_iterator(m_variables.end(), makeSlice);
   }
 
@@ -120,15 +141,24 @@ public:
 
   void merge(const Dataset &other);
 
-  template <class Tag> auto get(const std::string &name = std::string{}) const {
+  template <class Tag>
+  auto get(const std::string &name = std::string{}) const && = delete;
+  template <class Tag>
+  auto get(const std::string &name = std::string{}) const & {
     return m_variables[find(Tag{}, name)].template get<Tag>();
   }
 
-  template <class Tag> auto get(const std::string &name = std::string{}) {
+  template <class Tag>
+  auto get(const std::string &name = std::string{}) && = delete;
+  template <class Tag> auto get(const std::string &name = std::string{}) & {
     return m_variables[find(Tag{}, name)].template get<Tag>();
   }
 
-  const Dimensions &dimensions() const { return m_dimensions; }
+  // Currently `Dimensions` does not allocate memory so we could return by value
+  // instead of disabling this, but this way leaves more room for changes, I
+  // think.
+  const Dimensions &dimensions() const && = delete;
+  const Dimensions &dimensions() const & { return m_dimensions; }
 
   bool operator==(const Dataset &other) const;
   Dataset &operator+=(const Dataset &other);

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -369,14 +369,14 @@ public:
   }
 
   // Returning void to avoid potentially returning references to temporaries.
-  void assign(const Dataset &other);
-  void assign(const ConstDatasetSlice &other);
-  void operator+=(const Dataset &other);
-  void operator+=(const ConstDatasetSlice &other);
-  void operator-=(const Dataset &other);
-  void operator-=(const ConstDatasetSlice &other);
-  void operator*=(const Dataset &other);
-  void operator*=(const ConstDatasetSlice &other);
+  DatasetSlice assign(const Dataset &other);
+  DatasetSlice assign(const ConstDatasetSlice &other);
+  DatasetSlice operator+=(const Dataset &other);
+  DatasetSlice operator+=(const ConstDatasetSlice &other);
+  DatasetSlice operator-=(const Dataset &other);
+  DatasetSlice operator-=(const ConstDatasetSlice &other);
+  DatasetSlice operator*=(const Dataset &other);
+  DatasetSlice operator*=(const ConstDatasetSlice &other);
 
   VariableSlice operator()(const Tag tag, const std::string &name = "");
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -235,7 +235,7 @@ private:
     const ConstDatasetSlice &m_view;
   };
 
-  friend class IterAccess;
+  friend struct IterAccess;
 
 public:
   ConstDatasetSlice(const Dataset &dataset) : m_dataset(dataset) {
@@ -340,7 +340,7 @@ private:
     const DatasetSlice &m_view;
   };
 
-  friend class IterAccess;
+  friend struct IterAccess;
 
 public:
   DatasetSlice(Dataset &dataset)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -771,13 +771,13 @@ Variable Variable::operator-() const {
   return copy;
 }
 
-Variable &Variable::operator+=(const Variable &other) {
+Variable &Variable::operator+=(const Variable &other) & {
   return plus_equals(*this, other);
 }
-Variable &Variable::operator+=(const ConstVariableSlice &other) {
+Variable &Variable::operator+=(const ConstVariableSlice &other) & {
   return plus_equals(*this, other);
 }
-Variable &Variable::operator+=(const double value) {
+Variable &Variable::operator+=(const double value) & {
   // TODO By not setting a unit here this operator is only usable if the
   // variable is dimensionless. Should we ignore the unit for scalar operations,
   // i.e., set the same unit as *this.unit()?
@@ -794,10 +794,10 @@ template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
   return variable;
 }
 
-Variable &Variable::operator-=(const Variable &other) {
+Variable &Variable::operator-=(const Variable &other) & {
   return minus_equals(*this, other);
 }
-Variable &Variable::operator-=(const ConstVariableSlice &other) {
+Variable &Variable::operator-=(const ConstVariableSlice &other) & {
   return minus_equals(*this, other);
 }
 
@@ -811,13 +811,13 @@ template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   return variable;
 }
 
-Variable &Variable::operator*=(const Variable &other) {
+Variable &Variable::operator*=(const Variable &other) & {
   return times_equals(*this, other);
 }
-Variable &Variable::operator*=(const ConstVariableSlice &other) {
+Variable &Variable::operator*=(const ConstVariableSlice &other) & {
   return times_equals(*this, other);
 }
-Variable &Variable::operator*=(const double value) {
+Variable &Variable::operator*=(const double value) & {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
@@ -928,16 +928,16 @@ INSTANTIATE_SLICEVIEW(char);
 INSTANTIATE_SLICEVIEW(std::string);
 
 ConstVariableSlice Variable::operator()(const Dim dim, const gsl::index begin,
-                                        const gsl::index end) const {
+                                        const gsl::index end) const & {
   return {*this, dim, begin, end};
 }
 
 VariableSlice Variable::operator()(const Dim dim, const gsl::index begin,
-                                   const gsl::index end) {
+                                   const gsl::index end) & {
   return {*this, dim, begin, end};
 }
 
-ConstVariableSlice Variable::reshape(const Dimensions &dims) const {
+ConstVariableSlice Variable::reshape(const Dimensions &dims) const & {
   return {*this, dims};
 }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -823,7 +823,7 @@ Variable &Variable::operator*=(const double value) & {
   return times_equals(*this, other);
 }
 
-template <class T> void VariableSlice::assign(const T &other) {
+template <class T> VariableSlice VariableSlice::assign(const T &other) {
   // TODO Should mismatching tags be allowed, as long as the type matches?
   if (tag() != other.tag())
     throw std::runtime_error("Cannot assign to slice: Type mismatch.");
@@ -834,30 +834,31 @@ template <class T> void VariableSlice::assign(const T &other) {
     throw dataset::except::DimensionMismatchError(dimensions(),
                                                   other.dimensions());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);
+  return *this;
 }
 
-template void VariableSlice::assign(const Variable &);
-template void VariableSlice::assign(const ConstVariableSlice &);
+template VariableSlice VariableSlice::assign(const Variable &);
+template VariableSlice VariableSlice::assign(const ConstVariableSlice &);
 
-void VariableSlice::operator+=(const Variable &other) {
-  plus_equals(*this, other);
+VariableSlice VariableSlice::operator+=(const Variable &other) {
+  return plus_equals(*this, other);
 }
-void VariableSlice::operator+=(const ConstVariableSlice &other) {
-  plus_equals(*this, other);
-}
-
-void VariableSlice::operator-=(const Variable &other) {
-  minus_equals(*this, other);
-}
-void VariableSlice::operator-=(const ConstVariableSlice &other) {
-  minus_equals(*this, other);
+VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) {
+  return plus_equals(*this, other);
 }
 
-void VariableSlice::operator*=(const Variable &other) {
-  times_equals(*this, other);
+VariableSlice VariableSlice::operator-=(const Variable &other) {
+  return minus_equals(*this, other);
 }
-void VariableSlice::operator*=(const ConstVariableSlice &other) {
-  times_equals(*this, other);
+VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) {
+  return minus_equals(*this, other);
+}
+
+VariableSlice VariableSlice::operator*=(const Variable &other) {
+  return times_equals(*this, other);
+}
+VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) {
+  return times_equals(*this, other);
 }
 
 bool ConstVariableSlice::operator==(const Variable &other) const {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -250,6 +250,9 @@ public:
 
   std::unique_ptr<VariableConcept>
   reshape(const Dimensions &dims) const override {
+    if (this->dimensions().volume() != dims.volume())
+      throw std::runtime_error(
+          "Cannot reshape to dimensions with different volume");
     return std::make_unique<ViewModel<decltype(getReshaped(dims))>>(
         dims, getReshaped(dims));
   }
@@ -463,9 +466,6 @@ public:
   }
   VariableView<const value_type>
   getReshaped(const Dimensions &dims) const override {
-    if (this->dimensions().volume() != dims.volume())
-      throw std::runtime_error(
-          "Cannot reshape to dimensions with different volume");
     return makeVariableView(m_model.data(), 0, dims, dims);
   }
 
@@ -587,9 +587,6 @@ public:
 
   VariableView<const value_type>
   getReshaped(const Dimensions &dims) const override {
-    if (this->dimensions().volume() != dims.volume())
-      throw std::runtime_error(
-          "Cannot reshape to dimensions with different volume");
     return {m_model, dims};
   }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -941,6 +941,12 @@ ConstVariableSlice Variable::reshape(const Dimensions &dims) const & {
   return {*this, dims};
 }
 
+Variable Variable::reshape(const Dimensions &dims) && {
+  Variable reshaped(std::move(*this));
+  reshaped.setDimensions(dims);
+  return reshaped;
+}
+
 Variable ConstVariableSlice::reshape(const Dimensions &dims) const {
   // In general a variable slice is not contiguous. Therefore we cannot reshape
   // without making a copy (except for special cases).

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -823,7 +823,7 @@ Variable &Variable::operator*=(const double value) & {
   return times_equals(*this, other);
 }
 
-template <class T> VariableSlice &VariableSlice::assign(const T &other) {
+template <class T> void VariableSlice::assign(const T &other) {
   // TODO Should mismatching tags be allowed, as long as the type matches?
   if (tag() != other.tag())
     throw std::runtime_error("Cannot assign to slice: Type mismatch.");
@@ -834,31 +834,30 @@ template <class T> VariableSlice &VariableSlice::assign(const T &other) {
     throw dataset::except::DimensionMismatchError(dimensions(),
                                                   other.dimensions());
   data().copy(other.data(), Dim::Invalid, 0, 0, 1);
-  return *this;
 }
 
-template VariableSlice &VariableSlice::assign(const Variable &);
-template VariableSlice &VariableSlice::assign(const ConstVariableSlice &);
+template void VariableSlice::assign(const Variable &);
+template void VariableSlice::assign(const ConstVariableSlice &);
 
-VariableSlice &VariableSlice::operator+=(const Variable &other) {
-  return plus_equals(*this, other);
+void VariableSlice::operator+=(const Variable &other) {
+  plus_equals(*this, other);
 }
-VariableSlice &VariableSlice::operator+=(const ConstVariableSlice &other) {
-  return plus_equals(*this, other);
-}
-
-VariableSlice &VariableSlice::operator-=(const Variable &other) {
-  return minus_equals(*this, other);
-}
-VariableSlice &VariableSlice::operator-=(const ConstVariableSlice &other) {
-  return minus_equals(*this, other);
+void VariableSlice::operator+=(const ConstVariableSlice &other) {
+  plus_equals(*this, other);
 }
 
-VariableSlice &VariableSlice::operator*=(const Variable &other) {
-  return times_equals(*this, other);
+void VariableSlice::operator-=(const Variable &other) {
+  minus_equals(*this, other);
 }
-VariableSlice &VariableSlice::operator*=(const ConstVariableSlice &other) {
-  return times_equals(*this, other);
+void VariableSlice::operator-=(const ConstVariableSlice &other) {
+  minus_equals(*this, other);
+}
+
+void VariableSlice::operator*=(const Variable &other) {
+  times_equals(*this, other);
+}
+void VariableSlice::operator*=(const ConstVariableSlice &other) {
+  times_equals(*this, other);
 }
 
 bool ConstVariableSlice::operator==(const Variable &other) const {

--- a/src/variable.h
+++ b/src/variable.h
@@ -144,7 +144,8 @@ public:
   Variable(const Tag tag, const Unit::Id unit, const Dimensions &dimensions,
            T object);
 
-  const std::string &name() const {
+  const std::string &name() const && = delete;
+  const std::string &name() const & {
     static const std::string empty;
     if (!m_name)
       return empty;
@@ -165,16 +166,16 @@ public:
   bool operator!=(const Variable &other) const;
   bool operator!=(const ConstVariableSlice &other) const;
   Variable operator-() const;
-  Variable &operator+=(const Variable &other);
-  Variable &operator+=(const ConstVariableSlice &other);
-  Variable &operator+=(const double value);
-  Variable &operator-=(const Variable &other);
-  Variable &operator-=(const ConstVariableSlice &other);
-  Variable &operator*=(const Variable &other);
-  Variable &operator*=(const ConstVariableSlice &other);
-  Variable &operator*=(const double value);
+  Variable &operator+=(const Variable &other) &;
+  Variable &operator+=(const ConstVariableSlice &other) &;
+  Variable &operator+=(const double value) &;
+  Variable &operator-=(const Variable &other) &;
+  Variable &operator-=(const ConstVariableSlice &other) &;
+  Variable &operator*=(const Variable &other) &;
+  Variable &operator*=(const ConstVariableSlice &other) &;
+  Variable &operator*=(const double value) &;
 
-  const Unit &unit() const { return m_unit; }
+  Unit unit() const { return m_unit; }
   void setUnit(const Unit &unit) {
     // TODO
     // Some variables are special, e.g., Data::Tof, which must always have a
@@ -187,11 +188,14 @@ public:
 
   gsl::index size() const { return m_object->size(); }
 
-  const Dimensions &dimensions() const { return m_object->dimensions(); }
+  const Dimensions &dimensions() const && = delete;
+  const Dimensions &dimensions() const & { return m_object->dimensions(); }
   void setDimensions(const Dimensions &dimensions);
 
-  const VariableConcept &data() const { return *m_object; }
-  VariableConcept &data() { return m_object.access(); }
+  const VariableConcept &data() const && = delete;
+  const VariableConcept &data() const & { return *m_object; }
+  VariableConcept &data() && = delete;
+  VariableConcept &data() & { return m_object.access(); }
 
   Tag tag() const { return m_tag; }
   bool isCoord() const {
@@ -228,13 +232,21 @@ public:
     return gsl::make_span(cast<typename Tag::type>());
   }
 
+  // ATTENTION: It is really important to delete any function returning a
+  // (Const)VariableSlice for rvalue Variable. Otherwise the resulting slice
+  // will point to free'ed memory.
   ConstVariableSlice operator()(const Dim dim, const gsl::index begin,
-                                const gsl::index end = -1) const;
+                                const gsl::index end = -1) const &;
+  ConstVariableSlice operator()(const Dim dim, const gsl::index begin,
+                                const gsl::index end = -1) const && = delete;
 
   VariableSlice operator()(const Dim dim, const gsl::index begin,
-                           const gsl::index end = -1);
+                           const gsl::index end = -1) &;
+  VariableSlice operator()(const Dim dim, const gsl::index begin,
+                           const gsl::index end = -1) && = delete;
 
-  ConstVariableSlice reshape(const Dimensions &dims) const;
+  ConstVariableSlice reshape(const Dimensions &dims) const &;
+  ConstVariableSlice reshape(const Dimensions &dims) const && = delete;
 
   template <class... Tags> friend class LinearView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
@@ -311,7 +323,7 @@ public:
   void setName(const std::string &) {
     throw std::runtime_error("Cannot rename Variable via slice view.");
   }
-  const Unit &unit() const { return m_variable->unit(); }
+  Unit unit() const { return m_variable->unit(); }
   gsl::index size() const {
     if (m_view)
       return m_view->size();
@@ -338,7 +350,8 @@ public:
   }
 
   Tag tag() const { return m_variable->tag(); }
-  const VariableConcept &data() const {
+  const VariableConcept &data() const && = delete;
+  const VariableConcept &data() const & {
     if (m_view)
       return *m_view;
     else
@@ -349,6 +362,11 @@ public:
   bool isAttr() const { return m_variable->isAttr(); }
   bool isData() const { return m_variable->isData(); }
 
+  // Note: This return a proxy object (a VariableView) that does reference
+  // members owner by *this. Therefore we can support this even for temporaries
+  // and we do not need to delete the rvalue overload, unlike for many other
+  // methods. The data is owned by the underlying variable so it will not be
+  // deleted even if *this is a temporary and gets deleted.
   template <class Tag> auto get() const {
     static_assert(
         std::is_const<Tag>::value,
@@ -405,7 +423,8 @@ public:
   using ConstVariableSlice::data;
   using ConstVariableSlice::get;
 
-  VariableConcept &data() {
+  VariableConcept &data() && = delete;
+  VariableConcept &data() & {
     if (!m_view)
       return m_mutableVariable->data();
     if (m_view->isConstView())
@@ -413,6 +432,7 @@ public:
     return *m_view;
   }
 
+  // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
   template <class Tag>
   auto get(std::enable_if_t<std::is_const<Tag>::value> * = nullptr) {
     return const_cast<const VariableSlice *>(this)->get<Tag>();
@@ -424,6 +444,9 @@ public:
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();
   }
+
+  // Note: No need to delete rvalue overloads here, data is modified in
+  // underlying Variable.
   template <class T> VariableSlice &assign(const T &other);
   VariableSlice &operator+=(const Variable &other);
   VariableSlice &operator+=(const ConstVariableSlice &other);

--- a/src/variable.h
+++ b/src/variable.h
@@ -246,7 +246,13 @@ public:
                            const gsl::index end = -1) && = delete;
 
   ConstVariableSlice reshape(const Dimensions &dims) const &;
-  ConstVariableSlice reshape(const Dimensions &dims) const && = delete;
+  // Note: Do we have to delete the `const &&` version? Consider
+  //   const Variable var;
+  //   std::move(var).reshape({});
+  // This calls `reshape() const &` but in this case it is not a temporary and
+  // will not go out of scope, so that is ok (unless someone changes var and
+  // expects the reshaped view to be still valid).
+  Variable reshape(const Dimensions &dims) &&;
 
   template <class... Tags> friend class LinearView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);

--- a/src/variable.h
+++ b/src/variable.h
@@ -303,7 +303,9 @@ public:
     return ConstVariableSlice(*this, dim, begin, end);
   }
 
-  ConstVariableSlice reshape(const Dimensions &dims) const;
+  // Note the return type. Reshaping a non-contiguous slice cannot return a
+  // slice in general so we must return a copy of the data.
+  Variable reshape(const Dimensions &dims) const;
 
   const std::string &name() const { return m_variable->name(); }
   void setName(const std::string &) {

--- a/src/variable.h
+++ b/src/variable.h
@@ -43,6 +43,10 @@ public:
   virtual std::unique_ptr<VariableConcept>
   makeView(const Dim dim, const gsl::index begin,
            const gsl::index end = -1) = 0;
+
+  virtual std::unique_ptr<VariableConcept>
+  reshape(const Dimensions &dims) const = 0;
+
   virtual bool operator==(const VariableConcept &other) const = 0;
 
   virtual bool isContiguous() const = 0;
@@ -230,6 +234,8 @@ public:
   VariableSlice operator()(const Dim dim, const gsl::index begin,
                            const gsl::index end = -1);
 
+  ConstVariableSlice reshape(const Dimensions &dims) const;
+
   template <class... Tags> friend class LinearView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
@@ -278,7 +284,11 @@ class ConstVariableSlice {
 public:
   explicit ConstVariableSlice(const Variable &variable)
       : m_variable(&variable) {}
+  ConstVariableSlice(const Variable &variable, const Dimensions &dims)
+      : m_variable(&variable), m_view(variable.data().reshape(dims)) {}
   ConstVariableSlice(const ConstVariableSlice &other) = default;
+  ConstVariableSlice(const ConstVariableSlice &other, const Dimensions &dims)
+      : m_variable(other.m_variable), m_view(other.data().reshape(dims)) {}
   ConstVariableSlice(const Variable &variable, const Dim dim,
                      const gsl::index begin, const gsl::index end = -1)
       : m_variable(&variable),
@@ -292,6 +302,8 @@ public:
                                 const gsl::index end = -1) const {
     return ConstVariableSlice(*this, dim, begin, end);
   }
+
+  ConstVariableSlice reshape(const Dimensions &dims) const;
 
   const std::string &name() const { return m_variable->name(); }
   void setName(const std::string &) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -946,7 +946,7 @@ TEST(VariableSlice, slice_assign_from_variable) {
 TEST(VariableSlice, slice_binary_operations) {
   auto v = makeVariable<Data::Value>({{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
   // Note: There does not seem to be a way to test whether this is using the
-  // operators that onvert the second argument to Variable (it should not), or
+  // operators that convert the second argument to Variable (it should not), or
   // keep it as a view. See variable_benchmark.cpp for an attempt to verify
   // this.
   auto sum = v(Dim::X, 0) + v(Dim::X, 1);
@@ -955,4 +955,24 @@ TEST(VariableSlice, slice_binary_operations) {
   EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 7}));
   EXPECT_TRUE(equals(difference.get<const Data::Value>(), {-1, -1}));
   EXPECT_TRUE(equals(product.get<const Data::Value>(), {2, 12}));
+}
+
+TEST(Variable, reshape) {
+  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  auto view = var.reshape({Dim::Row, 6});
+  ASSERT_EQ(view.size(), 6);
+  ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
+  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+
+  auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
+  ASSERT_EQ(view2.size(), 6);
+  ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
+  EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+}
+
+TEST(Variable, reshape_and_slice) {
+  Variable var(Data::Value{}, {Dim::Spectrum, 100});
+  Variable center =
+      var.reshape({{Dim::X, 10}, {Dim::Y, 10}})(Dim::X, 2, 8)(Dim::Y, 2, 8)
+          .reshape({Dim::Spectrum, 36});
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -970,9 +970,25 @@ TEST(Variable, reshape) {
   EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
+TEST(Variable, reshape_fail) {
+  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  EXPECT_THROW_MSG(var.reshape({Dim::Row, 5}), std::runtime_error,
+                   "Cannot reshape to dimensions with different volume");
+}
+
 TEST(Variable, reshape_and_slice) {
-  Variable var(Data::Value{}, {Dim::Spectrum, 100});
+  Variable var(Data::Value{}, {Dim::Spectrum, 16},
+               {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+
+  auto slice =
+      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
+  EXPECT_TRUE(equals(slice.get<const Data::Value>(), {6, 7, 10, 11}));
+
   Variable center =
-      var.reshape({{Dim::X, 10}, {Dim::Y, 10}})(Dim::X, 2, 8)(Dim::Y, 2, 8)
-          .reshape({Dim::Spectrum, 36});
+      var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
+          .reshape({Dim::Spectrum, 4});
+
+  ASSERT_EQ(center.size(), 4);
+  ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
+  EXPECT_TRUE(equals(center.get<const Data::Value>(), {6, 7, 10, 11}));
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -970,6 +970,19 @@ TEST(Variable, reshape) {
   EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
+TEST(Variable, reshape_temporary) {
+  const Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Row, 4}},
+                     {1, 2, 3, 4, 5, 6, 7, 8});
+  auto reshaped = sum(var, Dim::X).reshape({{Dim::Y, 2}, {Dim::Z, 2}});
+  ASSERT_EQ(reshaped.size(), 4);
+  ASSERT_EQ(reshaped.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::Z, 2}}));
+  EXPECT_TRUE(equals(reshaped.get<const Data::Value>(), {6, 8, 10, 12}));
+
+  // This is not a temporary, we get a view into `var`.
+  EXPECT_EQ(typeid(decltype(std::move(var).reshape({}))),
+            typeid(ConstVariableSlice));
+}
+
 TEST(Variable, reshape_fail) {
   Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
   EXPECT_THROW_MSG(var.reshape({Dim::Row, 5}), std::runtime_error,


### PR DESCRIPTION
Depends on https://github.com/mantidproject/dataset/pull/5 being merged first. Please exclude those commits when reviewing.

`Dataset`, `Variable`, and their views are modified to avoid creating views of temporaries are getting references to members of temporaries. This prevent bugs like

```cpp
auto sum_y42 = sum(var, Dim::X)(Dim::Y, 42);
// sum_y42 is now a view that references free'ed data
```