### PR TITLE
Rename views to better reflect their purpose

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,8 +8,8 @@ target_link_libraries ( variable_benchmark LINK_PRIVATE Dataset benchmark )
 add_executable ( dataset_benchmark dataset_benchmark.cpp )
 target_link_libraries ( dataset_benchmark LINK_PRIVATE Dataset benchmark )
 
-add_executable ( dataset_view_benchmark dataset_view_benchmark.cpp )
-target_link_libraries ( dataset_view_benchmark LINK_PRIVATE Dataset benchmark )
+add_executable ( md_zip_view_benchmark md_zip_view_benchmark.cpp )
+target_link_libraries ( md_zip_view_benchmark LINK_PRIVATE Dataset benchmark )
 
 add_executable ( legacy_histogram_benchmark legacy_histogram_benchmark.cpp )
 target_link_libraries ( legacy_histogram_benchmark LINK_PRIVATE Dataset benchmark )

--- a/doc/design.md
+++ b/doc/design.md
@@ -35,7 +35,7 @@
   - [Variable tags](#design-components-variable-tags)
   - [`class Dimensions`](#design-components-dimensions)
   - [Dimension tags](#design-components-dimension-tags)
-  - [`class DatasetView`](#design-components-datasetview)
+  - [`class MDZipView`](#design-components-md-zip-view)
   - [`class DatasetIndex`](#design-components-datasetindex)
   - [Units](#design-components-units)
   - [Exceptions](#design-components-exceptions)
@@ -495,11 +495,11 @@ An incomplete list of dimension tags:
 In many cases there is a corresponding coordinate tag for a dimension.
 
 
-### <a name="design-components-datasetview"></a>`class DatasetView`
+### <a name="design-components-md-zip-view"></a>`class MDZipView`
 
 Due to the type-erasure we cannot simply treat `Dataset` as an array of structs, i.e., there is no equivalent to `API::MatrixWorkspace::getSpectrum(const size_t index)`.
 If only access to a single variable is required it can be accessed directly.
-For cases that require joint access to multiple variables we provide `class DatasetView`:
+For cases that require joint access to multiple variables we provide `class MDZipView`:
 - Effectively provides a "zip-iterator", with support for automatic on-the-fly broadcast or transposition of dimensions.
 - Nested view allows for accessing a histogram-like view.
 - Allows for joint iteration with bin-edge variables using a `Bin` wrapper, overcoming the old nuisance of having `length+1` bin edges.
@@ -816,7 +816,7 @@ Dataset tempEdges.insertAsEdge<Coord::Temperature>({Dim::Temperature, 6},
 // Empty dataset for accumulation.
 Dataset scan;
 auto dataPoint(combined);
-for (const auto temperature : DatasetView<Bin<Coord::Temperature>>(tempEdges)) {
+for (const auto temperature : MDZipView<Bin<Coord::Temperature>>(tempEdges)) {
   dataPoint.get<Data::Value>("sample - background")[0] =
       exp(-0.001 * temperature.center());
   // Note that concatenate will collapse dimensions of a variable if the
@@ -843,17 +843,17 @@ lambdaSlice.erase<Coord::Polarization>();
 lambdaSlice = slice(lambdaSlice, Dim::Polarization, spin[Spin::Up]) -
               slice(lambdaSlice, Dim::Polarization, spin[Spin::Down]);
 
-// Create a nested DatasetView, for "zip"-style iteration
+// Create a nested MDZipView, for "zip"-style iteration
 // Define an abbreviation for a nested view. For convenience, frequently
 // used variants could be provided as built-ins. Note the `Bin` wrapper,
 // which is used for joint iteration of bin-edge variables and other
 // variables.
-using Histogram = DatasetView<Bin<Coord::Temperature>, const Data::Value,
-                              const Data::StdDev>;
+using Histogram = MDZipView<Bin<Coord::Temperature>, const Data::Value,
+                            const Data::StdDev>;
 // We specify Dim::Temperature when creating the view, indicating that the
 // (outer) view will not iterate that dimension. This implies that it will
 // be the (only) dimension of the nested views.
-DatasetView<Histogram, const Coord::SpectrumNumber>
+MDZipView<Histogram, const Coord::SpectrumNumber>
     view(lambdaSlice, "sample - background", {Dim::Temperature});
 
 for (const auto &tempDependence : view) {
@@ -1148,8 +1148,8 @@ Having a clear and well defined strategy will reduce the risk of confusion.
 
 The go-to tag for storing uncertainties will be `Data::Variance`.
 `Data::StdDev` will exist, but is for *access* only, i.e., attempting to create a `Variable` with that tag should fail.
-Instead `Data::StdDev` can by used in combination with `DatasetView` to *read* the standard deviations if required, e.g., for visualization purposes.
-If it turns out to be useful it would also be possible to provide setters --- as opposed to a simple assignment which is possible if the actual underlying data is referenced --- for standard deviation using `DatasetView` .
+Instead `Data::StdDev` can by used in combination with `MDZipView` to *read* the standard deviations if required, e.g., for visualization purposes.
+If it turns out to be useful it would also be possible to provide setters --- as opposed to a simple assignment which is possible if the actual underlying data is referenced --- for standard deviation using `MDZipView` .
 
 
 ### <a name="design-details-distribution-histogram-distinguised-by-unit"></a>"Distributions" and "histogram data" are distinguished by their unit
@@ -1214,7 +1214,7 @@ If it turns out to be required after all, a callback-based system such as VTK's 
 This has not been supported in `DataObjects::Workspace2D` for 10 years, until a very recent change, i.e., it does not appear to be strictly necessary since it can be solved in other ways (see below).
 Support has been considered and prototyped, however there are two strong reasons it is not part of the final design:
 - Significant complication of implementation for all operations, leading to larger initial development cost and more difficult long-term maintenance.
-- Negatively affects the performance of iteration via `DatasetView`, *even if the length does not vary*.
+- Negatively affects the performance of iteration via `MDZipView`, *even if the length does not vary*.
 
 ##### Alternative solutions and workarounds
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
 
-add_library ( Dataset STATIC dataset.cpp dataset_view.cpp dimensions.cpp unit.cpp variable.cpp except.cpp )
+add_library ( Dataset STATIC dataset.cpp md_zip_view.cpp dimensions.cpp unit.cpp variable.cpp except.cpp )
 target_link_libraries ( Dataset PUBLIC Boost::boost OpenMP::OpenMP_CXX )
 target_include_directories ( Dataset SYSTEM PUBLIC "." ${CMAKE_BINARY_DIR}/gsl-src/include ${CMAKE_BINARY_DIR}/Eigen-src PRIVATE "../range-v3/include" )
 set_target_properties ( Dataset PROPERTIES POSITION_INDEPENDENT_CODE TRUE )

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -681,7 +681,7 @@ Dataset histogram(const Dataset &d, const Variable &coord) {
 }
 
 // We can specialize this to switch to a more efficient variant when sorting
-// datasets that represent events lists, using LinearView.
+// datasets that represent events lists, using ZipView.
 template <class Tag> struct Sort {
   static Dataset apply(const Dataset &d, const std::string &name) {
     auto const_axis = d.get<const Tag>(name);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -539,7 +539,7 @@ Dataset convert(const Dataset &d, const Dim from, const Dim to) {
   // auto converted = convert(dataset, Dim::Spectrum, Dim::TwoTheta);
   // This is a *derived* coordinate, no need to store it explicitly? May even be
   // prevented?
-  // DatasetView<const Coord::TwoTheta>(dataset);
+  // MDZipView<const Coord::TwoTheta>(dataset);
   return d;
 }
 
@@ -608,7 +608,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // currently).
   dataset::expect::equals(events[0](Data::Tof{}).unit(), coord.unit());
 
-  // TODO Can we reuse some code for bin handling from DatasetView?
+  // TODO Can we reuse some code for bin handling from MDZipView?
   const auto binDim = coordDimension[coord.tag().value()];
   const gsl::index nBin = coord.dimensions()[binDim] - 1;
   Dimensions dims = var.dimensions();

--- a/src/tags.h
+++ b/src/tags.h
@@ -343,9 +343,9 @@ template <class Tags> struct element_return_type<Bin<Tags>> {
   using type = DataBin;
 };
 
-template <class... Ts> class DatasetViewImpl;
-template <class... Tags> struct element_return_type<DatasetViewImpl<Tags...>> {
-  using type = DatasetViewImpl<Tags...>;
+template <class... Ts> class MDZipViewImpl;
+template <class... Tags> struct element_return_type<MDZipViewImpl<Tags...>> {
+  using type = MDZipViewImpl<Tags...>;
 };
 
 template <class Tag>

--- a/src/traits.h
+++ b/src/traits.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 class Dataset;
-template <class... Ts> class DatasetViewImpl;
+template <class... Ts> class MDZipViewImpl;
 
 namespace detail {
 template <class T, class Tuple> struct index;
@@ -27,12 +27,12 @@ struct and_<Cond, Conds...>
     : std::conditional<Cond::value, and_<Conds...>, std::false_type>::type {};
 
 // Cannot use std::is_const because we need to handle the special case of a
-// nested DatasetView.
+// nested MDZipView.
 template <class T> struct is_const : std::false_type {};
 template <class T> struct is_const<const T> : std::true_type {};
 
 template <class... Ts>
-struct is_const<DatasetViewImpl<Ts...>> : and_<is_const<Ts>...> {};
+struct is_const<MDZipViewImpl<Ts...>> : and_<is_const<Ts>...> {};
 
 template <class... Tags>
 using MaybeConstDataset =

--- a/src/variable.h
+++ b/src/variable.h
@@ -114,7 +114,7 @@ private:
   std::unique_ptr<T> m_data;
 };
 
-template <class... Tags> class LinearView;
+template <class... Tags> class ZipView;
 class ConstVariableSlice;
 class VariableSlice;
 template <class T1, class T2> T1 &plus_equals(T1 &, const T2 &);
@@ -254,14 +254,14 @@ public:
   // expects the reshaped view to be still valid).
   Variable reshape(const Dimensions &dims) &&;
 
-  template <class... Tags> friend class LinearView;
+  template <class... Tags> friend class ZipView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
 private:
   template <class T> const Vector<T> &cast() const;
   template <class T> Vector<T> &cast();
 
-  // Used by LinearView. Need to find a better way instead of having everyone as
+  // Used by ZipView. Need to find a better way instead of having everyone as
   // friend.
   Dimensions &mutableDimensions() { return m_object.access().m_dimensions; }
 
@@ -477,7 +477,7 @@ public:
 
 private:
   friend class Variable;
-  template <class... Tags> friend class LinearView;
+  template <class... Tags> friend class ZipView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
   // Special version creating const view from mutable view. Note that this does

--- a/src/zip_view.h
+++ b/src/zip_view.h
@@ -3,8 +3,8 @@
 /// @author Simon Heybrock
 /// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 /// National Laboratory, and European Spallation Source ERIC.
-#ifndef LINEAR_VIEW_H
-#define LINEAR_VIEW_H
+#ifndef ZIP_VIEW_H
+#define ZIP_VIEW_H
 
 #include "range/v3/view/zip.hpp"
 
@@ -39,25 +39,24 @@ template <class Tag1, class Tag2> struct AccessHelper<Tag1, Tag2> {
   }
 };
 
-template <class... Tags> class LinearView {
+template <class... Tags> class ZipView {
 public:
   using value_type = std::tuple<typename Tags::type...>;
 
-  LinearView(detail::MaybeConstDataset<Tags...> &dataset) {
+  ZipView(detail::MaybeConstDataset<Tags...> &dataset) {
     // As long as we do not support passing names, duplicate tags are not
     // supported, so this check should be enough.
     if (sizeof...(Tags) != dataset.size())
-      throw std::runtime_error("LinearView must be constructed based on "
+      throw std::runtime_error("ZipView must be constructed based on "
                                "*all* variables in a dataset.");
     // TODO Probably we can also support 0-dimensional variables that are not
     // touched?
     for (const auto &var : dataset)
       if (var.dimensions().count() != 1)
-        throw std::runtime_error("LinearView supports only datasets where "
+        throw std::runtime_error("ZipView supports only datasets where "
                                  "all variables are 1-dimensional.");
     if (dataset.dimensions().count() != 1)
-      throw std::runtime_error(
-          "LinearView supports only 1-dimensional datasets.");
+      throw std::runtime_error("ZipView supports only 1-dimensional datasets.");
 
     m_dimensions = {&dataset(Tags{}).m_mutableVariable->mutableDimensions()...};
     m_data = std::make_tuple(
@@ -86,9 +85,9 @@ private:
 };
 
 template <class... Tags>
-void swap(typename LinearView<Tags...>::Item &a,
-          typename LinearView<Tags...>::Item &b) noexcept {
+void swap(typename ZipView<Tags...>::Item &a,
+          typename ZipView<Tags...>::Item &b) noexcept {
   a.swap(b);
 }
 
-#endif // LINEAR_VIEW_H
+#endif // ZIP_VIEW_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # @author Simon Heybrock
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
-add_executable ( dataset_test tags_test.cpp dataset_test.cpp dataset_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp linear_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp )
+add_executable ( dataset_test tags_test.cpp dataset_test.cpp dataset_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp zip_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp )
 target_link_libraries( dataset_test
   LINK_PRIVATE
   Dataset

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # @author Simon Heybrock
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
-add_executable ( dataset_test tags_test.cpp dataset_test.cpp dataset_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp zip_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp )
+add_executable ( dataset_test tags_test.cpp dataset_test.cpp md_zip_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp zip_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp )
 target_link_libraries( dataset_test
   LINK_PRIVATE
   Dataset

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -10,7 +10,7 @@
 
 #include "test_macros.h"
 
-#include "dataset_view.h"
+#include "md_zip_view.h"
 
 TEST(EventWorkspace, EventList) {
   Dataset e;
@@ -107,8 +107,8 @@ TEST(EventWorkspace, basics) {
   // Note that we could determine the correct X axis automatically, since the
   // event data type/unit imply which coordinate to use, in this case events
   // have type Data::Tof so the axis is Coord::Tof.
-  using Histogram = DatasetView<Bin<Coord::Tof>, Data::Value, Data::Variance>;
-  DatasetView<Histogram, const Data::Events> view(d, {Dim::Tof});
+  using Histogram = MDZipView<Bin<Coord::Tof>, Data::Value, Data::Variance>;
+  MDZipView<Histogram, const Data::Events> view(d, {Dim::Tof});
   for (const auto &item : view) {
     const auto &hist = item.get<Histogram>();
     const auto &events = item.get<Data::Events>();

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -7,7 +7,7 @@
 
 #include "test_macros.h"
 
-#include "dataset_view.h"
+#include "md_zip_view.h"
 
 // Quick and dirty conversion to strings, should probably be part of our library
 // of basic routines.
@@ -33,7 +33,7 @@ TEST(TableWorkspace, basics) {
   table.insert<Data::String>("", {Dim::Row, 3}, 3);
 
   // Modify table with know columns.
-  DatasetView<const Data::Value, Data::String> view(table);
+  MDZipView<const Data::Value, Data::String> view(table);
   for (auto &item : view)
     if (item.value() < 0.0)
       item.get<Data::String>() = "why is this negative?";

--- a/test/example_instrument_test.cpp
+++ b/test/example_instrument_test.cpp
@@ -8,7 +8,7 @@
 #include "test_macros.h"
 
 #include "dataset_index.h"
-#include "dataset_view.h"
+#include "md_zip_view.h"
 
 TEST(ExampleInstrument, basics) {
   gsl::index ndet = 4;
@@ -17,7 +17,7 @@ TEST(ExampleInstrument, basics) {
   detectors.insert<Coord::DetectorId>({Dim::Detector, ndet}, {1, 2, 3, 4});
   detectors.insert<Coord::Position>({Dim::Detector, ndet}, ndet,
                                     Eigen::Vector3d{0.0, 0.0, 2.0});
-  DatasetView<const Coord::DetectorId, Coord::Position> view(detectors);
+  MDZipView<const Coord::DetectorId, Coord::Position> view(detectors);
   for (auto &det : view) {
     det.get<Coord::Position>()[0] = 0.1 * det.get<Coord::DetectorId>();
     EXPECT_EQ(det.get<Coord::Position>()[0],
@@ -27,7 +27,7 @@ TEST(ExampleInstrument, basics) {
   // For const access we need to make sure that the implementation is not
   // attempting to compute derived positions based on detector grouping (which
   // does not exist in this case).
-  DatasetView<const Coord::Position> directConstView(detectors);
+  MDZipView<const Coord::Position> directConstView(detectors);
   // If not implemented correctly this would actually segfault, not throw.
   ASSERT_NO_THROW(directConstView.begin()->get<Coord::Position>());
   EXPECT_EQ(directConstView.begin()->get<Coord::Position>()[0], 0.1);
@@ -45,9 +45,9 @@ TEST(ExampleInstrument, basics) {
   d.insert<Coord::DetectorInfo>({}, {detectors});
   d.insert<Coord::ComponentInfo>({}, {components});
 
-  EXPECT_ANY_THROW(static_cast<void>(DatasetView<Coord::Position>(d)));
-  ASSERT_NO_THROW(static_cast<void>(DatasetView<const Coord::Position>(d)));
-  DatasetView<const Coord::Position> specPos(d);
+  EXPECT_ANY_THROW(static_cast<void>(MDZipView<Coord::Position>(d)));
+  ASSERT_NO_THROW(static_cast<void>(MDZipView<const Coord::Position>(d)));
+  MDZipView<const Coord::Position> specPos(d);
   ASSERT_EQ(specPos.size(), 2);
   EXPECT_DOUBLE_EQ(specPos.begin()->get<Coord::Position>()[0], 0.15);
   EXPECT_DOUBLE_EQ((specPos.begin() + 1)->get<Coord::Position>()[0], 0.35);

--- a/test/zip_view_test.cpp
+++ b/test/zip_view_test.cpp
@@ -11,39 +11,39 @@
 #include "test_macros.h"
 
 #include "dataset.h"
-#include "linear_view.h"
+#include "zip_view.h"
 
-TEST(LinearView, construct_fail) {
+TEST(ZipView, construct_fail) {
   Dataset d;
 
   d.insert<Coord::X>({Dim::X, 3});
   d.insert<Data::Value>("", {Dim::X, 3});
   EXPECT_THROW_MSG(
-      LinearView<Coord::X> view(d), std::runtime_error,
-      "LinearView must be constructed based on *all* variables in a dataset.");
+      ZipView<Coord::X> view(d), std::runtime_error,
+      "ZipView must be constructed based on *all* variables in a dataset.");
   d.erase(Data::Value{});
 
   d.insert<Data::Value>("", {});
-  EXPECT_THROW_MSG((LinearView<Coord::X, Data::Value>(d)), std::runtime_error,
-                   "LinearView supports only datasets where all variables are "
+  EXPECT_THROW_MSG((ZipView<Coord::X, Data::Value>(d)), std::runtime_error,
+                   "ZipView supports only datasets where all variables are "
                    "1-dimensional.");
   d.erase(Data::Value{});
 
   d.insert<Coord::Y>({Dim::Y, 3});
-  EXPECT_THROW_MSG((LinearView<Coord::X, Coord::Y>(d)), std::runtime_error,
-                   "LinearView supports only 1-dimensional datasets.");
+  EXPECT_THROW_MSG((ZipView<Coord::X, Coord::Y>(d)), std::runtime_error,
+                   "ZipView supports only 1-dimensional datasets.");
 }
 
-TEST(LinearView, construct) {
+TEST(ZipView, construct) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 3});
-  EXPECT_NO_THROW(LinearView<Coord::X> view(d));
+  EXPECT_NO_THROW(ZipView<Coord::X> view(d));
 }
 
-TEST(LinearView, push_back_1_variable) {
+TEST(ZipView, push_back_1_variable) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 3});
-  LinearView<Coord::X> view(d);
+  ZipView<Coord::X> view(d);
   view.push_back({1.1});
   ASSERT_EQ(d.get<const Coord::X>().size(), 4);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
@@ -58,11 +58,11 @@ TEST(LinearView, push_back_1_variable) {
   EXPECT_EQ(data[4], 2.2);
 }
 
-TEST(LinearView, push_back_2_variables) {
+TEST(ZipView, push_back_2_variables) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 2});
   d.insert<Data::Value>("", {Dim::X, 2});
-  LinearView<Coord::X, Data::Value> view(d);
+  ZipView<Coord::X, Data::Value> view(d);
   view.push_back({1.1, 1.2});
   ASSERT_EQ(d.get<const Coord::X>().size(), 3);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 3);
@@ -82,12 +82,12 @@ TEST(LinearView, push_back_2_variables) {
   EXPECT_EQ(data[3], 2.3);
 }
 
-TEST(LinearView, std_algorithm_generate_n_with_back_inserter) {
+TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 0});
   d.insert<Data::Value>("", {Dim::X, 0});
 
-  LinearView<Coord::X, Data::Value> view(d);
+  ZipView<Coord::X, Data::Value> view(d);
 
   std::mt19937 rng;
   std::generate_n(std::back_inserter(view), 5,
@@ -110,10 +110,10 @@ TEST(LinearView, std_algorithm_generate_n_with_back_inserter) {
   }
 }
 
-TEST(LinearView, iterator_1_variable) {
+TEST(ZipView, iterator_1_variable) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
-  LinearView<Coord::X> view(d);
+  ZipView<Coord::X> view(d);
   EXPECT_EQ(std::distance(view.begin(), view.end()), 3);
   auto it = view.begin();
   EXPECT_EQ(std::get<0>(*it++), 1.0);
@@ -122,11 +122,11 @@ TEST(LinearView, iterator_1_variable) {
   EXPECT_EQ(it, view.end());
 }
 
-TEST(LinearView, iterator_modify) {
+TEST(ZipView, iterator_modify) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
   d.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  LinearView<Coord::X, Data::Value> view(d);
+  ZipView<Coord::X, Data::Value> view(d);
 
   // Note this peculiarity: `item` is returned by value but it is a proxy
   // object, i.e., it containts references that can be used to modify the
@@ -138,16 +138,16 @@ TEST(LinearView, iterator_modify) {
   EXPECT_TRUE(equals(d.get<const Data::Value>(), {2.2, 4.2, 6.2}));
 }
 
-TEST(LinearView, iterator_copy) {
+TEST(ZipView, iterator_copy) {
   Dataset source;
   source.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
   source.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  LinearView<Coord::X, Data::Value> source_view(source);
+  ZipView<Coord::X, Data::Value> source_view(source);
 
   Dataset d;
   d.insert<Coord::X>({Dim::X, 0});
   d.insert<Data::Value>("", {Dim::X, 0});
-  LinearView<Coord::X, Data::Value> view(d);
+  ZipView<Coord::X, Data::Value> view(d);
 
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
@@ -163,16 +163,16 @@ TEST(LinearView, iterator_copy) {
       equals(d.get<const Data::Value>(), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
 }
 
-TEST(LinearView, iterator_copy_if) {
+TEST(ZipView, iterator_copy_if) {
   Dataset source;
   source.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
   source.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  LinearView<Coord::X, Data::Value> source_view(source);
+  ZipView<Coord::X, Data::Value> source_view(source);
 
   Dataset d;
   d.insert<Coord::X>({Dim::X, 0});
   d.insert<Data::Value>("", {Dim::X, 0});
-  LinearView<Coord::X, Data::Value> view(d);
+  ZipView<Coord::X, Data::Value> view(d);
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
@@ -187,10 +187,10 @@ TEST(LinearView, iterator_copy_if) {
   EXPECT_TRUE(equals(d.get<const Data::Value>(), {2.1, 3.1, 2.1, 3.1}));
 }
 
-TEST(LinearView, iterator_sort) {
+TEST(ZipView, iterator_sort) {
   Dataset d;
   d.insert<Coord::X>({Dim::X, 4}, {3.0, 2.0, 1.0, 0.0});
-  LinearView<Coord::X> view(d);
+  ZipView<Coord::X> view(d);
 
   // Note: Unlike other std algorithms, std::sort does not work with these
   // iterators, must use ranges::sort.


### PR DESCRIPTION
Renamed:

- `LinearView` -> `ZipView` (behaves mostly like Python's `zip`).
- `DatasetView` -> `MDZipView` (like `zip` but also does broadcasting/transposing on-the-fly for variables with mixed dimensionality). This also avoids a confusing near-name-clash with `DatasetSlice`, which is a slice view.

I think code review actually not necessary in this case (since code compiles and tests still pass), this is mostly to inform about the rename.