### PR TITLE
Refactor VariableConcept to a more scalable mechanism

### DIFF
--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -162,6 +162,9 @@ if (var.type() != Type::Double) {
 }
 ```
 
+On second thought though, this probably still suffers from the combinatoric explosion:
+The type of the converting view unfortunately also depends on the type it is converting from, so we only moved the problem to another place.
+
 
 #### Non-trivial and derived item types
 

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -1,0 +1,155 @@
+## Tags, names, and grouping variables in Dataset
+
+
+### Current solution
+
+1. Names of variables define a grouping, which is used, e.g., to associate a variance with its data.
+2. Tags map directly to types.
+   This happens at compile time, i.e., a specific tag always defines a type.
+3. Tags are types (not `enum` values) such that they can be `const`-qualified.
+   This is necessary for the copy-on-write mechanism.
+   Runtime-tags are also supporting using a base class that holds an ID.
+
+The combination of defining a type and `const` qualification supports the following syntax:
+
+```cpp
+// 1. Read-only access to a single variable. 
+auto data = dataset.get<const Data::Value>();
+
+// 2. Write access to a single variable.
+auto data = dataset.get<Data::Value>();
+
+// 3. Associating variables with each other.
+auto data = dataset.get<const Data::Value>("sample1");
+auto errors = dataset.get<const Data::Variance>("sample1");
+
+// 4. Typed view of multiple variables.
+DatasetView<const Coord::X, Data::Value> view(dataset);
+
+// 5. Views of named variable.
+DatasetView<const Coord::X, Data::Value> view(dataset, "sample1");
+
+// 6. Getters with compile-time tags.
+auto &value = view.begin()->get<Data::Value>();
+
+// 7. Named getters.
+auto &x = view.begin()->x();
+
+// 8. View of multiple named variables.
+// Currently not supported since it requires an unclear mapping from template
+// arguments to name strings and, more importantly, it would require getters
+// with string arguments and comparisons, which would be very inefficient at
+// this level.
+DatasetView<const Coord::X, Data::Value, const Data::Value>
+    view(dataset, "sample1", "sample2");
+// Note that we avoid a positional way of resolving this: The order of arguments
+// is not reflected in the type of the view.
+auto &value = view.begin()->get<Data::Value>("sample1");
+```
+
+
+The examples are numbered and we will discuss alternative below.
+
+
+### Runtime tags, flexible type
+
+```cpp
+// 1. Read-only access to a single variable. 
+auto data = dataset.get<const double>(Data::Value);
+
+// 2. Write access to a single variable.
+auto data = dataset.get<double>(Data::Value);
+
+// 3. Associating variables with each other.
+auto data = dataset.get<const double>(Data::Value, "sample1");
+auto errors = dataset.get<const double>(Data::Variance, "sample1");
+
+// 4. Typed view of multiple variables.
+// This is awkward since we must mentally match a template argument to each tag.
+DatasetView<const double, double> view(dataset, Coord::X, Data::Value);
+// Clear but slightly more verbose.
+auto view = dataset.makeView(Label<const double, Coord::X>{},
+                             Label<double, Data::Value>{});
+
+// 5. Views of named variables.
+auto view = dataset.makeView(Label<const double, Coord::X>{},
+                             Label<double, Data::Value>("sample1"));
+
+// 6. Getters with compile-time tags.
+// It may at first seem like this is not possible since the tag does not imply a
+// type. However, the mapping from tag to type is fixed in the type of the view!
+auto &value = view.begin()->get<Data::Value>();
+
+// 7. Named getters.
+auto &x = view.begin()->x();
+
+// 8. View of multiple named variables.
+// This solves the problem of mapping tags to names, but the item-getter issue remains.
+auto view = dataset.makeView(Label<const double, Coord::X>{},
+                             Label<double, Data::Value>("sample1"),
+                             Label<const double, Data::Value>("sample2"));
+auto &value = view.begin()->get<Data::Value>("sample1");
+// Could provide a getter ID:
+auto view =
+    dataset.makeView(Label<const double, Coord::X>{},
+                     Label<double, Data::Value, Label::Id1>("sample1"),
+                     Label<const double, Data::Value, Label::Id2>("sample2"));
+auto &value = view.begin()->get<Label::Id1>();
+```
+
+The distinction between types and tags raises the question whether this is sufficient.
+Generic operations like addition would simply operate on all variables (or all variables that are addable).
+For more specific operations like generating a histogram from event data this is not so clear, and there are at least two options:
+- We can histogram any variable that has a compatible item type such as `std::vector<double>`.
+- Or we can histogram only variables with specific predefined tags, such as `Data::Events`.
+
+Do we thus need another conceptional level?
+Currently we have `type < tag < name`, i.e., the tag defines a concept that is more specific than a type.
+Would it make sense to extend this to `type < concept < tag < name`?
+Probably not, we should rather make the type more specific, i.e., think of it as `concept < tag < name`?
+
+
+### No tags, just names and types
+
+```cpp
+// 1. Read-only access to a single variable. 
+auto data = dataset.get<const double>("value");
+
+// 2. Write access to a single variable.
+auto data = dataset.get<double>("value");
+
+// 3. Associating variables with each other.
+// Requires mechanism using string prefix/suffix and restrictions on names.
+auto data = dataset.get<const double>("sample1");
+auto errors = dataset.get<const double>("sample1-variance");
+
+// 4. Typed view of multiple variables.
+// 5. Views of named variables.
+auto view =
+    dataset.makeView(Label<const double>("Coord.X"), Label<double>("value"));
+
+// 6. Getters with compile-time tags.
+// Not possible unless we assign IDs when creating the view.
+
+// 7. Named getters.
+// Not possible unless we assign IDs when creating the view.
+
+// 8. View of multiple named variables.
+// See above.
+```
+
+### Other
+
+It [has been criticised](https://github.com/mantidproject/dataset/pull/4#issuecomment-445320309) that the two-part item getters are awkward.
+In place of `dataset[Data.Variance, 'sample1']` an alternative `dataset.variances['sample1']` was suggested, which follows what `xarray` does for coordinates.
+
+Based on this example, this looks like a good suggestion, putting variances on a similar footing as coordinates.
+However, there would be two drawbacks to this:
+
+- We not only have data and variance that need to be grouped.
+  Another key example is event data, which can include time-of-flight, pulse-times, and weights.
+  If we did not have a grouping mechanism it would restrict our options when devising an event-storage format.
+- Unless we drop the connection between tag and type, we need a tag on the C++ side.
+
+Also note that we support storing data and variances in separate variables.
+If the variance variable did not have a tag it would be impossible to tell what it is.

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -140,6 +140,28 @@ This would lead to 2x2x2x2 = 16 cases.
 If also coordinates with flexible types are involved we quickly reach O(100) cases, which is unmanageable.
 Therefore, in practice we will need to put certain limitations on the type combinations that are supported, even for the more generic operations.
 
+One way to avoid combinatoric explosion may be to introduce a view that can convert precision on the fly.
+For example, when adding a variable containing `double` items to a variable containing `float` items, the former could be converted to a `float` view.
+
+```cpp
+// Assume we want to do a computation in double precision.
+template <class T>
+double compute(const T &view) {
+  double init = 0.0;
+  return std::accumulate(view.begin(), view.end(), init);
+}
+
+// Not actually including more than one input in this example, so there is no
+// "explosion", but the technique stays the same for multiple arguments.
+if (var.type() != Type::Double) {
+  auto doubleView = var.getConvertingView<float, double>();
+  return compute(doubleView);
+} else {
+  auto doubleSpan = var.get<double>();
+  return compute(doubleSpan);
+}
+```
+
 
 #### Non-trivial and derived item types
 

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -150,7 +150,7 @@ We can probably simply use a `typedef` to keep this convenience,
 ```cpp
 template <class T>
 using EventList = EventListProxy<Label<T, Data::Tof>, Label<int64_t, Data::PulseTime>>;
-auto eventLists = dataset.get<EventList>(Data::Events);
+auto eventLists = dataset.get<EventList<double>>(Data::Events);
 ```
 
 Another option is to specify only the precision in the getter, if we define a tag "category" at compile time and leave only the precision flexible:

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -323,6 +323,8 @@ Operations that combine two different concepts? Matrix-vector multiplication?
 - At the `Dataset` level:
   - Tags define a relationship between variables.
     Tags come in groups, and operations are defined for specific groups.
+    - Example 1: A data value and a variance form a group (a value with uncertainty).
+    - Example 2: A list of time-of-flight values and (optionally) lists of pulse-times, weights, and uncertainties form a group (an event-list).
   - Names of variables define a "family" of variables.
     Only variables from the same family are considered related when looking for variables with tags from the same tag group.
 - If we think in terms of concepts, which in turn define which operations can be applied:

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -209,7 +209,7 @@ auto data = dataset.get<const double>("sample1");
 auto errors = dataset.get<const double>("sample1-variance");
 
 // 5. Typed view of multiple variables.
-// 5. Views of named variables.
+// 6. Views of named variables.
 auto view =
     dataset.makeView(Label<const double>("Coord.X"), Label<double>("sample1"));
 
@@ -238,3 +238,14 @@ However, there would be two drawbacks to this:
 
 Also note that we support storing data and variances in separate variables.
 If the variance variable did not have a tag it would be impossible to tell what it is.
+
+As a counter argument, consider that for variables on their own it never actually makes a difference whether they represent coordinates, data, variances, other something else.
+The distinction becomes meaningful only once included in a dataset --- at which point we could support another mechanism to distinguish those concepts.
+It would however become more tricky and dangerous to move that auxiliary information from one dataset to another, consider
+
+```cpp
+// If tag is part of Variable:
+dataset.insert(variable);
+// If tags (or a similar concept) exist only on the Dataset level:
+dataset.insert(Coord::X, variable); // Prone bugs due to typos in tags.
+```

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -153,7 +153,7 @@ template <template <class> class Op> struct ArithmeticHelper<Op, std::string> {
 VariableConcept::VariableConcept(const Dimensions &dimensions)
     : m_dimensions(dimensions){};
 
-class NumberVariableConcept : public VariableConcept {
+class FloatingPointVariableConcept : public VariableConcept {
 public:
   using VariableConcept::VariableConcept;
   virtual void rebin(const VariableConcept &old, const Dim dim,
@@ -162,7 +162,7 @@ public:
 };
 
 template <class T> class ViewModel;
-template <class T> class NumberVariableConceptT;
+template <class T> class FloatingPointVariableConceptT;
 
 template <class T, typename Enable = void> struct concept {
   using type = VariableConcept;
@@ -170,8 +170,8 @@ template <class T, typename Enable = void> struct concept {
 };
 template <class T>
 struct concept<T, std::enable_if_t<std::is_floating_point<T>::value>> {
-  using type = NumberVariableConcept;
-  using typeT = NumberVariableConceptT<T>;
+  using type = FloatingPointVariableConcept;
+  using typeT = FloatingPointVariableConceptT<T>;
 };
 
 template <class T> using concept_t = typename concept<T>::type;
@@ -358,7 +358,8 @@ public:
   }
 };
 
-template <class T> class NumberVariableConceptT : public VariableConceptT<T> {
+template <class T>
+class FloatingPointVariableConceptT : public VariableConceptT<T> {
 public:
   using VariableConceptT<T>::VariableConceptT;
 
@@ -366,11 +367,11 @@ public:
              const VariableConcept &oldCoord,
              const VariableConcept &newCoord) override {
     // Dimensions of *this and old are guaranteed to be the same.
-    const auto &oldT = dynamic_cast<const NumberVariableConceptT &>(old);
+    const auto &oldT = dynamic_cast<const FloatingPointVariableConceptT &>(old);
     const auto &oldCoordT =
-        dynamic_cast<const NumberVariableConceptT &>(oldCoord);
+        dynamic_cast<const FloatingPointVariableConceptT &>(oldCoord);
     const auto &newCoordT =
-        dynamic_cast<const NumberVariableConceptT &>(newCoord);
+        dynamic_cast<const FloatingPointVariableConceptT &>(newCoord);
     if (this->dimensions().label(0) == dim &&
         oldCoord.dimensions().count() == 1 &&
         newCoord.dimensions().count() == 1) {
@@ -1036,7 +1037,7 @@ Variable rebin(const Variable &var, const Variable &oldCoord,
   dims.resize(dim, newCoord.dimensions()[dim] - 1);
   rebinned.setDimensions(dims);
   // TODO take into account unit if values have been divided by bin width.
-  dynamic_cast<NumberVariableConcept &>(rebinned.data())
+  dynamic_cast<FloatingPointVariableConcept &>(rebinned.data())
       .rebin(var.data(), dim, oldCoord.data(), newCoord.data());
   return rebinned;
 }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -127,6 +127,8 @@ template <class T> struct RebinHelper {
 VariableConcept::VariableConcept(const Dimensions &dimensions)
     : m_dimensions(dimensions){};
 
+// Some types such as Dataset support `+` (effectively appending table rows),
+// but are not arithmetic.
 class AddableVariableConcept : public VariableConcept {
 public:
   static constexpr const char *name = "addable";

--- a/src/variable.h
+++ b/src/variable.h
@@ -53,9 +53,6 @@ public:
   virtual bool isView() const = 0;
   virtual bool isConstView() const = 0;
 
-  virtual void rebin(const VariableConcept &old, const Dim dim,
-                     const VariableConcept &oldCoord,
-                     const VariableConcept &newCoord) = 0;
   virtual VariableConcept &operator+=(const VariableConcept &other) = 0;
   virtual VariableConcept &operator-=(const VariableConcept &other) = 0;
   virtual VariableConcept &operator*=(const VariableConcept &other) = 0;

--- a/src/variable.h
+++ b/src/variable.h
@@ -53,9 +53,6 @@ public:
   virtual bool isView() const = 0;
   virtual bool isConstView() const = 0;
 
-  virtual VariableConcept &operator+=(const VariableConcept &other) = 0;
-  virtual VariableConcept &operator-=(const VariableConcept &other) = 0;
-  virtual VariableConcept &operator*=(const VariableConcept &other) = 0;
   virtual gsl::index size() const = 0;
   virtual void copy(const VariableConcept &other, const Dim dim,
                     const gsl::index offset, const gsl::index otherBegin,

--- a/src/variable.h
+++ b/src/variable.h
@@ -24,6 +24,11 @@ class Variable;
 /// Abstract base class for any data that can be held by Variable. Also used to
 /// hold views to data by (Const)VariableSlice. This is using so-called
 /// concept-based polymorphism, see talks by Sean Parent.
+///
+/// This is the most generic representation for a multi-dimensional array of
+/// data. Depending on the item type more functionality such as binary
+/// operations is supported. Virtual methods for these are added in
+/// child-classes. See, e.g., `ArithmeticVariableConcept`.
 class VariableConcept {
 public:
   VariableConcept(const Dimensions &dimensions);

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -150,7 +150,7 @@ TEST(Variable, operator_plus_equal_different_unit) {
 TEST(Variable, operator_plus_equal_non_arithmetic_type) {
   auto a = makeVariable<Data::String>({Dim::X, 1}, {std::string("test")});
   EXPECT_THROW_MSG(a += a, std::runtime_error,
-                   "Cannot add strings. Use append() instead.");
+                   "Cannot apply operation, requires addable type.");
 }
 
 TEST(Variable, operator_plus_equal_different_variables_different_element_type) {


### PR DESCRIPTION
Previously `VariableConcept` included virtual methods for all possible functionality for any data types. However, not all data supports all operations, for example `*=` does not make sense for strings. Previously we manually disabled the functionality for each unsupported type.

This PR moves the more specific functionality into child classes. Right now the code size is not changed much, but the new structure should be more easily scalable to more operations.