### PR TITLE
Add operations with scalars for Variable, Dataset, and the respective slice objects.

### DIFF
--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -445,6 +445,12 @@ DatasetSlice DatasetSlice::operator+=(const ConstDatasetSlice &other) {
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
       *this, other);
 }
+DatasetSlice DatasetSlice::operator+=(const double value) {
+  for (auto var : *this)
+    if (var.tag() == Data::Value{})
+      var += value;
+  return *this;
+}
 
 DatasetSlice DatasetSlice::operator-=(const Dataset &other) {
   return binary_op_equals(
@@ -455,12 +461,26 @@ DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) {
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
+DatasetSlice DatasetSlice::operator-=(const double value) {
+  for (auto var : *this)
+    if (var.tag() == Data::Value{})
+      var -= value;
+  return *this;
+}
 
 DatasetSlice DatasetSlice::operator*=(const Dataset &other) {
   return times_equals(*this, other);
 }
 DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) {
   return times_equals(*this, other);
+}
+DatasetSlice DatasetSlice::operator*=(const double value) {
+  for (auto var : *this)
+    if (var.tag() == Data::Value{})
+      var *= value;
+    else if (var.tag() == Data::Variance{})
+      var *= value * value;
+  return *this;
 }
 
 Dataset operator+(Dataset a, const Dataset &b) { return a += b; }

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -349,6 +349,12 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
   return dataset;
 }
 
+Dataset Dataset::operator-() const {
+  auto copy(*this);
+  copy *= -1.0;
+  return copy;
+}
+
 Dataset &Dataset::operator+=(const Dataset &other) {
   return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
@@ -429,6 +435,11 @@ template <class T1, class T2> T1 &assign(T1 &dataset, const T2 &other) {
   return dataset;
 }
 
+Dataset ConstDatasetSlice::operator-() const {
+  Dataset copy(*this);
+  return -copy;
+}
+
 DatasetSlice DatasetSlice::assign(const Dataset &other) {
   return ::assign(*this, other);
 }
@@ -486,6 +497,15 @@ DatasetSlice DatasetSlice::operator*=(const double value) {
 Dataset operator+(Dataset a, const Dataset &b) { return a += b; }
 Dataset operator-(Dataset a, const Dataset &b) { return a -= b; }
 Dataset operator*(Dataset a, const Dataset &b) { return a *= b; }
+Dataset operator+(Dataset a, const ConstDatasetSlice &b) { return a += b; }
+Dataset operator-(Dataset a, const ConstDatasetSlice &b) { return a -= b; }
+Dataset operator*(Dataset a, const ConstDatasetSlice &b) { return a *= b; }
+Dataset operator+(Dataset a, const double b) { return a += b; }
+Dataset operator-(Dataset a, const double b) { return a -= b; }
+Dataset operator*(Dataset a, const double b) { return a *= b; }
+Dataset operator+(const double a, Dataset b) { return b += a; }
+Dataset operator-(const double a, Dataset b) { return -(b -= a); }
+Dataset operator*(const double a, Dataset b) { return b *= a; }
 
 std::vector<Dataset> split(const Dataset &d, const Dim dim,
                            const std::vector<gsl::index> &indices) {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -359,6 +359,12 @@ Dataset &Dataset::operator+=(const ConstDatasetSlice &other) {
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
       *this, other);
 }
+Dataset &Dataset::operator+=(const double value) {
+  for (auto &var : m_variables)
+    if (var.tag() == Data::Value{})
+      var += value;
+  return *this;
+}
 
 Dataset &Dataset::operator-=(const Dataset &other) {
   return binary_op_equals(
@@ -370,12 +376,26 @@ Dataset &Dataset::operator-=(const ConstDatasetSlice &other) {
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
+Dataset &Dataset::operator-=(const double value) {
+  for (auto &var : m_variables)
+    if (var.tag() == Data::Value{})
+      var -= value;
+  return *this;
+}
 
 Dataset &Dataset::operator*=(const Dataset &other) {
   return times_equals(*this, other);
 }
 Dataset &Dataset::operator*=(const ConstDatasetSlice &other) {
   return times_equals(*this, other);
+}
+Dataset &Dataset::operator*=(const double value) {
+  for (auto &var : m_variables)
+    if (var.tag() == Data::Value{})
+      var *= value;
+    else if (var.tag() == Data::Variance{})
+      var *= value * value;
+  return *this;
 }
 
 bool ConstDatasetSlice::contains(const Tag tag, const std::string &name) const {

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -376,10 +376,13 @@ public:
   DatasetSlice assign(const ConstDatasetSlice &other);
   DatasetSlice operator+=(const Dataset &other);
   DatasetSlice operator+=(const ConstDatasetSlice &other);
+  DatasetSlice operator+=(const double value);
   DatasetSlice operator-=(const Dataset &other);
   DatasetSlice operator-=(const ConstDatasetSlice &other);
+  DatasetSlice operator-=(const double value);
   DatasetSlice operator*=(const Dataset &other);
   DatasetSlice operator*=(const ConstDatasetSlice &other);
+  DatasetSlice operator*=(const double value);
 
   VariableSlice operator()(const Tag tag, const std::string &name = "");
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -161,6 +161,7 @@ public:
   const Dimensions &dimensions() const & { return m_dimensions; }
 
   bool operator==(const Dataset &other) const;
+  Dataset operator-() const;
   Dataset &operator+=(const Dataset &other);
   Dataset &operator+=(const ConstDatasetSlice &other);
   Dataset &operator+=(const double value);
@@ -301,6 +302,8 @@ public:
     return std::equal(begin(), end(), other.begin(), other.end());
   }
 
+  Dataset operator-() const;
+
 protected:
   const Dataset &m_dataset;
   std::vector<gsl::index> m_indices;
@@ -391,8 +394,17 @@ private:
 };
 
 Dataset operator+(Dataset a, const Dataset &b);
+Dataset operator+(Dataset a, const ConstDatasetSlice &b);
+Dataset operator+(Dataset a, const double b);
+Dataset operator+(const double a, Dataset b);
 Dataset operator-(Dataset a, const Dataset &b);
+Dataset operator-(Dataset a, const ConstDatasetSlice &b);
+Dataset operator-(Dataset a, const double b);
+Dataset operator-(const double a, Dataset b);
 Dataset operator*(Dataset a, const Dataset &b);
+Dataset operator*(Dataset a, const ConstDatasetSlice &b);
+Dataset operator*(Dataset a, const double b);
+Dataset operator*(const double a, Dataset b);
 std::vector<Dataset> split(const Dataset &d, const Dim dim,
                            const std::vector<gsl::index> &indices);
 Dataset concatenate(const Dataset &d1, const Dataset &d2, const Dim dim);

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -163,10 +163,13 @@ public:
   bool operator==(const Dataset &other) const;
   Dataset &operator+=(const Dataset &other);
   Dataset &operator+=(const ConstDatasetSlice &other);
+  Dataset &operator+=(const double value);
   Dataset &operator-=(const Dataset &other);
   Dataset &operator-=(const ConstDatasetSlice &other);
+  Dataset &operator-=(const double value);
   Dataset &operator*=(const Dataset &other);
   Dataset &operator*=(const ConstDatasetSlice &other);
+  Dataset &operator*=(const double value);
 
 private:
   gsl::index find(const Tag tag, const std::string &name) const;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -851,6 +851,11 @@ VariableSlice VariableSlice::operator+=(const Variable &other) {
 VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) {
   return plus_equals(*this, other);
 }
+VariableSlice VariableSlice::operator+=(const double value) {
+  Variable other(Data::Value{}, {}, {value});
+  other.setUnit(Unit::Id::Dimensionless);
+  return plus_equals(*this, other);
+}
 
 VariableSlice VariableSlice::operator-=(const Variable &other) {
   return minus_equals(*this, other);
@@ -858,11 +863,21 @@ VariableSlice VariableSlice::operator-=(const Variable &other) {
 VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) {
   return minus_equals(*this, other);
 }
+VariableSlice VariableSlice::operator-=(const double value) {
+  Variable other(Data::Value{}, {}, {value});
+  other.setUnit(Unit::Id::Dimensionless);
+  return minus_equals(*this, other);
+}
 
 VariableSlice VariableSlice::operator*=(const Variable &other) {
   return times_equals(*this, other);
 }
 VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) {
+  return times_equals(*this, other);
+}
+VariableSlice VariableSlice::operator*=(const double value) {
+  Variable other(Data::Value{}, {}, {value});
+  other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
 }
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -901,6 +901,11 @@ bool ConstVariableSlice::operator!=(const ConstVariableSlice &other) const {
   return !(*this == other);
 }
 
+Variable ConstVariableSlice::operator-() const {
+  Variable copy(*this);
+  return -copy;
+}
+
 void VariableSlice::setUnit(const Unit &unit) {
   // TODO Should we forbid setting the unit altogether? I think it is useful in
   // particular since views onto subsets of dataset do not imply slicing of

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -805,6 +805,10 @@ Variable &Variable::operator-=(const Variable &other) & {
 Variable &Variable::operator-=(const ConstVariableSlice &other) & {
   return minus_equals(*this, other);
 }
+Variable &Variable::operator-=(const double value) & {
+  Variable other(Data::Value{}, {}, {value});
+  return minus_equals(*this, other);
+}
 
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   dataset::expect::contains(variable.dimensions(), other.dimensions());
@@ -981,6 +985,12 @@ Variable operator*(Variable a, const Variable &b) { return a *= b; }
 Variable operator+(Variable a, const ConstVariableSlice &b) { return a += b; }
 Variable operator-(Variable a, const ConstVariableSlice &b) { return a -= b; }
 Variable operator*(Variable a, const ConstVariableSlice &b) { return a *= b; }
+Variable operator+(Variable a, const double b) { return a += b; }
+Variable operator-(Variable a, const double b) { return a -= b; }
+Variable operator*(Variable a, const double b) { return a *= b; }
+Variable operator+(const double a, Variable b) { return b += a; }
+Variable operator-(const double a, Variable b) { return -(b -= a); }
+Variable operator*(const double a, Variable b) { return b *= a; }
 
 // Example of a "derived" operation: Implementation does not require adding a
 // virtual function to VariableConcept.

--- a/src/variable.h
+++ b/src/variable.h
@@ -171,6 +171,7 @@ public:
   Variable &operator+=(const double value) &;
   Variable &operator-=(const Variable &other) &;
   Variable &operator-=(const ConstVariableSlice &other) &;
+  Variable &operator-=(const double value) &;
   Variable &operator*=(const Variable &other) &;
   Variable &operator*=(const ConstVariableSlice &other) &;
   Variable &operator*=(const double value) &;
@@ -500,6 +501,12 @@ Variable operator*(Variable a, const Variable &b);
 Variable operator+(Variable a, const ConstVariableSlice &b);
 Variable operator-(Variable a, const ConstVariableSlice &b);
 Variable operator*(Variable a, const ConstVariableSlice &b);
+Variable operator+(Variable a, const double b);
+Variable operator-(Variable a, const double b);
+Variable operator*(Variable a, const double b);
+Variable operator+(const double a, Variable b);
+Variable operator-(const double a, Variable b);
+Variable operator*(const double a, Variable b);
 
 std::vector<Variable> split(const Variable &var, const Dim dim,
                             const std::vector<gsl::index> &indices);

--- a/src/variable.h
+++ b/src/variable.h
@@ -468,10 +468,13 @@ public:
   template <class T> VariableSlice assign(const T &other);
   VariableSlice operator+=(const Variable &other);
   VariableSlice operator+=(const ConstVariableSlice &other);
+  VariableSlice operator+=(const double value);
   VariableSlice operator-=(const Variable &other);
   VariableSlice operator-=(const ConstVariableSlice &other);
+  VariableSlice operator-=(const double value);
   VariableSlice operator*=(const Variable &other);
   VariableSlice operator*=(const ConstVariableSlice &other);
+  VariableSlice operator*=(const double value);
 
   void setUnit(const Unit &unit);
 

--- a/src/variable.h
+++ b/src/variable.h
@@ -389,6 +389,7 @@ public:
   bool operator==(const ConstVariableSlice &other) const;
   bool operator!=(const Variable &other) const;
   bool operator!=(const ConstVariableSlice &other) const;
+  Variable operator-() const;
 
 protected:
   friend class Variable;

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -1073,3 +1073,33 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
       view_a_x13 -= view_a_x02, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
 }
+
+TEST(Dataset, binary_assign_with_scalar) {
+  Dataset d;
+  d.insert<Coord::X>({Dim::X, 2}, {1, 2});
+  d.insert<Data::Value>("a", {Dim::X, 2}, {1, 2});
+  d.insert<Data::Value>("b", {}, {3});
+  d.insert<Data::Variance>("a", {Dim::X, 2}, {4, 5});
+  d.insert<Data::Variance>("b", {}, {6});
+
+  d += 1;
+  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {2, 3}));
+  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  // Scalar treated as having 0 variance, `+` leaves variance unchanged.
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+
+  d -= 2;
+  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {0, 1}));
+  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {2}));
+  // Scalar treated as having 0 variance, `-` leaves variance unchanged.
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+
+  d *= 2;
+  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {0, 2}));
+  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  // Scalar treated as having 0 variance, `*` affects variance.
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {16, 20}));
+  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {24}));
+}

--- a/test/linear_view_test.cpp
+++ b/test/linear_view_test.cpp
@@ -90,8 +90,11 @@ TEST(LinearView, std_algorithm_generate_n_with_back_inserter) {
   LinearView<Coord::X, Data::Value> view(d);
 
   std::mt19937 rng;
-  std::generate_n(std::back_inserter(view), 5,
-                  [&] { return std::make_tuple(rng(), rng()); });
+  std::generate_n(std::back_inserter(view), 5, [&] {
+    const double v = rng();
+    const double x = rng();
+    return std::make_tuple(x, v);
+  });
 
   ASSERT_EQ(d.get<const Coord::X>().size(), 5);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -1041,3 +1041,19 @@ TEST(Variable, access_typed_view_edges) {
     EXPECT_EQ(values[8 + 2 * z + 1], 5);
   }
 }
+
+TEST(VariableSlice, scalar_operations) {
+  auto var = makeVariable<Data::Value>({{Dim::Y, 2}, {Dim::X, 3}},
+                                       {11, 12, 13, 21, 22, 23});
+
+  var(Dim::X, 0) += 1;
+  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 22, 22, 23}));
+  var(Dim::Y, 1) += 1;
+  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 23, 23, 24}));
+  var(Dim::X, 1, 3) += 1;
+  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 13, 14, 23, 24, 25}));
+  var(Dim::X, 1) -= 1;
+  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 14, 23, 23, 25}));
+  var(Dim::X, 2) *= 0;
+  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 0, 23, 23, 0}));
+}

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -92,6 +92,14 @@ TEST(Variable, operator_unary_minus) {
   EXPECT_EQ(b.get<const Data::Value>()[1], -2.2);
 }
 
+TEST(VariableSlice, unary_minus) {
+  const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  auto b = -a(Dim::X, 1);
+  EXPECT_EQ(a.get<const Data::Value>()[0], 1.1);
+  EXPECT_EQ(a.get<const Data::Value>()[1], 2.2);
+  EXPECT_EQ(b.get<const Data::Value>()[0], -2.2);
+}
+
 TEST(Variable, operator_plus_equal) {
   auto a = makeVariable<Data::Value>({Dim::X, 2}, {1.1, 2.2});
 

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -1042,6 +1042,25 @@ TEST(Variable, access_typed_view_edges) {
   }
 }
 
+TEST(Variable, non_in_place_scalar_operations) {
+  auto var = makeVariable<Data::Value>({{Dim::X, 2}}, {1, 2});
+
+  auto sum = var + 1;
+  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {2, 3}));
+  sum = 2 + var;
+  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 4}));
+
+  auto diff = var - 1;
+  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {0, 1}));
+  diff = 2 - var;
+  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {1, 0}));
+
+  auto prod = var * 2;
+  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {2, 4}));
+  prod = 3 * var;
+  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {3, 6}));
+}
+
 TEST(VariableSlice, scalar_operations) {
   auto var = makeVariable<Data::Value>({{Dim::Y, 2}, {Dim::X, 3}},
                                        {11, 12, 13, 21, 22, 23});


### PR DESCRIPTION
See title.

Also fixing a minor bug in a test that was relying on function argument evaluation order, which lead to a test failure when building with clang.