### PR TITLE
Remove copy on write mechanism from Variable

### DIFF
--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -370,47 +370,25 @@ Operations that combine two different concepts? Matrix-vector multiplication?
 
   // Using default type:
   auto x = dataset.get(Coord::X);
-  auto mutable_x = dataset.getMutable(Coord::X);
   // Custom type if default is not used:
-  // Note that we do not specify const-ness via type since that does not work
-  // for the default type. We need the `get` and `getMutable` accessors.
   auto x = dataset.get<float>(Coord::X);
-  auto x = dataset.getMutable<float>(Coord::X);
   // Tag-less variable:
   auto data = dataset.get<double>("sample1");
-  auto data = dataset.getMutable<double>("sample1");
   // Tagged and named:
   // Can use default type
   auto data = dataset.get(Data::Value, "sample1");
-  auto data = dataset.getMutable(Data::Value, "sample1");
   // Or custom
   auto data = dataset.get<float>(Data::Value, "sample1");
-  auto data = dataset.getMutable<float>(Data::Value, "sample1");
 
   // Accessing Variable:
   auto data = var.get<float>();
-  auto data = var.getMutable<float>();
+  // Globally default to double?
+  auto data = var.get();
   // Use default type (and check tag at same time):
   auto data = var.get(Coord::X);
-  auto data = var.getMutable(Coord::X);
   // Use custom type (and check tag at same time):
   auto data = var.get<float>(Coord::X);
-  auto data = var.getMutable<float>(Coord::X);
-
-  // Should we rely 100% on const-correctness? Would work for variable!
-  auto data = var.get<float>(); // trigger copy if var is not const
-  // What about Dataset, usually only some variables are to be modified?
-  // How can we get a const variable reference without being too verbose.
-  for (auto var : dataset) {
-    const auto &constVar = var;
-    if (constVar.get<float>()[0] == 0.0);
-      // ...
-  }
   ```
-
-
-
-
 
 
 #### Conclusion

--- a/doc/design.md
+++ b/doc/design.md
@@ -246,7 +246,6 @@ The name of data variables is furthermore used to imply a grouping of variables.
 *Example: In a dataset containing data variables `Data::Value` and `Data::Variance` a matching variable name implies that the uncertainties stored in `Data::Variance` are associated with the data stored in `Data::Value`.*
 
 The data in `Variable` is held by a type-erased handle, i.e., a `Variable` can hold data of any type.
-The data handle also implements a copy-on-write mechanism, which makes `Variable` and `Dataset` cheap to copy and saves memory if only some variables in a dataset are modified.
 
 
 ### <a name="overview-operations"></a>Operations
@@ -404,8 +403,6 @@ There are very few methods for direct manipulation of `Dataset`:
 The current implementation in the prototype is mostly complete regarding the actual `Dataset` interface.
 Most other functionality would probably be added as free functions.
 - Some interface cleanup for finding variables or checking for existence of certain tags/names is required.
-- `merge` is currently a member method, but should probably be made a free function.
-  Given the copy-on-write mechanism there is no advantage in having it as a method.
 - Insertion mechanism for bin-edge variables needs to be clarified.
 
 
@@ -1034,6 +1031,10 @@ See also a [working example](../test/Run_test.cpp) that shows automatic matching
 
 ### <a name="design-details-copy-on-write-mechanism"></a>Copy-on-write mechanism
 
+##### Update: Copy-on-write removed during detailed-design evaluation
+
+See [copy-on-write evaluation](design-copy-on-write-evaluation.md).
+
 ##### Context
 
 From a high-level point of view there are two extremes that can be adopted when copying a `dict`-like object like `Dataset`:
@@ -1358,7 +1359,7 @@ We would like to support slicing as in `numpy` and `xarray`, e.g., `array[2:4,10
 In both `numpy` and `xarray` the returned object is a view, i.e., data is not extracted.
 
 The ownership and copying discussion in the section [Copy-on-write mechanism](#design-details-copy-on-write-mechanism) is related to such slice-views and implies:
-- Any iterator obtained from a view is invalidated if any non-`const` method on *any other view* to the same `Variable` is called.
+- Any iterator obtained from a view is invalidated if any non-`const` method on *any other view* to the same `Variable` is called (*Update: The copy-on-write mechanism was removed as part of detailed-design, so this is issue no longer present.*).
   - The view itself can stay valid since it references the variable, not its data.
 - Contrary to the `numpy` behavior, if the owning `Variable` goes out of scope all views should probably become invalid.
   To support views that stay valid we would need to wrap all variables in `Dataset` into a `shared_ptr` and the benefit does not seem to justify this additional complexity at this point.

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,7 +43,7 @@ Dataset tofToEnergy(const Dataset &d) {
   auto physicalConstants =
       boost::units::si::constants::codata::m_n / (2.0 * meV * mus2_to_s2);
 
-  ConstMDZipView<Coord::Position> specPos(d);
+  ConstMDZipView<const Coord::Position> specPos(d);
   const auto factor = [&](const auto &item) {
     const auto &pos = item.template get<Coord::Position>();
     double l_total = l1 + (samplePos - pos).norm();
@@ -79,13 +79,7 @@ Dataset tofToEnergy(const Dataset &d) {
       throw std::runtime_error(
           "TODO Converting units of event data not implemented yet.");
     } else {
-      // TODO Changing Dim::Tof to Dim::Energy. Currently this is not possible
-      // without making a copy of the data, which is inefficient. If we cannot
-      // move the dimensions outside the cow_ptr in Variable, another option
-      // would be to support in-place modification. Probably a better solution
-      // would be to decouple the pointer holding VariableConcept from the COW
-      // mechanism, i.e., to COW inside VariableConcept to hold the data
-      // array?
+      // Changing Dim::Tof to Dim::Energy.
       // TODO Also need to check here if variable contains count/bin_width,
       // should fail then?
       converted.insert(var.reshape(varDims));

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,7 +43,7 @@ Dataset tofToEnergy(const Dataset &d) {
   auto physicalConstants =
       boost::units::si::constants::codata::m_n / (2.0 * meV * mus2_to_s2);
 
-  MDZipView<const Coord::Position> specPos(d);
+  ConstMDZipView<Coord::Position> specPos(d);
   const auto factor = [&](const auto &item) {
     const auto &pos = item.template get<Coord::Position>();
     double l_total = l1 + (samplePos - pos).norm();
@@ -127,7 +127,7 @@ Dataset tofToDeltaE(const Dataset &d) {
                    [&l1](const double Ei) { return l1 / sqrt(Ei); });
 
     scale.setDimensions(dims);
-    MDZipView<const Coord::Position> specPos(d);
+    ConstMDZipView<Coord::Position> specPos(d);
     std::transform(specPos.begin(), specPos.end(),
                    scale.get<Data::Value>().begin(), [&](const auto &item) {
                      const auto &pos = item.template get<Coord::Position>();
@@ -139,7 +139,7 @@ Dataset tofToDeltaE(const Dataset &d) {
 
     tofShift.setDimensions(dims);
     // Ef can be different for every spectrum so we access it also via a view.
-    MDZipView<const Coord::Position, const Coord::Ef> geometry(d);
+    ConstMDZipView<Coord::Position, Coord::Ef> geometry(d);
     std::transform(geometry.begin(), geometry.end(),
                    tofShift.get<Data::Value>().begin(), [&](const auto &item) {
                      const auto &pos = item.template get<Coord::Position>();

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -318,9 +318,9 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
             // view, not a span, i.e., it is less efficient. May need to do this
             // differently for optimal performance.
             auto v1 = var1.template get<Data::Value>();
-            const auto v2 = var2.template get<const Data::Value>();
+            const auto v2 = var2.template get<Data::Value>();
             auto e1 = error1.template get<Data::Variance>();
-            const auto e2 = error2.template get<const Data::Variance>();
+            const auto e2 = error2.template get<Data::Variance>();
             // TODO Need to ensure that data is contiguous!
             aligned::multiply(v1.size(), v1.data(), e1.data(), v2.data(),
                               e2.data());
@@ -636,7 +636,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // TODO Is there are more generic way to find "histogrammable" data, not
   // specific to (neutron) events? Something like Data::ValueVector, i.e., any
   // data variable that contains a vector of values at each point?
-  const auto &events = var.get<const Data::Events>();
+  const auto &events = var.get<Data::Events>();
   // TODO This way of handling events (and their units) as nested Dataset feels
   // a bit unwieldy. Would it be a better option to store TOF (or any derived
   // values) as simple vectors in Data::Events? There would be a separate
@@ -681,7 +681,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   const auto edges = getView<double>(coord, dims);
   auto edge = edges.begin();
   for (const auto &eventList : events) {
-    const auto tofs = eventList.get<const Data::Tof>();
+    const auto tofs = eventList.get<Data::Tof>();
     if (!std::is_sorted(tofs.begin(), tofs.end()))
       throw std::runtime_error(
           "TODO: Histograms can currently only be created from sorted data.");
@@ -723,7 +723,7 @@ Dataset histogram(const Dataset &d, const Variable &coord) {
 // datasets that represent events lists, using ZipView.
 template <class Tag> struct Sort {
   static Dataset apply(const Dataset &d, const std::string &name) {
-    auto const_axis = d.get<const Tag>(name);
+    auto const_axis = d.get<Tag>(name);
     if (d(Tag{}, name).dimensions().count() != 1)
       throw std::runtime_error("Axis for sorting must be 1-dimensional.");
     const auto sortDim = d(Tag{}, name).dimensions().label(0);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -494,18 +494,26 @@ DatasetSlice DatasetSlice::operator*=(const double value) {
   return *this;
 }
 
-Dataset operator+(Dataset a, const Dataset &b) { return a += b; }
-Dataset operator-(Dataset a, const Dataset &b) { return a -= b; }
-Dataset operator*(Dataset a, const Dataset &b) { return a *= b; }
-Dataset operator+(Dataset a, const ConstDatasetSlice &b) { return a += b; }
-Dataset operator-(Dataset a, const ConstDatasetSlice &b) { return a -= b; }
-Dataset operator*(Dataset a, const ConstDatasetSlice &b) { return a *= b; }
-Dataset operator+(Dataset a, const double b) { return a += b; }
-Dataset operator-(Dataset a, const double b) { return a -= b; }
-Dataset operator*(Dataset a, const double b) { return a *= b; }
-Dataset operator+(const double a, Dataset b) { return b += a; }
-Dataset operator-(const double a, Dataset b) { return -(b -= a); }
-Dataset operator*(const double a, Dataset b) { return b *= a; }
+// Note: The std::move here is necessary because RVO does not work for variables
+// that are function parameters.
+Dataset operator+(Dataset a, const Dataset &b) { return std::move(a += b); }
+Dataset operator-(Dataset a, const Dataset &b) { return std::move(a -= b); }
+Dataset operator*(Dataset a, const Dataset &b) { return std::move(a *= b); }
+Dataset operator+(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a += b);
+}
+Dataset operator-(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a -= b);
+}
+Dataset operator*(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a *= b);
+}
+Dataset operator+(Dataset a, const double b) { return std::move(a += b); }
+Dataset operator-(Dataset a, const double b) { return std::move(a -= b); }
+Dataset operator*(Dataset a, const double b) { return std::move(a *= b); }
+Dataset operator+(const double a, Dataset b) { return std::move(b += a); }
+Dataset operator-(const double a, Dataset b) { return std::move(-(b -= a)); }
+Dataset operator*(const double a, Dataset b) { return std::move(b *= a); }
 
 std::vector<Dataset> split(const Dataset &d, const Dim dim,
                            const std::vector<gsl::index> &indices) {

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -69,6 +69,10 @@ std::string to_string(const Tag tag) {
     return "Coord::Y";
   case Coord::Z{}.value():
     return "Coord::Z";
+  case Coord::Position{}.value():
+    return "Coord::Position";
+  case Coord::DetectorGrouping{}.value():
+    return "Coord::DetectorGrouping";
   case Data::Value{}.value():
     return "Data::Value";
   case Data::Variance{}.value():

--- a/src/tags.h
+++ b/src/tags.h
@@ -351,28 +351,29 @@ private:
 
 template <class T> struct Bin { using type = DataBin; };
 
-template <class Tag> struct element_return_type {
+template <class D, class Tag> struct element_return_type {
   using type = std::conditional_t<
       std::is_base_of<detail::ReturnByValuePolicy, Tag>::value,
       typename Tag::type,
       std::conditional_t<
-          std::is_const<Tag>::value,
+          std::is_const<D>::value || std::is_const<Tag>::value,
           std::conditional_t<
               std::is_base_of<detail::ReturnByValueIfConstPolicy, Tag>::value,
               typename Tag::type, const typename Tag::type &>,
           typename Tag::type &>>;
 };
 
-template <class Tags> struct element_return_type<Bin<Tags>> {
+template <class D, class Tags> struct element_return_type<D, Bin<Tags>> {
   using type = DataBin;
 };
 
-template <class... Ts> class MDZipViewImpl;
-template <class... Tags> struct element_return_type<MDZipViewImpl<Tags...>> {
-  using type = MDZipViewImpl<Tags...>;
+template <class D, class... Ts> class MDZipViewImpl;
+template <class D, class... Tags>
+struct element_return_type<D, MDZipViewImpl<D, Tags...>> {
+  using type = MDZipViewImpl<D, Tags...>;
 };
 
-template <class Tag>
-using element_return_type_t = typename element_return_type<Tag>::type;
+template <class D, class Tag>
+using element_return_type_t = typename element_return_type<D, Tag>::type;
 
 #endif // TAGS_H

--- a/src/traits.h
+++ b/src/traits.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 class Dataset;
-template <class... Ts> class MDZipViewImpl;
+template <class D, class... Ts> class MDZipViewImpl;
 
 namespace detail {
 template <class T, class Tuple> struct index;
@@ -31,8 +31,8 @@ struct and_<Cond, Conds...>
 template <class T> struct is_const : std::false_type {};
 template <class T> struct is_const<const T> : std::true_type {};
 
-template <class... Ts>
-struct is_const<MDZipViewImpl<Ts...>> : and_<is_const<Ts>...> {};
+template <class D, class... Ts>
+struct is_const<MDZipViewImpl<D, Ts...>> : and_<is_const<Ts>...> {};
 
 template <class... Tags>
 using MaybeConstDataset =

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -993,20 +993,7 @@ const VariableView<const T> ConstVariableSlice::cast() const {
           dimensions()};
 }
 
-template <class T> VariableView<const T> VariableSlice::cast() const {
-  if (!m_view)
-    return dynamic_cast<const DataModel<Vector<T>> &>(data()).getView(
-        dimensions());
-  if (m_view->isConstView())
-    return {
-        dynamic_cast<const ViewModel<VariableView<const T>> &>(data()).m_model,
-        dimensions()};
-  // Make a const view from the mutable one.
-  return {dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model,
-          dimensions()};
-}
-
-template <class T> VariableView<T> VariableSlice::cast() {
+template <class T> VariableView<T> VariableSlice::cast() const {
   if (m_view)
     return dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model;
   return dynamic_cast<DataModel<Vector<T>> &>(data()).getView(dimensions());
@@ -1015,8 +1002,7 @@ template <class T> VariableView<T> VariableSlice::cast() {
 #define INSTANTIATE_SLICEVIEW(...)                                             \
   template const VariableView<const __VA_ARGS__>                               \
   ConstVariableSlice::cast<__VA_ARGS__>() const;                               \
-  template VariableView<const __VA_ARGS__> VariableSlice::cast() const;        \
-  template VariableView<__VA_ARGS__> VariableSlice::cast();
+  template VariableView<__VA_ARGS__> VariableSlice::cast() const;
 
 INSTANTIATE_SLICEVIEW(double);
 INSTANTIATE_SLICEVIEW(int32_t);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1197,7 +1197,7 @@ Variable filter(const Variable &var, const Variable &filter) {
     throw std::runtime_error(
         "Cannot filter variable: The filter must by 1-dimensional.");
   const auto dim = filter.dimensions().labels()[0];
-  auto mask = filter.get<const Coord::Mask>();
+  auto mask = filter.get<Coord::Mask>();
 
   const gsl::index removed = std::count(mask.begin(), mask.end(), 0);
   if (removed == 0)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -514,11 +514,6 @@ public:
   }
 
   std::unique_ptr<VariableConcept>
-  cloneMutable(VariableConcept &) const override {
-    throw std::runtime_error("DataModel::cloneMutable() should not be called.");
-  }
-
-  std::unique_ptr<VariableConcept>
   clone(const Dimensions &dims) const override {
     return std::make_unique<DataModel<T>>(dims, T(dims.volume()));
   }
@@ -637,14 +632,6 @@ public:
 
   std::unique_ptr<VariableConcept> clone() const override {
     return std::make_unique<ViewModel<T>>(this->dimensions(), m_model);
-  }
-
-  std::unique_ptr<VariableConcept>
-  cloneMutable(VariableConcept &mutableData) const override {
-    auto *data =
-        dynamic_cast<conceptT_t<value_type> &>(mutableData).getSpan().data();
-    return std::make_unique<ViewModel<VariableView<value_type>>>(
-        this->dimensions(), m_model.createMutable(data));
   }
 
   std::unique_ptr<VariableConcept> clone(const Dimensions &) const override {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -883,7 +883,7 @@ Variable &Variable::operator/=(const double value) & {
   return divide_equals(*this, other);
 }
 
-template <class T> VariableSlice VariableSlice::assign(const T &other) {
+template <class T> VariableSlice VariableSlice::assign(const T &other) const {
   // TODO Should mismatching tags be allowed, as long as the type matches?
   if (tag() != other.tag())
     throw std::runtime_error("Cannot assign to slice: Type mismatch.");
@@ -897,52 +897,52 @@ template <class T> VariableSlice VariableSlice::assign(const T &other) {
   return *this;
 }
 
-template VariableSlice VariableSlice::assign(const Variable &);
-template VariableSlice VariableSlice::assign(const ConstVariableSlice &);
+template VariableSlice VariableSlice::assign(const Variable &) const;
+template VariableSlice VariableSlice::assign(const ConstVariableSlice &) const;
 
-VariableSlice VariableSlice::operator+=(const Variable &other) {
+VariableSlice VariableSlice::operator+=(const Variable &other) const {
   return plus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) const {
   return plus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator+=(const double value) {
+VariableSlice VariableSlice::operator+=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return plus_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator-=(const Variable &other) {
+VariableSlice VariableSlice::operator-=(const Variable &other) const {
   return minus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) const {
   return minus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator-=(const double value) {
+VariableSlice VariableSlice::operator-=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return minus_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator*=(const Variable &other) {
+VariableSlice VariableSlice::operator*=(const Variable &other) const {
   return times_equals(*this, other);
 }
-VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) const {
   return times_equals(*this, other);
 }
-VariableSlice VariableSlice::operator*=(const double value) {
+VariableSlice VariableSlice::operator*=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator/=(const Variable &other) {
+VariableSlice VariableSlice::operator/=(const Variable &other) const {
   return divide_equals(*this, other);
 }
-VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) const {
   return divide_equals(*this, other);
 }
-VariableSlice VariableSlice::operator/=(const double value) {
+VariableSlice VariableSlice::operator/=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return divide_equals(*this, other);
@@ -969,7 +969,7 @@ Variable ConstVariableSlice::operator-() const {
   return -copy;
 }
 
-void VariableSlice::setUnit(const Unit &unit) {
+void VariableSlice::setUnit(const Unit &unit) const {
   // TODO Should we forbid setting the unit altogether? I think it is useful in
   // particular since views onto subsets of dataset do not imply slicing of
   // variables but return slice views.

--- a/src/variable.h
+++ b/src/variable.h
@@ -230,13 +230,7 @@ public:
     return gsl::make_span(cast<typename Tag::type>());
   }
 
-  template <class Tag>
-  auto get(std::enable_if_t<std::is_const<Tag>::value> * = nullptr) {
-    return const_cast<const Variable *>(this)->get<Tag>();
-  }
-
-  template <class Tag>
-  auto get(std::enable_if_t<!std::is_const<Tag>::value> * = nullptr) {
+  template <class Tag> auto get() {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return gsl::make_span(cast<typename Tag::type>());
@@ -420,13 +414,7 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class Tag>
-  auto get(std::enable_if_t<std::is_const<Tag>::value> * = nullptr) {
-    return const_cast<const VariableSlice *>(this)->get<Tag>();
-  }
-
-  template <class Tag>
-  auto get(std::enable_if_t<!std::is_const<Tag>::value> * = nullptr) {
+  template <class Tag> auto get() {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();

--- a/src/variable.h
+++ b/src/variable.h
@@ -436,21 +436,21 @@ public:
   // the Python exports to return `a` after calling `a += b` instead of
   // returning `a += b` but I am not sure how Pybind11 handles object lifetimes
   // (would this suffer from the same issue?).
-  template <class T> VariableSlice assign(const T &other);
-  VariableSlice operator+=(const Variable &other);
-  VariableSlice operator+=(const ConstVariableSlice &other);
-  VariableSlice operator+=(const double value);
-  VariableSlice operator-=(const Variable &other);
-  VariableSlice operator-=(const ConstVariableSlice &other);
-  VariableSlice operator-=(const double value);
-  VariableSlice operator*=(const Variable &other);
-  VariableSlice operator*=(const ConstVariableSlice &other);
-  VariableSlice operator*=(const double value);
-  VariableSlice operator/=(const Variable &other);
-  VariableSlice operator/=(const ConstVariableSlice &other);
-  VariableSlice operator/=(const double value);
+  template <class T> VariableSlice assign(const T &other) const;
+  VariableSlice operator+=(const Variable &other) const;
+  VariableSlice operator+=(const ConstVariableSlice &other) const;
+  VariableSlice operator+=(const double value) const;
+  VariableSlice operator-=(const Variable &other) const;
+  VariableSlice operator-=(const ConstVariableSlice &other) const;
+  VariableSlice operator-=(const double value) const;
+  VariableSlice operator*=(const Variable &other) const;
+  VariableSlice operator*=(const ConstVariableSlice &other) const;
+  VariableSlice operator*=(const double value) const;
+  VariableSlice operator/=(const Variable &other) const;
+  VariableSlice operator/=(const ConstVariableSlice &other) const;
+  VariableSlice operator/=(const double value) const;
 
-  void setUnit(const Unit &unit);
+  void setUnit(const Unit &unit) const;
 
 private:
   friend class Variable;

--- a/src/variable.h
+++ b/src/variable.h
@@ -12,7 +12,6 @@
 #include <gsl/gsl_util>
 #include <gsl/span>
 
-#include "cow_ptr.h"
 #include "dimensions.h"
 #include "tags.h"
 #include "unit.h"

--- a/src/variable.h
+++ b/src/variable.h
@@ -416,7 +416,7 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class Tag> auto get() {
+  template <class Tag> auto get() const {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();
@@ -457,10 +457,7 @@ private:
   template <class... Tags> friend class ZipView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
-  // Special version creating const view from mutable view. Note that this does
-  // not return a reference but by value.
-  template <class T> VariableView<const T> cast() const;
-  template <class T> VariableView<T> cast();
+  template <class T> VariableView<T> cast() const;
 
   Variable *m_mutableVariable;
 };

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -18,7 +18,7 @@ TEST(EventWorkspace, EventList) {
   // `size()` gives number of variables, not the number of events in this case!
   // Do we need something like `count()`, returning the volume of the Dataset?
   EXPECT_EQ(e.size(), 1);
-  EXPECT_EQ(e.get<const Data::Tof>().size(), 0);
+  EXPECT_EQ(e.get<Data::Tof>().size(), 0);
 
   // Cannot change size of Dataset easily right now, is that a problem here? Can
   // use concatenate, but there is no `push_back` or similar:
@@ -26,7 +26,7 @@ TEST(EventWorkspace, EventList) {
   e2.insert<Data::Tof>("", {Dim::Event, 3}, {1.1, 2.2, 3.3});
   e = concatenate(e, e2, Dim::Event);
   e = concatenate(e, e2, Dim::Event);
-  EXPECT_EQ(e.get<const Data::Tof>().size(), 6);
+  EXPECT_EQ(e.get<Data::Tof>().size(), 6);
 
   // Can insert pulse times if needed.
   e.insert<Data::PulseTime>("", e(Data::Tof{}).dimensions(),
@@ -39,11 +39,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.first < b.first; });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {1.1, 1.1, 2.2, 2.2, 3.3, 3.3})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({2.0, 1.1, 1.0, 3.0, 2.1, 1.2})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
 
   // Sort by pulse time:
   ranges::sort(
@@ -51,11 +48,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.second < b.second; });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {2.2, 1.1, 3.3, 1.1, 3.3, 2.2})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({1.0, 1.1, 1.2, 2.0, 2.1, 3.0})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 
   // Sort by pulse time then tof:
   ranges::sort(view.begin(), view.end(),
@@ -64,11 +58,8 @@ TEST(EventWorkspace, EventList) {
                  return a.second < b.second && a.first < b.first;
                });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {2.2, 1.1, 3.3, 1.1, 3.3, 2.2})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({1.0, 1.1, 1.2, 2.0, 2.1, 3.0})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 }
 
 TEST(EventWorkspace, basics) {
@@ -146,13 +137,13 @@ TEST(EventWorkspace, plus) {
 
   auto eventLists = sum.get<Data::Events>();
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<const Data::Tof>().size(), 2 * 10);
-  EXPECT_EQ(eventLists[1].get<const Data::Tof>().size(), 2 * 20);
+  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 2 * 10);
+  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 2 * 20);
 
   sum += d;
 
   eventLists = sum.get<Data::Events>();
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<const Data::Tof>().size(), 3 * 10);
-  EXPECT_EQ(eventLists[1].get<const Data::Tof>().size(), 3 * 20);
+  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 3 * 10);
+  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 3 * 20);
 }

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -534,10 +534,6 @@ TEST(Dataset, concatenate) {
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
   EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
-  // Coord::X is shared since it it was the same in x and x2 and is thus
-  // "constant" along Dim::Y in xy.
-  EXPECT_EQ(&x.get<const Coord::X>()[0], &xy.get<const Coord::X>()[0]);
-  EXPECT_NE(&x.get<const Data::Value>()[0], &xy.get<const Data::Value>()[0]);
 
   xy = concatenate(xy, x, Dim::Y);
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
@@ -628,10 +624,6 @@ TEST(Dataset, concatenate_with_attributes) {
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
   EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
-  // Coord::X is shared since it it was the same in x and x2 and is thus
-  // "constant" along Dim::Y in xy.
-  EXPECT_EQ(&x.get<const Coord::X>()[0], &xy.get<const Coord::X>()[0]);
-  EXPECT_NE(&x.get<const Data::Value>()[0], &xy.get<const Data::Value>()[0]);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
   EXPECT_EQ(xy.get<const Attr::ExperimentLog>().size(), 2);
@@ -854,7 +846,8 @@ TEST(Dataset, filter) {
   EXPECT_EQ(filtered.get<const Coord::X>()[1], 0.0);
 
   ASSERT_EQ(filtered.get<const Coord::Y>().size(), 2);
-  ASSERT_EQ(&filtered.get<const Coord::Y>()[0], &d.get<const Coord::Y>()[0]);
+  EXPECT_EQ(filtered.get<const Coord::Y>()[0], 1.0);
+  EXPECT_EQ(filtered.get<const Coord::Y>()[1], 0.9);
 
   ASSERT_EQ(filtered.get<const Data::Value>().size(), 4);
   EXPECT_EQ(filtered.get<const Data::Value>()[0], 2.0);

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -210,7 +210,7 @@ TEST(Dataset, const_get) {
   d.insert<Data::Value>("", Dimensions{}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
   const auto &const_d(d);
-  auto view = const_d.get<const Data::Value>();
+  auto view = const_d.get<Data::Value>();
   // No non-const access to variable if Dataset is const, will not compile:
   // auto &view = const_d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
@@ -234,7 +234,7 @@ TEST(Dataset, get_const) {
   Dataset d;
   d.insert<Data::Value>("", Dimensions{}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
-  auto view = d.get<const Data::Value>();
+  auto view = d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is now deduced to be const, so assignment will not compile:
@@ -465,7 +465,7 @@ TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
   auto sum = std::move(a) + b;
   EXPECT_EQ(&sum.get<Data::Value>()[0], addr);
 
-  const auto *addr2 = &a2.get<const Data::Value>()[0];
+  const auto *addr2 = &a2.get<Data::Value>()[0];
   auto sum2 = a2 + b;
   EXPECT_NE(&sum2.get<Data::Value>()[0], addr2);
 }
@@ -478,28 +478,28 @@ TEST(Dataset, slice) {
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i);
     ASSERT_EQ(sliceX.size(), 1);
-    ASSERT_EQ(sliceX.get<const Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i, i + 1);
     ASSERT_EQ(sliceX.size(), 2);
-    ASSERT_EQ(sliceX.get<const Coord::X>().size(), 1);
-    EXPECT_EQ(sliceX.get<const Coord::X>()[0], 0.1 * i);
-    ASSERT_EQ(sliceX.get<const Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get<Coord::X>().size(), 1);
+    EXPECT_EQ(sliceX.get<Coord::X>()[0], 0.1 * i);
+    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1, 2}) {
     Dataset sliceY = d(Dim::Y, i);
     ASSERT_EQ(sliceY.size(), 2);
-    ASSERT_EQ(sliceY.get<const Coord::X>(), d.get<const Coord::X>());
-    ASSERT_EQ(sliceY.get<const Data::Value>().size(), 2);
-    EXPECT_EQ(sliceY.get<const Data::Value>()[0], 0.0 + 2 * i);
-    EXPECT_EQ(sliceY.get<const Data::Value>()[1], 1.0 + 2 * i);
+    ASSERT_EQ(sliceY.get<Coord::X>(), d.get<Coord::X>());
+    ASSERT_EQ(sliceY.get<Data::Value>().size(), 2);
+    EXPECT_EQ(sliceY.get<Data::Value>()[0], 0.0 + 2 * i);
+    EXPECT_EQ(sliceY.get<Data::Value>()[1], 1.0 + 2 * i);
   }
   EXPECT_THROW_MSG(
       d(Dim::Z, 0), std::runtime_error,
@@ -525,23 +525,23 @@ TEST(Dataset, concatenate) {
   a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<const Data::Value>().size(), 2);
+  EXPECT_EQ(x.get<Coord::X>().size(), 2);
+  EXPECT_EQ(x.get<Data::Value>().size(), 2);
   auto x2(x);
   x2.get<Data::Value>()[0] = 100.0;
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
 
   xy = concatenate(xy, x, Dim::Y);
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 6);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 6);
 
   xy = concatenate(xy, xy, Dim::Y);
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 12);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 12);
 }
 
 TEST(Dataset, concatenate_with_bin_edges) {
@@ -574,8 +574,8 @@ TEST(Dataset, concatenate_with_bin_edges) {
   EXPECT_NO_THROW(merged = concatenate(ds, ds2, Dim::X));
   EXPECT_EQ(merged.dimensions().count(), 1);
   EXPECT_TRUE(merged.dimensions().contains(Dim::X));
-  EXPECT_TRUE(equals(merged.get<const Coord::X>(), {0.1, 0.2, 0.3}));
-  EXPECT_TRUE(equals(merged.get<const Data::Value>(), {2.2, 3.3}));
+  EXPECT_TRUE(equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3}));
+  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 3.3}));
 }
 
 TEST(Dataset, concatenate_with_varying_bin_edges) {
@@ -596,8 +596,8 @@ TEST(Dataset, concatenate_with_varying_bin_edges) {
   EXPECT_EQ(merged.dimensions()[Dim::X], 2);
   EXPECT_EQ(merged.dimensions()[Dim::Y], 2);
   EXPECT_TRUE(
-      equals(merged.get<const Coord::X>(), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
-  EXPECT_TRUE(equals(merged.get<const Data::Value>(), {2.2, 4.4, 3.3, 5.5}));
+      equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
+  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 4.4, 3.3, 5.5}));
 }
 
 TEST(Dataset, concatenate_with_attributes) {
@@ -610,10 +610,10 @@ TEST(Dataset, concatenate_with_attributes) {
 
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<const Data::Value>().size(), 2);
-  EXPECT_EQ(x.get<const Attr::ExperimentLog>().size(), 1);
-  EXPECT_EQ(x.get<const Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(x.get<Coord::X>().size(), 2);
+  EXPECT_EQ(x.get<Data::Value>().size(), 2);
+  EXPECT_EQ(x.get<Attr::ExperimentLog>().size(), 1);
+  EXPECT_EQ(x.get<Attr::ExperimentLog>()[0], logs);
 
   auto x2(x);
   x2.get<Data::Value>()[0] = 100.0;
@@ -622,12 +622,12 @@ TEST(Dataset, concatenate_with_attributes) {
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
-  EXPECT_EQ(xy.get<const Attr::ExperimentLog>().size(), 2);
-  EXPECT_EQ(xy.get<const Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(xy.get<Attr::ExperimentLog>().size(), 2);
+  EXPECT_EQ(xy.get<Attr::ExperimentLog>()[0], logs);
 
   EXPECT_NO_THROW(concatenate(xy, xy, Dim::X));
 
@@ -693,8 +693,8 @@ TEST(Dataset, rebin) {
 
   d.insert<Data::Value>("", {Dim::X, 2}, {10.0, 20.0});
   auto rebinned = rebin(d, coordNew);
-  EXPECT_EQ(rebinned.get<const Data::Value>().size(), 1);
-  EXPECT_EQ(rebinned.get<const Data::Value>()[0], 30.0);
+  EXPECT_EQ(rebinned.get<Data::Value>().size(), 1);
+  EXPECT_EQ(rebinned.get<Data::Value>()[0], 30.0);
 }
 
 Dataset makeEvents() {
@@ -740,8 +740,8 @@ TEST(Dataset, histogram) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 1, 4}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 1, 4}));
 }
 
 TEST(Dataset, histogram_2D_coord) {
@@ -754,8 +754,8 @@ TEST(Dataset, histogram_2D_coord) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, histogram_2D_transpose_coord) {
@@ -772,8 +772,8 @@ TEST(Dataset, histogram_2D_transpose_coord) {
   // dimension will almost be the innermost one.
   ASSERT_EQ(hist(Data::Value{}, "sample1").dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Tof, 2}}));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, sort) {
@@ -784,21 +784,21 @@ TEST(Dataset, sort) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<const Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<const Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
+  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
 
-  ASSERT_EQ(sorted.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(sorted.get<const Data::Value>().size(), 4);
-  EXPECT_EQ(sorted.get<const Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[3], 1.0);
+  ASSERT_EQ(sorted.get<Data::Value>().size(), 4);
+  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
 }
 
 TEST(Dataset, sort_2D) {
@@ -810,25 +810,25 @@ TEST(Dataset, sort_2D) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<const Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<const Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
+  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
 
-  ASSERT_EQ(sorted.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(sorted.get<const Data::Value>().size(), 8);
-  EXPECT_EQ(sorted.get<const Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[3], 1.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[4], 8.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[5], 6.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[6], 7.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[7], 5.0);
+  ASSERT_EQ(sorted.get<Data::Value>().size(), 8);
+  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[4], 8.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[5], 6.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[6], 7.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[7], 5.0);
 }
 
 TEST(Dataset, filter) {
@@ -841,19 +841,19 @@ TEST(Dataset, filter) {
 
   auto filtered = filter(d, select);
 
-  ASSERT_EQ(filtered.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(filtered.get<const Coord::X>()[0], 1.0);
-  EXPECT_EQ(filtered.get<const Coord::X>()[1], 0.0);
+  ASSERT_EQ(filtered.get<Coord::X>().size(), 2);
+  EXPECT_EQ(filtered.get<Coord::X>()[0], 1.0);
+  EXPECT_EQ(filtered.get<Coord::X>()[1], 0.0);
 
-  ASSERT_EQ(filtered.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(filtered.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(filtered.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(filtered.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(filtered.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(filtered.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(filtered.get<const Data::Value>().size(), 4);
-  EXPECT_EQ(filtered.get<const Data::Value>()[0], 2.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[1], 4.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[2], 6.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[3], 8.0);
+  ASSERT_EQ(filtered.get<Data::Value>().size(), 4);
+  EXPECT_EQ(filtered.get<Data::Value>()[0], 2.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[1], 4.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[2], 6.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[3], 8.0);
 }
 
 TEST(Dataset, integrate) {
@@ -867,7 +867,7 @@ TEST(Dataset, integrate) {
   EXPECT_FALSE(integral.contains(Coord::X{}));
   // Note: The current implementation assumes that Data::Value is counts,
   // handling of other data is not implemented yet.
-  EXPECT_TRUE(equals(integral.get<const Data::Value>(), {30.0}));
+  EXPECT_TRUE(equals(integral.get<Data::Value>(), {30.0}));
 }
 
 TEST(DatasetSlice, basics) {
@@ -911,19 +911,19 @@ TEST(DatasetSlice, minus_equals) {
 
   EXPECT_NO_THROW(d -= d["a"]);
 
-  EXPECT_EQ(d.get<const Data::Value>("a")[0], 0.0);
-  EXPECT_EQ(d.get<const Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<const Data::Variance>("a")[0], 2.0);
-  EXPECT_EQ(d.get<const Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Value>("a")[0], 0.0);
+  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Variance>("a")[0], 2.0);
+  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
 
   ASSERT_NO_THROW(d["a"] -= d["b"]);
 
   ASSERT_EQ(d.size(), 6);
   // Note: Variable not renamed when operating with slices.
-  EXPECT_EQ(d.get<const Data::Value>("a")[0], -1.0);
-  EXPECT_EQ(d.get<const Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<const Data::Variance>("a")[0], 3.0);
-  EXPECT_EQ(d.get<const Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Value>("a")[0], -1.0);
+  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Variance>("a")[0], 3.0);
+  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
 }
 
 TEST(DatasetSlice, slice_spatial) {
@@ -974,14 +974,12 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1, 2, 3, 4}));
-  EXPECT_TRUE(equals(d.get<const Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4}));
+  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1024,14 +1022,12 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1, 2, 3, 4, 5}));
-  EXPECT_TRUE(equals(d.get<const Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4, 5}));
+  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   auto view_a_x01 = d["a"](Dim::X, 0, 1);
   auto view_a_x12 = d["a"](Dim::X, 1, 2);
@@ -1039,8 +1035,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 1 so we get 2 edges.
   ASSERT_EQ(view_a_x01.dimensions()[Dim::X], 1);
   ASSERT_EQ(view_a_x01[0].dimensions()[Dim::X], 2);
-  EXPECT_TRUE(equals(view_a_x01[0].get<const Coord::X>(), {1, 2}));
-  EXPECT_TRUE(equals(view_a_x12[0].get<const Coord::X>(), {2, 3}));
+  EXPECT_TRUE(equals(view_a_x01[0].get<Coord::X>(), {1, 2}));
+  EXPECT_TRUE(equals(view_a_x12[0].get<Coord::X>(), {2, 3}));
 
   auto view_a_x02 = d["a"](Dim::X, 0, 2);
   auto view_a_x13 = d["a"](Dim::X, 1, 3);
@@ -1048,8 +1044,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 2 so we get 3 edges.
   ASSERT_EQ(view_a_x02.dimensions()[Dim::X], 2);
   ASSERT_EQ(view_a_x02[0].dimensions()[Dim::X], 3);
-  EXPECT_TRUE(equals(view_a_x02[0].get<const Coord::X>(), {1, 2, 3}));
-  EXPECT_TRUE(equals(view_a_x13[0].get<const Coord::X>(), {2, 3, 4}));
+  EXPECT_TRUE(equals(view_a_x02[0].get<Coord::X>(), {1, 2, 3}));
+  EXPECT_TRUE(equals(view_a_x13[0].get<Coord::X>(), {2, 3, 4}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1088,25 +1084,25 @@ TEST(Dataset, binary_assign_with_scalar) {
   d.insert<Data::Variance>("d2", {}, {6});
 
   d += 1;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {2, 3}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {2, 3}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
 
   d -= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {0, 1}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 1}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
 
   d *= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {0, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {16, 20}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {24}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {16, 20}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {24}));
 }
 
 TEST(DatasetSlice, binary_assign_with_scalar) {
@@ -1120,29 +1116,29 @@ TEST(DatasetSlice, binary_assign_with_scalar) {
   auto slice = d(Dim::X, 1);
 
   slice += 1;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 3}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 3}));
   // TODO This behavior should be reconsidered and probably change: A slice
   // should not include variables that do not have the dimension, otherwise,
   // e.g., looping over slices will apply an operation to that variable more
   // than once.
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
 
   slice -= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
 
   slice *= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 20}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 20}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {24}));
 }
 
 TEST(Dataset, binary_with_scalar) {
@@ -1154,37 +1150,37 @@ TEST(Dataset, binary_with_scalar) {
   d.insert<Data::Variance>("b", {}, {6});
 
   auto sum = d + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {2, 3}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {2, 3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
   sum = 2 + d;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {3, 4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3, 4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
 
   auto diff = d - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {0, 1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0, 1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
   diff = 2 - d;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {1, 0}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1, 0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
 
   auto prod = d * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {2, 4}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {16, 20}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {2, 4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {16, 20}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
   prod = 3 * d;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {3, 6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {36, 45}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {3, 6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {36, 45}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
 }
 
 TEST(DatasetSlice, binary_with_scalar) {
@@ -1201,37 +1197,37 @@ TEST(DatasetSlice, binary_with_scalar) {
   // DatasetSlice to Dataset, so this test is actually testing that conversion,
   // not the binary operation iteself.
   auto sum = slice + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {3}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
   sum = 2 + slice;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
 
   auto diff = slice - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
   diff = 2 - slice;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {0}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
 
   auto prod = slice * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {20}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {20}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
   prod = 3 * slice;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {45}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {45}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
 }
 
 Dataset makeTofDataForUnitConversion() {
@@ -1271,11 +1267,11 @@ TEST(Dataset, convert) {
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 4}}));
   // TODO Check unit.
 
-  const auto values = coord.get<const Coord::Energy>();
+  const auto values = coord.get<Coord::Energy>();
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 437 * sqrt ( E[meV] )
   Variable tof_in_seconds = tof(Coord::Tof{}) * 1e-6;
-  const auto tofs = tof_in_seconds.get<const Coord::Tof>();
+  const auto tofs = tof_in_seconds.get<Coord::Tof>();
   // Spectrum 0 is 11 m from source
   EXPECT_NEAR(values[0], pow((11.0 / tofs[0]) / 437.0, 2), values[0] * 0.01);
   EXPECT_NEAR(values[1], pow((11.0 / tofs[1]) / 437.0, 2), values[1] * 0.01);
@@ -1292,7 +1288,7 @@ TEST(Dataset, convert) {
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
-  EXPECT_TRUE(equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1355,18 +1351,17 @@ TEST(Dataset, convert_direct_inelastic) {
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
-  EXPECT_FALSE(equals(coord.get<const Coord::DeltaE>(),
-                      {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+  EXPECT_FALSE(
+      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position see same deltaE.
-  EXPECT_EQ(coord(Dim::Spectrum, 0).get<const Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<const Coord::DeltaE>()[0]);
+  EXPECT_EQ(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
+            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(
-      equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1409,19 +1404,18 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
-  EXPECT_FALSE(equals(coord.get<const Coord::DeltaE>(),
-                      {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+  EXPECT_FALSE(
+      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position, but now their Ei differs, so deltaE is also
   // different (compare to test for single Ei above).
-  EXPECT_NE(coord(Dim::Spectrum, 0).get<const Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<const Coord::DeltaE>()[0]);
+  EXPECT_NE(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
+            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(
-      equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -31,12 +31,12 @@ TEST(MDZipView, construct_with_const_Dataset) {
   d.insert<Data::Value>("", {Dim::X, 1}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
   const auto const_d(d);
-  EXPECT_NO_THROW(MDZipView<const Data::Value> view(const_d));
+  EXPECT_NO_THROW(ConstMDZipView<Data::Value> view(const_d));
   EXPECT_NO_THROW(
-      MDZipView<MDZipView<const Data::Value>> nested(const_d, {Dim::X}));
-  EXPECT_NO_THROW(static_cast<void>(
-      MDZipView<MDZipView<const Data::Value>, const Data::Int>(const_d,
-                                                               {Dim::X})));
+      ConstMDZipView<ConstMDZipView<Data::Value>> nested(const_d, {Dim::X}));
+  EXPECT_NO_THROW(
+      static_cast<void>(ConstMDZipView<ConstMDZipView<Data::Value>, Data::Int>(
+          const_d, {Dim::X})));
 }
 
 TEST(MDZipView, iterator) {
@@ -568,8 +568,10 @@ TEST(MDZipView, type_sorting_nested) {
   data.insert<Coord::Y>({}, 1);
   MDZipView<Coord::X, MDZipView<Coord::Y>> a(data);
   MDZipView<MDZipView<Coord::Y>, Coord::X> b(data);
-  EXPECT_EQ(typeid(decltype(a)),
-            typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<Coord::Y>>));
+  EXPECT_EQ(
+      typeid(decltype(a)),
+      typeid(
+          MDZipViewImpl<Dataset, Coord::X, MDZipViewImpl<Dataset, Coord::Y>>));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(b)));
 }
 
@@ -583,12 +585,12 @@ TEST(MDZipView, type_sorting_two_nested) {
   MDZipView<MDZipView<Coord::Y, Coord::Z>, Coord::X> c(data);
   MDZipView<MDZipView<Coord::Z, Coord::Y>, Coord::X> d(data);
   EXPECT_EQ(typeid(decltype(a)),
-            typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<Coord::Y, Coord::Z>>));
+            typeid(MDZipViewImpl<Dataset, Coord::X, MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(b)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(c)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(d)));
-  MDZipView<Coord::X, MDZipView<const Coord::Y, Coord::Z>> a_const(data);
-  EXPECT_EQ(
-      typeid(decltype(a_const)),
-      typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<const Coord::Y, Coord::Z>>));
+  MDZipView<Coord::X, MDZipView<Coord::Y, Coord::Z>> a_const(data);
+  EXPECT_EQ(typeid(decltype(a_const)),
+            typeid(MDZipViewImpl<Dataset, Coord::X,
+                                 MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
 }

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -63,26 +63,6 @@ TEST(MDZipView, iterator) {
   ASSERT_EQ(it, view.end());
 }
 
-TEST(MDZipView, copy_on_write) {
-  Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, 2);
-  d.insert<Coord::Y>({Dim::X, 2}, 2);
-  const auto copy(d);
-
-  MDZipView<const Coord::X> const_view(d);
-  EXPECT_EQ(&const_view.begin()->get<Coord::X>(),
-            &copy.get<const Coord::X>()[0]);
-  // Again, just to confirm that the call to `copy.get` is not the reason for
-  // breaking sharing:
-  EXPECT_EQ(&const_view.begin()->get<Coord::X>(),
-            &copy.get<const Coord::X>()[0]);
-
-  MDZipView<Coord::X, const Coord::Y> view(d);
-  EXPECT_NE(&view.begin()->get<Coord::X>(), &copy.get<const Coord::X>()[0]);
-  // Breaks sharing only for the non-const variables:
-  EXPECT_EQ(&view.begin()->get<Coord::Y>(), &copy.get<const Coord::Y>()[0]);
-}
-
 TEST(MDZipView, single_column) {
   Dataset d;
   d.insert<Data::Value>("", Dimensions(Dim::Tof, 10), 10);
@@ -342,57 +322,6 @@ TEST(MDZipView, nested_MDZipView_constant_variable) {
       EXPECT_EQ(subitem.get<Data::Value>(), value);
     }
   }
-}
-
-TEST(MDZipView, nested_MDZipView_copy_on_write) {
-  Dataset d;
-  d.insert<Data::Value>("", Dimensions({{Dim::Y, 2}, {Dim::X, 2}}),
-                        {1.0, 2.0, 3.0, 4.0});
-  d.insert<Coord::X>(Dimensions({{Dim::Y, 2}, {Dim::X, 2}}),
-                     {10.0, 20.0, 30.0, 40.0});
-
-  auto copy(d);
-
-  MDZipView<MDZipView<const Data::Value, const Coord::X>> const_view(copy,
-                                                                     {Dim::X});
-
-  EXPECT_EQ(&d.get<const Data::Value>()[0],
-            &(const_view.begin()
-                  ->get<MDZipView<const Data::Value, const Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_EQ(&d.get<const Coord::X>()[0],
-            &(const_view.begin()
-                  ->get<MDZipView<const Data::Value, const Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
-
-  MDZipView<MDZipView<const Data::Value, Coord::X>> partially_const_view(
-      copy, {Dim::X});
-
-  EXPECT_EQ(&d.get<const Data::Value>()[0],
-            &(partially_const_view.begin()
-                  ->get<MDZipView<const Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_NE(&d.get<const Coord::X>()[0],
-            &(partially_const_view.begin()
-                  ->get<MDZipView<const Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
-
-  MDZipView<MDZipView<Data::Value, Coord::X>> nonconst_view(copy, {Dim::X});
-
-  EXPECT_NE(&d.get<const Data::Value>()[0],
-            &(nonconst_view.begin()
-                  ->get<MDZipView<Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_NE(&d.get<const Coord::X>()[0],
-            &(nonconst_view.begin()
-                  ->get<MDZipView<Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
 }
 
 TEST(MDZipView, histogram_using_nested_MDZipView) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -42,21 +42,13 @@ TEST(Variable, span_references_Variable) {
   EXPECT_EQ(observer[0], 1.0);
 }
 
-TEST(Variable, sharing) {
-  const Variable a1(Data::Value{}, {Dim::Tof, 2});
-  const auto a2(a1);
-  // TODO Should we require the use of `const` with the tag if Variable is
-  // const?
-  EXPECT_EQ(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
-}
-
 TEST(Variable, copy) {
   const Variable a1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
   const auto &data1 = a1.get<const Data::Value>();
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_EQ(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
+  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
   EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<Data::Value>()[0]);
   const auto &data2 = a2.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.1);
@@ -498,52 +490,17 @@ TEST(Variable, mean) {
 
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
   ConstVariableSlice view(var);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
+  EXPECT_EQ(var.get<const Coord::X>().data(),
             view.get<const Coord::X>().data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
   Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
   VariableSlice view(var);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
+  EXPECT_EQ(var.get<const Coord::X>().data(),
             view.get<const Coord::X>().data());
-  EXPECT_NE(copy.get<const Coord::X>().data(), view.get<Coord::X>().data());
-}
-
-TEST(VariableSlice,
-     copy_on_write_variable_from_full_view_shares_original_data) {
-  const Variable var(Coord::X{}, {{Dim::X, 3}});
-  ConstVariableSlice view(var);
-  Variable copy(view);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            var.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_const_view) {
-  const Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_mutable_view) {
-  Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_nested_mutable_view) {
-  Variable var(Coord::X{}, {{Dim::Y, 3}, {Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0)(Dim::Y, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
+  EXPECT_EQ(var.get<const Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, strides) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -16,7 +16,7 @@ TEST(Variable, construct) {
   ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2)));
   ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2), 2));
   const Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  const auto &data = a.get<const Data::Value>();
+  const auto &data = a.get<Data::Value>();
   EXPECT_EQ(data.size(), 2);
 }
 
@@ -28,7 +28,7 @@ TEST(Variable, construct_fail) {
 
 TEST(Variable, span_references_Variable) {
   Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  auto observer = a.get<const Data::Value>();
+  auto observer = a.get<Data::Value>();
   // This line does not compile, const-correctness works:
   // observer[0] = 1.0;
 
@@ -44,12 +44,12 @@ TEST(Variable, span_references_Variable) {
 
 TEST(Variable, copy) {
   const Variable a1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
-  const auto &data1 = a1.get<const Data::Value>();
+  const auto &data1 = a1.get<Data::Value>();
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
-  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<Data::Value>()[0]);
+  EXPECT_NE(&a1.get<Data::Value>()[0], &a2.get<Data::Value>()[0]);
+  EXPECT_NE(&a1.get<Data::Value>()[0], &a2.get<Data::Value>()[0]);
   const auto &data2 = a2.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.1);
   EXPECT_EQ(data2[1], 2.2);
@@ -78,18 +78,18 @@ TEST(Variable, operator_equals) {
 TEST(Variable, operator_unary_minus) {
   const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a;
-  EXPECT_EQ(a.get<const Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<const Data::Value>()[1], 2.2);
-  EXPECT_EQ(b.get<const Data::Value>()[0], -1.1);
-  EXPECT_EQ(b.get<const Data::Value>()[1], -2.2);
+  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
+  EXPECT_EQ(a.get<Data::Value>()[1], 2.2);
+  EXPECT_EQ(b.get<Data::Value>()[0], -1.1);
+  EXPECT_EQ(b.get<Data::Value>()[1], -2.2);
 }
 
 TEST(VariableSlice, unary_minus) {
   const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a(Dim::X, 1);
-  EXPECT_EQ(a.get<const Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<const Data::Value>()[1], 2.2);
-  EXPECT_EQ(b.get<const Data::Value>()[0], -2.2);
+  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
+  EXPECT_EQ(a.get<Data::Value>()[1], 2.2);
+  EXPECT_EQ(b.get<Data::Value>()[0], -2.2);
 }
 
 TEST(Variable, operator_plus_equal) {
@@ -265,18 +265,18 @@ TEST(Variable, slice) {
     Variable sliceX = parent(Dim::X, index);
     ASSERT_EQ(sliceX.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::Y, 2}}));
     auto base = static_cast<double>(index);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], base + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], base + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], base + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], base + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], base + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], base + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], base + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], base + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], base + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], base + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], base + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], base + 21.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index);
     ASSERT_EQ(sliceY.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::X, 4}}));
-    const auto &data = sliceY.get<const Data::Value>();
+    const auto &data = sliceY.get<Data::Value>();
     auto base = static_cast<double>(index);
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * base + 8 * static_cast<double>(z) + 1.0);
@@ -289,7 +289,7 @@ TEST(Variable, slice) {
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceZ = parent(Dim::Z, index);
     ASSERT_EQ(sliceZ.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -306,37 +306,37 @@ TEST(Variable, slice_range) {
     Variable sliceX = parent(Dim::X, index, index + 1);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], index + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], index + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], index + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], index + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], index + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], index + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], index + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], index + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], index + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], index + 21.0);
   }
 
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceX = parent(Dim::X, index, index + 2);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], index + 2.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], index + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], index + 6.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], index + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], index + 10.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[6], index + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[7], index + 14.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[8], index + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[9], index + 18.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[10], index + 21.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[11], index + 22.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], index + 2.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], index + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], index + 6.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], index + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], index + 10.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[6], index + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[7], index + 14.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[8], index + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[9], index + 18.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[10], index + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[11], index + 22.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index, index + 1);
     ASSERT_EQ(sliceY.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
-    const auto &data = sliceY.get<const Data::Value>();
+    const auto &data = sliceY.get<Data::Value>();
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * index + 8 * z + 1.0);
       EXPECT_EQ(data[4 * z + 1], 4 * index + 8 * z + 2.0);
@@ -354,7 +354,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 1);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -363,7 +363,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 2);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
     for (gsl::index xy = 0; xy < 8; ++xy)
@@ -387,14 +387,14 @@ TEST(Variable, concatenate) {
   const auto abba = concatenate(ab, ba, Dim::Q);
   ASSERT_EQ(abba.size(), 4);
   EXPECT_EQ(abba.dimensions().count(), 2);
-  const auto &data2 = abba.get<const Data::Value>();
+  const auto &data2 = abba.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.0);
   EXPECT_EQ(data2[1], 2.0);
   EXPECT_EQ(data2[2], 2.0);
   EXPECT_EQ(data2[3], 1.0);
   const auto ababbaba = concatenate(abba, abba, Dim::Tof);
   ASSERT_EQ(ababbaba.size(), 8);
-  const auto &data3 = ababbaba.get<const Data::Value>();
+  const auto &data3 = ababbaba.get<Data::Value>();
   EXPECT_EQ(data3[0], 1.0);
   EXPECT_EQ(data3[1], 2.0);
   EXPECT_EQ(data3[2], 1.0);
@@ -405,7 +405,7 @@ TEST(Variable, concatenate) {
   EXPECT_EQ(data3[7], 1.0);
   const auto abbaabba = concatenate(abba, abba, Dim::Q);
   ASSERT_EQ(abbaabba.size(), 8);
-  const auto &data4 = abbaabba.get<const Data::Value>();
+  const auto &data4 = abbaabba.get<Data::Value>();
   EXPECT_EQ(data4[0], 1.0);
   EXPECT_EQ(data4[1], 2.0);
   EXPECT_EQ(data4[2], 2.0);
@@ -464,43 +464,41 @@ TEST(Variable, rebin) {
   auto rebinned = rebin(var, oldEdge, newEdge);
   ASSERT_EQ(rebinned.dimensions().count(), 1);
   ASSERT_EQ(rebinned.dimensions().volume(), 1);
-  ASSERT_EQ(rebinned.get<const Data::Value>().size(), 1);
-  EXPECT_EQ(rebinned.get<const Data::Value>()[0], 3.0);
+  ASSERT_EQ(rebinned.get<Data::Value>().size(), 1);
+  EXPECT_EQ(rebinned.get<Data::Value>()[0], 3.0);
 }
 
 TEST(Variable, sum) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto sumX = sum(var, Dim::X);
   ASSERT_EQ(sumX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(sumX.get<const Data::Value>(), {3.0, 7.0}));
+  EXPECT_TRUE(equals(sumX.get<Data::Value>(), {3.0, 7.0}));
   auto sumY = sum(var, Dim::Y);
   ASSERT_EQ(sumY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(sumY.get<const Data::Value>(), {4.0, 6.0}));
+  EXPECT_TRUE(equals(sumY.get<Data::Value>(), {4.0, 6.0}));
 }
 
 TEST(Variable, mean) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto meanX = mean(var, Dim::X);
   ASSERT_EQ(meanX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(meanX.get<const Data::Value>(), {1.5, 3.5}));
+  EXPECT_TRUE(equals(meanX.get<Data::Value>(), {1.5, 3.5}));
   auto meanY = mean(var, Dim::Y);
   ASSERT_EQ(meanY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(meanY.get<const Data::Value>(), {2.0, 3.0}));
+  EXPECT_TRUE(equals(meanY.get<Data::Value>(), {2.0, 3.0}));
 }
 
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X{}, {{Dim::X, 3}});
   ConstVariableSlice view(var);
-  EXPECT_EQ(var.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
   Variable var(Coord::X{}, {{Dim::X, 3}});
   VariableSlice view(var);
-  EXPECT_EQ(var.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-  EXPECT_EQ(var.get<const Coord::X>().data(), view.get<Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, strides) {
@@ -528,7 +526,7 @@ TEST(VariableSlice, strides) {
 
 TEST(VariableSlice, get) {
   const Variable var(Data::Value{}, {Dim::X, 3}, {1, 2, 3});
-  EXPECT_EQ(var(Dim::X, 1, 2).get<const Data::Value>()[0], 2.0);
+  EXPECT_EQ(var(Dim::X, 1, 2).get<Data::Value>()[0], 2.0);
 }
 
 TEST(VariableSlice, slicing_does_not_transpose) {
@@ -550,7 +548,7 @@ TEST(VariableSlice, self_overlapping_view_operation) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var -= var(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   // This is the critical part: After subtracting for y=0 the view points to
@@ -565,7 +563,7 @@ TEST(VariableSlice, minus_equals_slice_const_outer) {
   const auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -582,7 +580,7 @@ TEST(VariableSlice, minus_equals_slice_outer) {
   auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -599,7 +597,7 @@ TEST(VariableSlice, minus_equals_slice_inner) {
   auto copy(var);
 
   var -= copy(Dim::X, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 1.0);
   EXPECT_EQ(data[2], 0.0);
@@ -616,7 +614,7 @@ TEST(VariableSlice, minus_equals_slice_of_slice) {
   auto copy(var);
 
   var -= copy(Dim::X, 1)(Dim::Y, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -629,7 +627,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 0, 2);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], -21.0);
@@ -638,7 +636,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 0, 2);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -12.0);
     EXPECT_EQ(data[1], -13.0);
     EXPECT_EQ(data[2], -22.0);
@@ -647,7 +645,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -21.0);
     EXPECT_EQ(data[1], -22.0);
     EXPECT_EQ(data[2], -31.0);
@@ -656,7 +654,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -22.0);
     EXPECT_EQ(data[1], -23.0);
     EXPECT_EQ(data[2], -32.0);
@@ -668,7 +666,7 @@ TEST(VariableSlice, slice_inner_minus_equals) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::X, 0) -= var(Dim::X, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -1.0);
   EXPECT_EQ(data[1], 2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -679,7 +677,7 @@ TEST(VariableSlice, slice_outer_minus_equals) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::Y, 0) -= var(Dim::Y, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], 3.0);
@@ -692,7 +690,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -708,7 +706,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -724,7 +722,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -740,7 +738,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -759,7 +757,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -775,7 +773,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -791,7 +789,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -807,7 +805,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -828,7 +826,7 @@ TEST(VariableSlice, slice_minus_lower_dimensional) {
 
   target(Dim::Y, 1, 2) -= source;
 
-  const auto data = target.get<const Data::Value>();
+  const auto data = target.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], -1.0);
@@ -841,19 +839,19 @@ TEST(VariableSlice, variable_copy_from_slice) {
 
   Variable target1(source(Dim::X, 0, 2)(Dim::Y, 0, 2));
   EXPECT_EQ(target1.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target1.get<const Data::Value>(), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target1.get<Data::Value>(), {11, 12, 21, 22}));
 
   Variable target2(source(Dim::X, 1, 3)(Dim::Y, 0, 2));
   EXPECT_EQ(target2.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target2.get<const Data::Value>(), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target2.get<Data::Value>(), {12, 13, 22, 23}));
 
   Variable target3(source(Dim::X, 0, 2)(Dim::Y, 1, 3));
   EXPECT_EQ(target3.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target3.get<const Data::Value>(), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target3.get<Data::Value>(), {21, 22, 31, 32}));
 
   Variable target4(source(Dim::X, 1, 3)(Dim::Y, 1, 3));
   EXPECT_EQ(target4.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target4.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target4.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_assign_from_slice) {
@@ -863,19 +861,19 @@ TEST(VariableSlice, variable_assign_from_slice) {
 
   target = source(Dim::X, 0, 2)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {11, 12, 21, 22}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {12, 13, 22, 23}));
 
   target = source(Dim::X, 0, 2)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {21, 22, 31, 32}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_self_assign_via_slice) {
@@ -886,7 +884,7 @@ TEST(VariableSlice, variable_self_assign_via_slice) {
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, slice_assign_from_variable) {
@@ -899,29 +897,29 @@ TEST(VariableSlice, slice_assign_from_variable) {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {11, 12, 0, 21, 22, 0, 0, 0, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 11, 12, 0, 21, 22, 0, 0, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 0, 0, 11, 12, 0, 21, 22, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 0, 0, 0, 11, 12, 0, 21, 22}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
   }
 }
 
@@ -935,10 +933,10 @@ TEST(VariableSlice, slice_binary_operations) {
   auto difference = v(Dim::X, 0) - v(Dim::X, 1);
   auto product = v(Dim::X, 0) * v(Dim::X, 1);
   auto ratio = v(Dim::X, 0) / v(Dim::X, 1);
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 7}));
-  EXPECT_TRUE(equals(difference.get<const Data::Value>(), {-1, -1}));
-  EXPECT_TRUE(equals(product.get<const Data::Value>(), {2, 12}));
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {1.0 / 2.0, 3.0 / 4.0}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {3, 7}));
+  EXPECT_TRUE(equals(difference.get<Data::Value>(), {-1, -1}));
+  EXPECT_TRUE(equals(product.get<Data::Value>(), {2, 12}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {1.0 / 2.0, 3.0 / 4.0}));
 }
 
 TEST(Variable, reshape) {
@@ -947,12 +945,12 @@ TEST(Variable, reshape) {
   auto view = var.reshape({Dim::Row, 6});
   ASSERT_EQ(view.size(), 6);
   ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
-  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 
   auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
   ASSERT_EQ(view2.size(), 6);
   ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view2.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, reshape_temporary) {
@@ -961,7 +959,7 @@ TEST(Variable, reshape_temporary) {
   auto reshaped = sum(var, Dim::X).reshape({{Dim::Y, 2}, {Dim::Z, 2}});
   ASSERT_EQ(reshaped.size(), 4);
   ASSERT_EQ(reshaped.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(reshaped.get<const Data::Value>(), {6, 8, 10, 12}));
+  EXPECT_TRUE(equals(reshaped.get<Data::Value>(), {6, 8, 10, 12}));
 
   // This is not a temporary, we get a view into `var`.
   EXPECT_EQ(typeid(decltype(std::move(var).reshape({}))),
@@ -980,7 +978,7 @@ TEST(Variable, reshape_and_slice) {
 
   auto slice =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
-  EXPECT_TRUE(equals(slice.get<const Data::Value>(), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(slice.get<Data::Value>(), {6, 7, 10, 11}));
 
   Variable center =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
@@ -988,7 +986,7 @@ TEST(Variable, reshape_and_slice) {
 
   ASSERT_EQ(center.size(), 4);
   ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
-  EXPECT_TRUE(equals(center.get<const Data::Value>(), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(center.get<Data::Value>(), {6, 7, 10, 11}));
 }
 
 TEST(Variable, reshape_mutable) {
@@ -998,9 +996,9 @@ TEST(Variable, reshape_mutable) {
   auto view = var.reshape({Dim::Row, 6});
   view.get<Data::Value>()[3] = 0;
 
-  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(copy.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get<Data::Value>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(copy.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, access_typed_view) {
@@ -1043,24 +1041,24 @@ TEST(Variable, non_in_place_scalar_operations) {
   Variable var(Data::Value{}, {{Dim::X, 2}}, {1, 2});
 
   auto sum = var + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {2, 3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {2, 3}));
   sum = 2 + var;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {3, 4}));
 
   auto diff = var - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {0, 1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>(), {0, 1}));
   diff = 2 - var;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {1, 0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>(), {1, 0}));
 
   auto prod = var * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {2, 4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>(), {2, 4}));
   prod = 3 * var;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {3, 6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>(), {3, 6}));
 
   auto ratio = var / 2;
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {1.0 / 2.0, 1.0}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {1.0 / 2.0, 1.0}));
   ratio = 3 / var;
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {3.0, 1.5}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {3.0, 1.5}));
 }
 
 TEST(VariableSlice, scalar_operations) {
@@ -1068,15 +1066,15 @@ TEST(VariableSlice, scalar_operations) {
                {11, 12, 13, 21, 22, 23});
 
   var(Dim::X, 0) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 22, 22, 23}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 13, 22, 22, 23}));
   var(Dim::Y, 1) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 23, 23, 24}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 13, 23, 23, 24}));
   var(Dim::X, 1, 3) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 13, 14, 23, 24, 25}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 13, 14, 23, 24, 25}));
   var(Dim::X, 1) -= 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 14, 23, 23, 25}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 14, 23, 23, 25}));
   var(Dim::X, 2) *= 0;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 0, 23, 23, 0}));
   var(Dim::Y, 0) /= 2;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {6, 6, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {6, 6, 0, 23, 23, 0}));
 }


### PR DESCRIPTION
Based on the evaluation in https://github.com/mantidproject/dataset/pull/19, this PR removes the copy-on-write mechanism from `Variable`.

Notes:
- `MDZipView` does still require the `const` qualified tags (not in all cases). This is because it is not just necessary for the copy-on-write, but mainly to handle iteration of variables that have fewer dimensions: Access the lower-dimensional objects can only be `const`, otherwise we risk conflicting writes or repeated processing of the same item.