### PR TITLE
Add histogram function to generate a histogram from event data.

### DIFF
--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -593,6 +593,67 @@ Dataset rebin(const Dataset &d, const Variable &newCoord) {
   return out;
 }
 
+Dataset histogram(const Variable &var, const Variable &coord) {
+  // TODO Check that dimensions that are in both var and coord match.
+  // TODO Check that the dimension the coord is for (the binning axis) is not
+  // part of var.
+  const auto &events = var.get<const Data::Events>();
+  dataset::expect::equals(events[0](Data::Tof{}).unit(), coord.unit());
+
+  // TODO Can we reuse the code for bin handling from DatasetView?
+  const auto binDim = coordDimension[coord.tag().value()];
+  const gsl::index nBin = coord.dimensions()[binDim] - 1;
+  Dimensions dims = var.dimensions();
+  dims.addInner(binDim, nBin);
+  // Compute offset to next edge.
+  const gsl::index offset = coord.dimensions().offset(binDim);
+
+  const auto edges = getView<double>(coord, dims);
+  Dataset hist;
+  hist.insert(coord);
+  hist.insert<Data::Value>(var.name(), dims);
+  hist.insert<Data::Variance>(var.name(), dims);
+
+  auto counts = hist.get<Data::Value>(var.name());
+  gsl::index cur = 0;
+  auto edge = edges.begin();
+  for (const auto &eventList : events) {
+    // TODO Change this to support generic data, not just Data::Tofs (do not
+    // encode unit in tag).
+    const auto tofs = eventList.get<const Data::Tof>();
+    if (!std::is_sorted(tofs.begin(), tofs.end()))
+      throw std::runtime_error(
+          "TODO: Histograms can currently only be created from sorted data.");
+    gsl::index bin = 0;
+    auto left = *edge;
+    auto begin = std::lower_bound(tofs.begin(), tofs.end(), left);
+    while (bin++ != nBin) {
+      // The iterator cannot see the last edge, we must add the offset to the
+      // memory location, *not* to the iterator.
+      const auto right = *(&*edge + offset);
+      const auto end = std::upper_bound(begin, tofs.end(), right);
+      //fprintf(stderr, "%lf %lf %ld %ld %lu\n", left, right, cur, offset, edge-edges.begin());
+      counts[cur] = std::distance(begin, end);
+      begin = end;
+      left = right;
+      ++edge;
+      ++cur;
+    }
+  }
+
+  // TODO Would need to add handling for weighted events etc. here.
+  return hist;
+}
+
+Dataset histogram(const Dataset &d, const Variable &coord) {
+  Dataset hist;
+  hist.insert(coord);
+  for (const auto &var : d)
+    if (var.tag() == Data::Events{})
+      hist.merge(histogram(var, coord));
+  return hist;
+}
+
 // We can specialize this to switch to a more efficient variant when sorting
 // datasets that represent events lists, using LinearView.
 template <class Tag> struct Sort {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -646,6 +646,9 @@ Dataset histogram(const Variable &var, const Variable &coord) {
       // The iterator cannot see the last edge, we must add the offset to the
       // memory location, *not* to the iterator.
       const auto right = *(&*edge + nextEdgeOffset);
+      if (right < left)
+        throw std::runtime_error(
+            "Coordinate used for binning is not increasing.");
       const auto end = std::upper_bound(begin, tofs.end(), right);
       counts[cur] = std::distance(begin, end);
       begin = end;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -394,6 +394,7 @@ Dataset concatenate(const Dataset &d1, const Dataset &d2, const Dim dim);
 Dataset convert(const Dataset &d, const Dim from, const Dim to);
 // Not verified, likely wrong in some cases
 Dataset rebin(const Dataset &d, const Variable &newCoord);
+Dataset histogram(const Dataset &d, const Variable &coord);
 
 Dataset sort(const Dataset &d, const Tag t, const std::string &name = "");
 // Note: Can provide stable_sort for sorting by multiple columns, e.g., for a

--- a/src/dimensions.cpp
+++ b/src/dimensions.cpp
@@ -87,6 +87,7 @@ void Dimensions::erase(const Dim label) {
   m_dims[m_ndim] = Dim::Invalid;
 }
 
+/// Add a new dimension, which will be the outermost dimension.
 void Dimensions::add(const Dim label, const gsl::index size) {
   if (contains(label))
     throw std::runtime_error("Duplicate dimension.");
@@ -98,6 +99,17 @@ void Dimensions::add(const Dim label, const gsl::index size) {
   }
   m_shape[0] = size;
   m_dims[0] = label;
+  ++m_ndim;
+}
+
+/// Add a new dimension, which will be the innermost dimension.
+void Dimensions::addInner(const Dim label, const gsl::index size) {
+  if (contains(label))
+    throw std::runtime_error("Duplicate dimension.");
+  if (m_ndim == 6)
+    throw std::runtime_error("More than 6 dimensions are not supported.");
+  m_shape[m_ndim] = size;
+  m_dims[m_ndim] = label;
   ++m_ndim;
 }
 

--- a/src/dimensions.h
+++ b/src/dimensions.h
@@ -118,7 +118,9 @@ public:
   void resize(const gsl::index i, const gsl::index size);
   void erase(const Dim label);
 
+  // TODO Better names required.
   void add(const Dim label, const gsl::index size);
+  void addInner(const Dim label, const gsl::index size);
 
   int32_t index(const Dim label) const;
 

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -150,6 +150,12 @@ UnitMismatchError::UnitMismatchError(const Unit &a, const Unit &b)
 } // namespace except
 
 namespace expect {
+void dimensionMatches(const Dimensions &dims, const Dim dim,
+                      const gsl::index length) {
+  if (dims[dim] != length)
+    throw except::DimensionLengthError(dims, dim, length);
+}
+
 void equals(const Unit &a, const Unit &b) {
   if (!(a == b))
     throw except::UnitMismatchError(a, b);

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -95,6 +95,12 @@ std::string to_string(const Unit &unit) {
   }
 }
 
+std::string to_string(const Variable &variable) {
+  std::string s("Variable(");
+  s += to_string(variable.tag()) + ", " + variable.name() + ")";
+  return s;
+}
+
 std::string to_string(const Dataset &dataset) {
   std::string s("Dataset with ");
   s += std::to_string(dataset.size()) + " variables";

--- a/src/except.h
+++ b/src/except.h
@@ -17,12 +17,15 @@ class Dataset;
 class Dimensions;
 class Tag;
 class Unit;
+class Variable;
 
 namespace dataset {
 std::string to_string(const Dim dim);
 std::string to_string(const Dimensions &dims);
 std::string to_string(const Tag tag);
 std::string to_string(const Unit &unit);
+std::string to_string(const Variable &variable);
+std::string to_string(const Dataset &dataset);
 
 namespace except {
 

--- a/src/except.h
+++ b/src/except.h
@@ -66,6 +66,8 @@ struct UnitMismatchError : public UnitError {
 } // namespace except
 
 namespace expect {
+void dimensionMatches(const Dimensions &dims, const Dim dim,
+                      const gsl::index length);
 void equals(const Unit &a, const Unit &b);
 
 template <class T> void contains(const T &a, const T &b) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1100,3 +1100,10 @@ Variable mean(const Variable &var, const Dim dim) {
   double scale = 1.0 / static_cast<double>(var.dimensions()[dim]);
   return summed * makeVariable<Data::Value>({}, {scale});
 }
+
+template <>
+VariableView<const double> getView<double>(const Variable &var,
+                                           const Dimensions &dims) {
+  return dynamic_cast<const VariableConceptT<double> &>(var.data())
+      .getView(dims);
+}

--- a/src/variable.h
+++ b/src/variable.h
@@ -509,4 +509,7 @@ Variable filter(const Variable &var, const Variable &filter);
 Variable sum(const Variable &var, const Dim dim);
 Variable mean(const Variable &var, const Dim dim);
 
+template <class T>
+VariableView<const T> getView(const Variable &var, const Dimensions &dims);
+
 #endif // VARIABLE_H

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -736,6 +736,11 @@ TEST(Dataset, histogram_failures) {
       makeVariable<Coord::Tof>({{Dim::Spectrum, 3}, {Dim::Tof, 3}});
   EXPECT_THROW(histogram(d, coordWithLengthMismatch),
                dataset::except::DimensionLengthError);
+
+  auto coordNotIncreasing =
+      makeVariable<Coord::Tof>({Dim::Tof, 3}, {1.0, 1.5, 1.4});
+  EXPECT_THROW_MSG(histogram(d, coordNotIncreasing), std::runtime_error,
+                   "Coordinate used for binning is not increasing.");
 }
 
 TEST(Dataset, histogram) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -1005,3 +1005,39 @@ TEST(Variable, reshape_and_slice) {
   ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
   EXPECT_TRUE(equals(center.get<const Data::Value>(), {6, 7, 10, 11}));
 }
+
+TEST(Variable, access_typed_view) {
+  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}}, {1, 2, 3, 4, 5, 6});
+  const auto values =
+      getView<double>(var, {{Dim::Y, 2}, {Dim::Z, 4}, {Dim::X, 3}});
+  ASSERT_EQ(values.size(), 24);
+
+  for (const auto z : {0, 1, 2, 3}) {
+    EXPECT_EQ(values[3 * z + 0], 1);
+    EXPECT_EQ(values[3 * z + 1], 2);
+    EXPECT_EQ(values[3 * z + 2], 3);
+  }
+  for (const auto z : {0, 1, 2, 3}) {
+    EXPECT_EQ(values[12 + 3 * z + 0], 4);
+    EXPECT_EQ(values[12 + 3 * z + 1], 5);
+    EXPECT_EQ(values[12 + 3 * z + 2], 6);
+  }
+}
+
+TEST(Variable, access_typed_view_edges) {
+  // If a variable contains bin edges we want to "skip" the last edge. Say bins
+  // is in direction Y:
+  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  const auto values =
+      getView<double>(var, {{Dim::Y, 2}, {Dim::Z, 4}, {Dim::X, 2}});
+  ASSERT_EQ(values.size(), 16);
+
+  for (const auto z : {0, 1, 2, 3}) {
+    EXPECT_EQ(values[2 * z + 0], 1);
+    EXPECT_EQ(values[2 * z + 1], 4);
+  }
+  for (const auto z : {0, 1, 2, 3}) {
+    EXPECT_EQ(values[8 + 2 * z + 0], 2);
+    EXPECT_EQ(values[8 + 2 * z + 1], 5);
+  }
+}


### PR DESCRIPTION
Add function similar to `numpy.histogram` to generate a dataset containing a histogram from a dataset containing event lists.

Implementation has highlighted a number of things that require more thought, I would appreciate if the reviewers could comment on the following:

1. We may encounter more and more cases where we need to access a variable of arbitrary tag but with a fixed type (the alternative would be to add more virtual methods to `VariableConcept`, which we may want to avoid for higher-level functionality). To this end the `getView` helper template was added. This works fine (could maybe be made a member of variable) but I am not entirely sure about it. Arbitrary dimensions can be specified which aid in automatic broadcasting when processing the returned view alongside a view of other data. Is the encapsulation good enough?

2. I am feeling more and more that for *data* variables it may be more convenient to have only tags that correspond to specific types, instead of to specific concepts. For example, currently events are stored as `Data::Events`, i.e., a specific concept, whereas it would be more generic/flexible to simply use something like `Data::Float64Vector`. `histogram` would then work also for other data, not just events. This also links into the unclear plans we have for mixed precision support.

3. Given item 2), does the same apply also for coordinates? Should we just have the "`dtype`" and tag as separate concepts? That is, instead of the current `dataset.get<Coord::X>()` use `dataset.get<const double>(Coord::X)` (where `Coord::X` would now be an `enum` value instead of a type)? There is some extra typing (unless we default the template parameter), but this would certainly have advantages.