### PR TITLE
Decouple dtype from tags

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -417,7 +417,7 @@ static void BM_Dataset_EventWorkspace_plus(benchmark::State &state) {
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : d.get<const Data::Events>())
+  for (auto &eventList : d.get<Data::Events>())
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations());
   // 2 for Tof and PulseTime
@@ -443,7 +443,7 @@ static void BM_Dataset_EventWorkspace_grow(benchmark::State &state) {
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : update.get<const Data::Events>())
+  for (auto &eventList : update.get<Data::Events>())
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations() * actualEvents);
 }

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -15,8 +15,8 @@
 static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
   Dataset d;
   for (int i = 0; i < state.range(0); ++i)
-    d.insert<Data::Value>("name" + std::to_string(i), Dimensions{}, 1);
-  d.insert<Data::Int>("name", Dimensions{}, 1);
+    d.insert(Data::Value{}, "name" + std::to_string(i), Dimensions{}, 1);
+  d.insert(Data::Int{}, "name", Dimensions{}, 1);
   for (auto _ : state)
     d.get<Data::Int>();
   state.SetItemsProcessed(state.iterations());
@@ -30,9 +30,9 @@ BENCHMARK(BM_Dataset_get_with_many_columns)
 static void BM_Dataset_as_Histogram(benchmark::State &state) {
   gsl::index nPoint = state.range(0);
   Dataset d;
-  d.insert<Coord::Tof>({Dim::Tof, nPoint}, nPoint);
-  d.insert<Data::Value>("", {Dim::Tof, nPoint}, nPoint);
-  d.insert<Data::Variance>("", {Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Value{}, "", {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Variance{}, "", {Dim::Tof, nPoint}, nPoint);
   std::vector<Dataset> histograms;
   gsl::index nSpec = std::min(1000000l, 10000000 / (nPoint + 1));
   for (gsl::index i = 0; i < nSpec; ++i) {
@@ -56,11 +56,11 @@ BENCHMARK(BM_Dataset_as_Histogram)->RangeMultiplier(2)->Range(0, 2 << 14);
 
 static void BM_Dataset_as_Histogram_with_slice(benchmark::State &state) {
   Dataset d;
-  d.insert<Coord::Tof>({Dim::Tof, 1000}, 1000);
+  d.insert(Coord::Tof{}, {Dim::Tof, 1000}, 1000);
   gsl::index nSpec = 10000;
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, nSpec}});
-  d.insert<Data::Value>("sample", dims, dims.volume());
-  d.insert<Data::Variance>("sample", dims, dims.volume());
+  d.insert(Data::Value{}, "sample", dims, dims.volume());
+  d.insert(Data::Variance{}, "sample", dims, dims.volume());
 
   for (auto _ : state) {
     auto sum = d(Dim::Spectrum, 0);
@@ -76,15 +76,15 @@ BENCHMARK(BM_Dataset_as_Histogram_with_slice);
 Dataset makeSingleDataDataset(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
 
-  d.insert<Coord::DetectorId>({Dim::Detector, nSpec}, nSpec);
-  d.insert<Coord::Position>({Dim::Detector, nSpec}, nSpec);
-  d.insert<Coord::DetectorGrouping>({Dim::Spectrum, nSpec}, nSpec);
-  d.insert<Coord::SpectrumNumber>({Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::DetectorId{}, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position{}, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec}, nSpec);
 
-  d.insert<Coord::Tof>({Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert<Data::Value>("sample", dims, dims.volume());
-  d.insert<Data::Variance>("sample", dims, dims.volume());
+  d.insert(Data::Value{}, "sample", dims, dims.volume());
+  d.insert(Data::Variance{}, "sample", dims, dims.volume());
 
   return d;
 }
@@ -92,17 +92,17 @@ Dataset makeSingleDataDataset(const gsl::index nSpec, const gsl::index nPoint) {
 Dataset makeDataset(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
 
-  d.insert<Coord::DetectorId>({Dim::Detector, nSpec}, nSpec);
-  d.insert<Coord::Position>({Dim::Detector, nSpec}, nSpec);
-  d.insert<Coord::DetectorGrouping>({Dim::Spectrum, nSpec}, nSpec);
-  d.insert<Coord::SpectrumNumber>({Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::DetectorId{}, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position{}, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec}, nSpec);
 
-  d.insert<Coord::Tof>({Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert<Data::Value>("sample", dims, dims.volume());
-  d.insert<Data::Variance>("sample", dims, dims.volume());
-  d.insert<Data::Value>("background", dims, dims.volume());
-  d.insert<Data::Variance>("background", dims, dims.volume());
+  d.insert(Data::Value{}, "sample", dims, dims.volume());
+  d.insert(Data::Variance{}, "sample", dims, dims.volume());
+  d.insert(Data::Value{}, "background", dims, dims.volume());
+  d.insert(Data::Variance{}, "background", dims, dims.volume());
 
   return d;
 }
@@ -238,15 +238,15 @@ Dataset makeBeamline(const gsl::index nDet) {
   // would be higher.
   Dataset dets;
 
-  dets.insert<Coord::DetectorId>({Dim::Detector, nDet});
-  dets.insert<Coord::Mask>({Dim::Detector, nDet});
-  dets.insert<Coord::Position>({Dim::Detector, nDet});
+  dets.insert(Coord::DetectorId{}, {Dim::Detector, nDet});
+  dets.insert(Coord::Mask{}, {Dim::Detector, nDet});
+  dets.insert(Coord::Position{}, {Dim::Detector, nDet});
   auto ids = dets.get<Coord::DetectorId>();
   std::iota(ids.begin(), ids.end(), 1);
 
   Dataset d;
-  d.insert<Coord::DetectorInfo>({}, {dets});
-  d.insert<Attr::ExperimentLog>("NeXus logs", {});
+  d.insert(Coord::DetectorInfo{}, {}, {dets});
+  d.insert(Attr::ExperimentLog{}, "NeXus logs", {});
 
   return d;
 }
@@ -254,8 +254,8 @@ Dataset makeBeamline(const gsl::index nDet) {
 Dataset makeSpectra(const gsl::index nSpec) {
   Dataset d;
 
-  d.insert<Coord::DetectorGrouping>({Dim::Spectrum, nSpec});
-  d.insert<Coord::SpectrumNumber>({Dim::Spectrum, nSpec});
+  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec});
+  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec});
   auto groups = d.get<Coord::DetectorGrouping>();
   for (gsl::index i = 0; i < groups.size(); ++i)
     groups[i] = {i};
@@ -267,12 +267,12 @@ Dataset makeSpectra(const gsl::index nSpec) {
 
 Dataset makeData(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
-  d.insert<Coord::Tof>({Dim::Tof, nPoint + 1});
+  d.insert(Coord::Tof{}, {Dim::Tof, nPoint + 1});
   auto tofs = d.get<Coord::Tof>();
   std::iota(tofs.begin(), tofs.end(), 0.0);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert<Data::Value>("sample", dims);
-  d.insert<Data::Variance>("sample", dims);
+  d.insert(Data::Value{}, "sample", dims);
+  d.insert(Data::Variance{}, "sample", dims);
   return d;
 }
 
@@ -349,23 +349,23 @@ Dataset makeEventWorkspace(const gsl::index nSpec, const gsl::index nEvent) {
   auto d = makeBeamline(nSpec);
   d.merge(makeSpectra(nSpec));
 
-  d.insert<Coord::Tof>({Dim::Tof, 2});
+  d.insert(Coord::Tof{}, {Dim::Tof, 2});
 
-  d.insert<Data::Events>("events", {Dim::Spectrum, nSpec});
+  d.insert(Data::Events{}, "events", {Dim::Spectrum, nSpec});
   std::random_device rd;
   std::mt19937 mt(rd());
   std::uniform_int_distribution<int> dist(0, nEvent);
   Dataset empty;
-  empty.insert<Data::Tof>("", {Dim::Event, 0});
-  empty.insert<Data::PulseTime>("", {Dim::Event, 0});
+  empty.insert(Data::Tof{}, "", {Dim::Event, 0});
+  empty.insert(Data::PulseTime{}, "", {Dim::Event, 0});
   for (auto &eventList : d.get<Data::Events>()) {
     // 1/4 of the event lists is empty
     gsl::index count = std::max(0l, dist(mt) - nEvent / 4);
     if (count == 0)
       eventList = empty;
     else {
-      eventList.insert<Data::Tof>("", {Dim::Event, count});
-      eventList.insert<Data::PulseTime>("", {Dim::Event, count});
+      eventList.insert(Data::Tof{}, "", {Dim::Event, count});
+      eventList.insert(Data::PulseTime{}, "", {Dim::Event, count});
     }
   }
 

--- a/benchmark/md_zip_view_benchmark.cpp
+++ b/benchmark/md_zip_view_benchmark.cpp
@@ -58,9 +58,9 @@ static void BM_MDZipView_multi_column_mixed_dimension(benchmark::State &state) {
   Dataset d;
   Dimensions dims;
   dims.add(Dim::Spectrum, state.range(0));
-  d.insert<Data::Int>("specnums", dims, state.range(0));
+  d.insert(Data::Int{}, "specnums", dims, state.range(0));
   dims.add(Dim::Tof, 1000);
-  d.insert<Data::Value>("histograms", dims, state.range(0) * 1000);
+  d.insert(Data::Value{}, "histograms", dims, state.range(0) * 1000);
   gsl::index elements = 1000 * state.range(0);
 
   for (auto _ : state) {
@@ -81,11 +81,11 @@ static void BM_MDZipView_mixed_dimension_addition(benchmark::State &state) {
   Dataset d;
   Dimensions dims;
   dims.add(Dim::Spectrum, state.range(0));
-  d.insert<Data::Variance>("", dims, state.range(0));
+  d.insert(Data::Variance{}, "", dims, state.range(0));
   dims.add(Dim::Tof, 100);
   dims.add(Dim::Run, 10);
   gsl::index elements = state.range(0) * 100 * 10;
-  d.insert<Data::Value>("", dims, elements);
+  d.insert(Data::Value{}, "", dims, elements);
 
   for (auto _ : state) {
     MDZipView<Data::Value, const Data::Variance> view(d);
@@ -107,11 +107,11 @@ BM_MDZipView_mixed_dimension_addition_threaded(benchmark::State &state) {
   Dataset d;
   Dimensions dims;
   dims.add(Dim::Spectrum, state.range(0));
-  d.insert<Data::Variance>("", dims, state.range(0));
+  d.insert(Data::Variance{}, "", dims, state.range(0));
   dims.add(Dim::Tof, 100);
   dims.add(Dim::Run, 10);
   gsl::index elements = state.range(0) * 100 * 10;
-  d.insert<Data::Value>("", dims, elements);
+  d.insert(Data::Value{}, "", dims, elements);
 
   for (auto _ : state) {
     MDZipView<Data::Value, const Data::Variance> view(d);
@@ -133,12 +133,12 @@ static void
 BM_MDZipView_multi_column_mixed_dimension_nested(benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert<Data::Int>("specnums", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::Int{}, "specnums", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Tof, 1000);
   dims.add(Dim::Spectrum, nSpec);
-  d.insert<Data::Value>("histograms", dims, nSpec * 1000);
-  d.insert<Data::Variance>("histograms", dims, nSpec * 1000);
+  d.insert(Data::Value{}, "histograms", dims, nSpec * 1000);
+  d.insert(Data::Variance{}, "histograms", dims, nSpec * 1000);
   MDZipView<MDZipView<Data::Value>, Data::Int> it(d, {Dim::Tof});
 
   for (auto _ : state) {
@@ -163,12 +163,12 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_threaded(
     benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert<Data::Int>("specnums", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::Int{}, "specnums", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Tof, 1000);
   dims.add(Dim::Spectrum, nSpec);
-  d.insert<Data::Value>("histograms", dims, nSpec * 1000);
-  d.insert<Data::Variance>("histograms", dims, nSpec * 1000);
+  d.insert(Data::Value{}, "histograms", dims, nSpec * 1000);
+  d.insert(Data::Variance{}, "histograms", dims, nSpec * 1000);
   MDZipView<MDZipView<Data::Value>, Data::Int> it(d, {Dim::Tof});
 
   for (auto _ : state) {
@@ -196,12 +196,12 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_transpose(
     benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert<Data::Int>("specnums", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::Int{}, "specnums", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Spectrum, nSpec);
   dims.add(Dim::Tof, 1000);
-  d.insert<Data::Value>("histograms", dims, nSpec * 1000);
-  d.insert<Data::Variance>("histograms", dims, nSpec * 1000);
+  d.insert(Data::Value{}, "histograms", dims, nSpec * 1000);
+  d.insert(Data::Variance{}, "histograms", dims, nSpec * 1000);
   MDZipView<MDZipView<Data::Value>, Data::Int> it(d, {Dim::Tof});
 
   for (auto _ : state) {

--- a/doc/design-tag-considerations.md
+++ b/doc/design-tag-considerations.md
@@ -370,47 +370,25 @@ Operations that combine two different concepts? Matrix-vector multiplication?
 
   // Using default type:
   auto x = dataset.get(Coord::X);
-  auto mutable_x = dataset.getMutable(Coord::X);
   // Custom type if default is not used:
-  // Note that we do not specify const-ness via type since that does not work
-  // for the default type. We need the `get` and `getMutable` accessors.
   auto x = dataset.get<float>(Coord::X);
-  auto x = dataset.getMutable<float>(Coord::X);
   // Tag-less variable:
   auto data = dataset.get<double>("sample1");
-  auto data = dataset.getMutable<double>("sample1");
   // Tagged and named:
   // Can use default type
   auto data = dataset.get(Data::Value, "sample1");
-  auto data = dataset.getMutable(Data::Value, "sample1");
   // Or custom
   auto data = dataset.get<float>(Data::Value, "sample1");
-  auto data = dataset.getMutable<float>(Data::Value, "sample1");
 
   // Accessing Variable:
   auto data = var.get<float>();
-  auto data = var.getMutable<float>();
+  // Globally default to double?
+  auto data = var.get();
   // Use default type (and check tag at same time):
   auto data = var.get(Coord::X);
-  auto data = var.getMutable(Coord::X);
   // Use custom type (and check tag at same time):
   auto data = var.get<float>(Coord::X);
-  auto data = var.getMutable<float>(Coord::X);
-
-  // Should we rely 100% on const-correctness? Would work for variable!
-  auto data = var.get<float>(); // trigger copy if var is not const
-  // What about Dataset, usually only some variables are to be modified?
-  // How can we get a const variable reference without being too verbose.
-  for (auto var : dataset) {
-    const auto &constVar = var;
-    if (constVar.get<float>()[0] == 0.0);
-      // ...
-  }
   ```
-
-
-
-
 
 
 #### Conclusion

--- a/doc/design.md
+++ b/doc/design.md
@@ -715,52 +715,52 @@ Dataset detInfo;
 // Add some information about the instrument. This would likely be wrapped in
 // convenience functions.
 // Data passed as argument, e.g., initializer_list.
-detInfo.insert<Coord::DetectorId>({Dim::Detector, 4}, {1, 2, 3, 4});
+detInfo.insert(Coord::DetectorId{}, {Dim::Detector, 4}, {1, 2, 3, 4});
 // No data passed, will be default-constructed.
-detInfo.insert<Coord::Position>({Dim::Detector, 4});
+detInfo.insert(Coord::Position{}, {Dim::Detector, 4});
 
 // Create an empty dataset.
 Dataset d;
 // Add detector information to main dataset.
-d.insert<Coord::DetectorInfo>({}, {detInfo});
+d.insert(Coord::DetectorInfo{}, {}, {detInfo});
 
 // Add spectrum-to-detector mapping and spectrum numbers.
 std::vector<std::vector<gsl::index>> grouping = {{0, 2}, {1}, {}};
-d.insert<Coord::DetectorGrouping>({Dim::Spectrum, 3}, grouping);
-d.insert<Coord::SpectrumNumber>({Dim::Spectrum, 3}, {1, 2, 3});
+d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 3}, grouping);
+d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 3}, {1, 2, 3});
 
 // Add time-of-flight axis ("X" in current Mantid nomenclature) which
 // will be shared for all spectra.
-d.insert<Coord::Tof>({Dim::Tof, 1000});
+d.insert(Coord::Tof{}, {Dim::Tof, 1000});
 Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
 
 // Add data and uncertainties ("Y" and "E" in current Mantid nomenclature).
-d.insert<Data::Value>("sample", dims);
-d.insert<Data::Variance>("sample", dims);
+d.insert(Data::Value{}, "sample", dims);
+d.insert(Data::Variance{}, "sample", dims);
 
 // Add another set of data and uncertainties.
-d.insert<Data::Value>("background", dims);
-d.insert<Data::Variance>("background", dims);
+d.insert(Data::Value{}, "background", dims);
+d.insert(Data::Variance{}, "background", dims);
 
 // Add monitors as a nested dataset. In practice storing monitors as attribute
 // instead of as a coordinate may turn out to be more convenient.
-d.insert<Coord::MonitorName>({Dim::Monitor, 2}, "beam-status", "main");
-d.insert<Coord::Monitor>({Dim::Monitor, 2});
+d.insert(Coord::MonitorName{}, {Dim::Monitor, 2}, "beam-status", "main");
+d.insert(Coord::Monitor{}, {Dim::Monitor, 2});
 // Add data to monitors. Use DatasetIndex to do lookup by name.
 DatasetIndex<Coord::MonitorName> monitors(d);
 // First monitor has histogram data and is pixelated.
 int pixels = 10 * 10;
 auto &beam_mon = d.get<Coord::Monitor>()[monitors["beam-status"]];
-beam_mon.insert<Coord::Tof>("", {Dim::Tof, 101});
-beam_mon.insert<Data::Value>("", {{Dim::Tof, 100}, {Dim::Spectrum}},
+beam_mon.insert(Coord::Tof{}, "", {Dim::Tof, 101});
+beam_mon.insert(Data::Value{}, "", {{Dim::Tof, 100}, {Dim::Spectrum}},
                              100 * pixels);
-beam_mon.insert<Data::Variance>("", {{Dim::Tof, 100}, {Dim::Spectrum}},
+beam_mon.insert(Data::Variance{}, "", {{Dim::Tof, 100}, {Dim::Spectrum}},
                                 100 * pixels);
 // Second monitor is event-mode.
 auto &main_mon = d.get<Coord::Monitor>()[monitors["main"]];
 // Note that there is Coord::Tof and Data::Tof, the latter is used for events.
-main_mon.insert<Data::Tof>("", {Dim::Event, 238576});
-main_mon.insert<Data::PulseTime>("", {Dim::Event, 238576});
+main_mon.insert(Data::Tof{}, "", {Dim::Event, 238576});
+main_mon.insert(Data::PulseTime{}, "", {Dim::Event, 238576});
 
 // Convert monitor to histogram.
 auto mon = d.get<Coord::Monitor>()[monitors["main"]];
@@ -777,8 +777,8 @@ d /= d.get<Coord::Monitor>()[monitors["main"]];
 
 // Build equivalent to Mantid's WorkspaceSingleValue.
 Dataset offset;
-offset.insert<Data::Value>("sample", {}, {1.0});
-offset.insert<Data::Variance>("sample", {}, {0.1});
+offset.insert(Data::Value{}, "sample", {}, {1.0});
+offset.insert(Data::Variance{}, "sample", {}, {0.1});
 // Note the use of name "sample" such that offset affects sample, not
 // other `Data` variables such as "background".
 d += offset;
@@ -789,16 +789,16 @@ d["sample"] - d["background"];
 
 // Copy the dataset. All variables use copy-on-write, so this is cheap.
 auto spinUp(d);
-spinUp.insert<Coord::Polarization>({}, {Spin::Up});
+spinUp.insert(Coord::Polarization{}, {}, {Spin::Up});
 auto spinDown(d);
-spinDown.insert<Coord::Polarization>({}, {Spin::Down});
+spinDown.insert(Coord::Polarization{}, {}, {Spin::Down});
 
 // Combine data for spin-up and spin-down in same dataset, polarization is
 // an extra dimension.
 auto combined = concatenate(Dim::Polarization, spinUp, spinDown);
 
 // Do a temperature scan, adding a new temperature dimension to the dataset.
-Dataset tempEdges.insert<Coord::Temperature>({Dim::Temperature, 6},
+Dataset tempEdges.insert(Coord::Temperature{}, {Dim::Temperature, 6},
                                              {273.0, 200.0, 100.0, 10.0, 4.2,
                                               4.1});
 // Empty dataset for accumulation.

--- a/doc/design.md
+++ b/doc/design.md
@@ -246,7 +246,6 @@ The name of data variables is furthermore used to imply a grouping of variables.
 *Example: In a dataset containing data variables `Data::Value` and `Data::Variance` a matching variable name implies that the uncertainties stored in `Data::Variance` are associated with the data stored in `Data::Value`.*
 
 The data in `Variable` is held by a type-erased handle, i.e., a `Variable` can hold data of any type.
-The data handle also implements a copy-on-write mechanism, which makes `Variable` and `Dataset` cheap to copy and saves memory if only some variables in a dataset are modified.
 
 
 ### <a name="overview-operations"></a>Operations
@@ -404,8 +403,6 @@ There are very few methods for direct manipulation of `Dataset`:
 The current implementation in the prototype is mostly complete regarding the actual `Dataset` interface.
 Most other functionality would probably be added as free functions.
 - Some interface cleanup for finding variables or checking for existence of certain tags/names is required.
-- `merge` is currently a member method, but should probably be made a free function.
-  Given the copy-on-write mechanism there is no advantage in having it as a method.
 - Insertion mechanism for bin-edge variables needs to be clarified.
 
 
@@ -1034,6 +1031,10 @@ See also a [working example](../test/Run_test.cpp) that shows automatic matching
 
 ### <a name="design-details-copy-on-write-mechanism"></a>Copy-on-write mechanism
 
+##### Update: Copy-on-write removed during detailed-design evaluation
+
+See [copy-on-write evaluation](design-copy-on-write-evaluation.md).
+
 ##### Context
 
 From a high-level point of view there are two extremes that can be adopted when copying a `dict`-like object like `Dataset`:
@@ -1358,7 +1359,7 @@ We would like to support slicing as in `numpy` and `xarray`, e.g., `array[2:4,10
 In both `numpy` and `xarray` the returned object is a view, i.e., data is not extracted.
 
 The ownership and copying discussion in the section [Copy-on-write mechanism](#design-details-copy-on-write-mechanism) is related to such slice-views and implies:
-- Any iterator obtained from a view is invalidated if any non-`const` method on *any other view* to the same `Variable` is called.
+- Any iterator obtained from a view is invalidated if any non-`const` method on *any other view* to the same `Variable` is called (*Update: The copy-on-write mechanism was removed as part of detailed-design, so this is issue no longer present.*).
   - The view itself can stay valid since it references the variable, not its data.
 - Contrary to the `numpy` behavior, if the owning `Variable` goes out of scope all views should probably become invalid.
   To support views that stay valid we would need to wrap all variables in `Dataset` into a `shared_ptr` and the benefit does not seem to justify this additional complexity at this point.

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -108,7 +108,7 @@ void insertCoord1D(Dataset &self, const Tag,
   const auto &labels = std::get<0>(data);
   const auto &values = std::get<1>(data);
   Dimensions dims{labels, {static_cast<gsl::index>(values.size())}};
-  self.insert<const Tag>(dims, values);
+  self.insert(Tag{}, dims, values);
 }
 
 // Note the concretely typed py::array_t. If we use py::array it will not match
@@ -131,7 +131,7 @@ void insert(Dataset &self, const std::pair<Tag, const std::string &> &key,
     if (self(tag, name) == var)
       return;
   const auto &data = var.template get<const Tag>();
-  self.insert<Tag>(name, var.dimensions(), data.begin(), data.end());
+  self.insert(Tag{}, name, var.dimensions(), data.begin(), data.end());
 }
 
 void insertDefaultInit(

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -130,7 +130,7 @@ void insert(Dataset &self, const std::pair<Tag, const std::string &> &key,
   if (self.contains(tag, name))
     if (self(tag, name) == var)
       return;
-  const auto &data = var.template get<const Tag>();
+  const auto &data = var.template get<Tag>();
   self.insert(Tag{}, name, var.dimensions(), data.begin(), data.end());
 }
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,7 +43,7 @@ Dataset tofToEnergy(const Dataset &d) {
   auto physicalConstants =
       boost::units::si::constants::codata::m_n / (2.0 * meV * mus2_to_s2);
 
-  ConstMDZipView<Coord::Position> specPos(d);
+  ConstMDZipView<const Coord::Position> specPos(d);
   const auto factor = [&](const auto &item) {
     const auto &pos = item.template get<Coord::Position>();
     double l_total = l1 + (samplePos - pos).norm();
@@ -79,13 +79,7 @@ Dataset tofToEnergy(const Dataset &d) {
       throw std::runtime_error(
           "TODO Converting units of event data not implemented yet.");
     } else {
-      // TODO Changing Dim::Tof to Dim::Energy. Currently this is not possible
-      // without making a copy of the data, which is inefficient. If we cannot
-      // move the dimensions outside the cow_ptr in Variable, another option
-      // would be to support in-place modification. Probably a better solution
-      // would be to decouple the pointer holding VariableConcept from the COW
-      // mechanism, i.e., to COW inside VariableConcept to hold the data
-      // array?
+      // Changing Dim::Tof to Dim::Energy.
       // TODO Also need to check here if variable contains count/bin_width,
       // should fail then?
       converted.insert(var.reshape(varDims));

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -21,8 +21,7 @@ Dataset tofToEnergy(const Dataset &d) {
                              "only supported for elastic scattering.");
 
   // 1. Compute conversion factor
-  const auto &compPos =
-      d.get<const Coord::ComponentInfo>()[0].get<const Coord::Position>();
+  const auto &compPos = d.get<Coord::ComponentInfo>()[0].get<Coord::Position>();
   // TODO Need a better mechanism to identify source and sample.
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
@@ -99,8 +98,7 @@ Dataset tofToDeltaE(const Dataset &d) {
                              "cannot have both for inelastic scattering.");
 
   // 1. Compute conversion factors
-  const auto &compPos =
-      d.get<const Coord::ComponentInfo>()[0].get<const Coord::Position>();
+  const auto &compPos = d.get<Coord::ComponentInfo>()[0].get<Coord::Position>();
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
   const double l1 = (sourcePos - samplePos).norm();
@@ -116,7 +114,7 @@ Dataset tofToDeltaE(const Dataset &d) {
 
     // This is how we support multi-Ei data!
     tofShift.setDimensions(d(Coord::Ei{}).dimensions());
-    const auto &Ei = d.get<const Coord::Ei>();
+    const auto &Ei = d.get<Coord::Ei>();
     std::transform(Ei.begin(), Ei.end(), tofShift.get<Data::Value>().begin(),
                    [&l1](const double Ei) { return l1 / sqrt(Ei); });
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,7 +43,7 @@ Dataset tofToEnergy(const Dataset &d) {
   auto physicalConstants =
       boost::units::si::constants::codata::m_n / (2.0 * meV * mus2_to_s2);
 
-  MDZipView<const Coord::Position> specPos(d);
+  ConstMDZipView<Coord::Position> specPos(d);
   const auto factor = [&](const auto &item) {
     const auto &pos = item.template get<Coord::Position>();
     double l_total = l1 + (samplePos - pos).norm();
@@ -127,7 +127,7 @@ Dataset tofToDeltaE(const Dataset &d) {
                    [&l1](const double Ei) { return l1 / sqrt(Ei); });
 
     scale.setDimensions(dims);
-    MDZipView<const Coord::Position> specPos(d);
+    ConstMDZipView<Coord::Position> specPos(d);
     std::transform(specPos.begin(), specPos.end(),
                    scale.get<Data::Value>().begin(), [&](const auto &item) {
                      const auto &pos = item.template get<Coord::Position>();
@@ -139,7 +139,7 @@ Dataset tofToDeltaE(const Dataset &d) {
 
     tofShift.setDimensions(dims);
     // Ef can be different for every spectrum so we access it also via a view.
-    MDZipView<const Coord::Position, const Coord::Ef> geometry(d);
+    ConstMDZipView<Coord::Position, Coord::Ef> geometry(d);
     std::transform(geometry.begin(), geometry.end(),
                    tofShift.get<Data::Value>().begin(), [&](const auto &item) {
                      const auto &pos = item.template get<Coord::Position>();

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -318,9 +318,9 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
             // view, not a span, i.e., it is less efficient. May need to do this
             // differently for optimal performance.
             auto v1 = var1.template get<Data::Value>();
-            const auto v2 = var2.template get<const Data::Value>();
+            const auto v2 = var2.template get<Data::Value>();
             auto e1 = error1.template get<Data::Variance>();
-            const auto e2 = error2.template get<const Data::Variance>();
+            const auto e2 = error2.template get<Data::Variance>();
             // TODO Need to ensure that data is contiguous!
             aligned::multiply(v1.size(), v1.data(), e1.data(), v2.data(),
                               e2.data());
@@ -636,7 +636,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // TODO Is there are more generic way to find "histogrammable" data, not
   // specific to (neutron) events? Something like Data::ValueVector, i.e., any
   // data variable that contains a vector of values at each point?
-  const auto &events = var.get<const Data::Events>();
+  const auto &events = var.get<Data::Events>();
   // TODO This way of handling events (and their units) as nested Dataset feels
   // a bit unwieldy. Would it be a better option to store TOF (or any derived
   // values) as simple vectors in Data::Events? There would be a separate
@@ -681,7 +681,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   const auto edges = getView<double>(coord, dims);
   auto edge = edges.begin();
   for (const auto &eventList : events) {
-    const auto tofs = eventList.get<const Data::Tof>();
+    const auto tofs = eventList.get<Data::Tof>();
     if (!std::is_sorted(tofs.begin(), tofs.end()))
       throw std::runtime_error(
           "TODO: Histograms can currently only be created from sorted data.");
@@ -723,7 +723,7 @@ Dataset histogram(const Dataset &d, const Variable &coord) {
 // datasets that represent events lists, using ZipView.
 template <class Tag> struct Sort {
   static Dataset apply(const Dataset &d, const std::string &name) {
-    auto const_axis = d.get<const Tag>(name);
+    auto const_axis = d.get<Tag>(name);
     if (d(Tag{}, name).dimensions().count() != 1)
       throw std::runtime_error("Axis for sorting must be 1-dimensional.");
     const auto sortDim = d(Tag{}, name).dimensions().label(0);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -494,18 +494,26 @@ DatasetSlice DatasetSlice::operator*=(const double value) {
   return *this;
 }
 
-Dataset operator+(Dataset a, const Dataset &b) { return a += b; }
-Dataset operator-(Dataset a, const Dataset &b) { return a -= b; }
-Dataset operator*(Dataset a, const Dataset &b) { return a *= b; }
-Dataset operator+(Dataset a, const ConstDatasetSlice &b) { return a += b; }
-Dataset operator-(Dataset a, const ConstDatasetSlice &b) { return a -= b; }
-Dataset operator*(Dataset a, const ConstDatasetSlice &b) { return a *= b; }
-Dataset operator+(Dataset a, const double b) { return a += b; }
-Dataset operator-(Dataset a, const double b) { return a -= b; }
-Dataset operator*(Dataset a, const double b) { return a *= b; }
-Dataset operator+(const double a, Dataset b) { return b += a; }
-Dataset operator-(const double a, Dataset b) { return -(b -= a); }
-Dataset operator*(const double a, Dataset b) { return b *= a; }
+// Note: The std::move here is necessary because RVO does not work for variables
+// that are function parameters.
+Dataset operator+(Dataset a, const Dataset &b) { return std::move(a += b); }
+Dataset operator-(Dataset a, const Dataset &b) { return std::move(a -= b); }
+Dataset operator*(Dataset a, const Dataset &b) { return std::move(a *= b); }
+Dataset operator+(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a += b);
+}
+Dataset operator-(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a -= b);
+}
+Dataset operator*(Dataset a, const ConstDatasetSlice &b) {
+  return std::move(a *= b);
+}
+Dataset operator+(Dataset a, const double b) { return std::move(a += b); }
+Dataset operator-(Dataset a, const double b) { return std::move(a -= b); }
+Dataset operator*(Dataset a, const double b) { return std::move(a *= b); }
+Dataset operator+(const double a, Dataset b) { return std::move(b += a); }
+Dataset operator-(const double a, Dataset b) { return std::move(-(b -= a)); }
+Dataset operator*(const double a, Dataset b) { return std::move(b *= a); }
 
 std::vector<Dataset> split(const Dataset &d, const Dim dim,
                            const std::vector<gsl::index> &indices) {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -667,7 +667,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
 
   Dataset hist;
   hist.insert(coord);
-  hist.insert<Data::Value>(var.name(), dims);
+  hist.insert(Data::Value{}, var.name(), dims);
 
   // Counts has outer dimensions as input, with a new inner dimension given by
   // the binning dimensions. We iterate over all dimensions as a flat array.
@@ -704,7 +704,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   }
 
   // TODO Would need to add handling for weighted events etc. here.
-  hist.insert<Data::Variance>(var.name(), dims, counts.begin(), counts.end());
+  hist.insert(Data::Variance{}, var.name(), dims, counts.begin(), counts.end());
   return hist;
 }
 

--- a/src/dataset_index.h
+++ b/src/dataset_index.h
@@ -13,7 +13,7 @@
 template <class Tag> class DatasetIndex {
 public:
   DatasetIndex(const Dataset &dataset) {
-    const auto &axis = dataset.get<const Tag>();
+    const auto &axis = dataset.get<Tag>();
     gsl::index current = 0;
     for (auto item : axis)
       m_index[item] = current++;

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -69,6 +69,10 @@ std::string to_string(const Tag tag) {
     return "Coord::Y";
   case Coord::Z{}.value():
     return "Coord::Z";
+  case Coord::Position{}.value():
+    return "Coord::Position";
+  case Coord::DetectorGrouping{}.value():
+    return "Coord::DetectorGrouping";
   case Data::Value{}.value():
     return "Data::Value";
   case Data::Variance{}.value():

--- a/src/tags.h
+++ b/src/tags.h
@@ -351,28 +351,29 @@ private:
 
 template <class T> struct Bin { using type = DataBin; };
 
-template <class Tag> struct element_return_type {
+template <class D, class Tag> struct element_return_type {
   using type = std::conditional_t<
       std::is_base_of<detail::ReturnByValuePolicy, Tag>::value,
       typename Tag::type,
       std::conditional_t<
-          std::is_const<Tag>::value,
+          std::is_const<D>::value || std::is_const<Tag>::value,
           std::conditional_t<
               std::is_base_of<detail::ReturnByValueIfConstPolicy, Tag>::value,
               typename Tag::type, const typename Tag::type &>,
           typename Tag::type &>>;
 };
 
-template <class Tags> struct element_return_type<Bin<Tags>> {
+template <class D, class Tags> struct element_return_type<D, Bin<Tags>> {
   using type = DataBin;
 };
 
-template <class... Ts> class MDZipViewImpl;
-template <class... Tags> struct element_return_type<MDZipViewImpl<Tags...>> {
-  using type = MDZipViewImpl<Tags...>;
+template <class D, class... Ts> class MDZipViewImpl;
+template <class D, class... Tags>
+struct element_return_type<D, MDZipViewImpl<D, Tags...>> {
+  using type = MDZipViewImpl<D, Tags...>;
 };
 
-template <class Tag>
-using element_return_type_t = typename element_return_type<Tag>::type;
+template <class D, class Tag>
+using element_return_type_t = typename element_return_type<D, Tag>::type;
 
 #endif // TAGS_H

--- a/src/tags.h
+++ b/src/tags.h
@@ -376,4 +376,13 @@ struct element_return_type<D, MDZipViewImpl<D, Tags...>> {
 template <class D, class Tag>
 using element_return_type_t = typename element_return_type<D, Tag>::type;
 
+enum class DType { Unknown, Double, Float, Int32, Int64, String, Char };
+template <class T> constexpr DType dtype = DType::Unknown;
+template <> constexpr DType dtype<double> = DType::Double;
+template <> constexpr DType dtype<float> = DType::Float;
+template <> constexpr DType dtype<int32_t> = DType::Int32;
+template <> constexpr DType dtype<int64_t> = DType::Int64;
+template <> constexpr DType dtype<std::string> = DType::String;
+template <> constexpr DType dtype<char> = DType::Char;
+
 #endif // TAGS_H

--- a/src/traits.h
+++ b/src/traits.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 class Dataset;
-template <class... Ts> class MDZipViewImpl;
+template <class D, class... Ts> class MDZipViewImpl;
 
 namespace detail {
 template <class T, class Tuple> struct index;
@@ -31,8 +31,8 @@ struct and_<Cond, Conds...>
 template <class T> struct is_const : std::false_type {};
 template <class T> struct is_const<const T> : std::true_type {};
 
-template <class... Ts>
-struct is_const<MDZipViewImpl<Ts...>> : and_<is_const<Ts>...> {};
+template <class D, class... Ts>
+struct is_const<MDZipViewImpl<D, Ts...>> : and_<is_const<Ts>...> {};
 
 template <class... Tags>
 using MaybeConstDataset =

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -993,20 +993,7 @@ const VariableView<const T> ConstVariableSlice::cast() const {
           dimensions()};
 }
 
-template <class T> VariableView<const T> VariableSlice::cast() const {
-  if (!m_view)
-    return dynamic_cast<const DataModel<Vector<T>> &>(data()).getView(
-        dimensions());
-  if (m_view->isConstView())
-    return {
-        dynamic_cast<const ViewModel<VariableView<const T>> &>(data()).m_model,
-        dimensions()};
-  // Make a const view from the mutable one.
-  return {dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model,
-          dimensions()};
-}
-
-template <class T> VariableView<T> VariableSlice::cast() {
+template <class T> VariableView<T> VariableSlice::cast() const {
   if (m_view)
     return dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model;
   return dynamic_cast<DataModel<Vector<T>> &>(data()).getView(dimensions());
@@ -1015,8 +1002,7 @@ template <class T> VariableView<T> VariableSlice::cast() {
 #define INSTANTIATE_SLICEVIEW(...)                                             \
   template const VariableView<const __VA_ARGS__>                               \
   ConstVariableSlice::cast<__VA_ARGS__>() const;                               \
-  template VariableView<const __VA_ARGS__> VariableSlice::cast() const;        \
-  template VariableView<__VA_ARGS__> VariableSlice::cast();
+  template VariableView<__VA_ARGS__> VariableSlice::cast() const;
 
 INSTANTIATE_SLICEVIEW(double);
 INSTANTIATE_SLICEVIEW(int32_t);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -694,6 +694,7 @@ template <class T> Vector<T> &Variable::cast() {
 
 INSTANTIATE(std::string)
 INSTANTIATE(double)
+INSTANTIATE(float)
 INSTANTIATE(char)
 INSTANTIATE(int32_t)
 INSTANTIATE(int64_t)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -532,8 +532,8 @@ public:
 /// Implementation of VariableConcept that represents a view onto data.
 template <class T>
 class ViewModel
-    : public conceptT_t<std::remove_const_t<typename T::value_type>> {
-  using value_type = std::remove_const_t<typename T::value_type>;
+    : public conceptT_t<std::remove_const_t<typename T::element_type>> {
+  using value_type = typename T::value_type;
 
   void requireMutable() const {
     if (isConstView())
@@ -558,7 +558,7 @@ public:
   gsl::span<value_type> getSpan() override {
     requireMutable();
     requireContiguous();
-    if constexpr (std::is_const<typename T::value_type>::value)
+    if constexpr (std::is_const<typename T::element_type>::value)
       return gsl::span<value_type>();
     else
       return gsl::make_span(m_model.data(), m_model.data() + size());
@@ -567,7 +567,7 @@ public:
                                 const gsl::index end) override {
     requireMutable();
     requireContiguous();
-    if constexpr (std::is_const<typename T::value_type>::value) {
+    if constexpr (std::is_const<typename T::element_type>::value) {
       static_cast<void>(dim);
       static_cast<void>(begin);
       static_cast<void>(end);
@@ -589,7 +589,7 @@ public:
 
   VariableView<value_type> getView(const Dimensions &dims) override {
     requireMutable();
-    if constexpr (std::is_const<typename T::value_type>::value) {
+    if constexpr (std::is_const<typename T::element_type>::value) {
       static_cast<void>(dims);
       return VariableView<value_type>(nullptr, 0, {}, {});
     } else {
@@ -599,7 +599,7 @@ public:
   VariableView<value_type> getView(const Dimensions &dims, const Dim dim,
                                    const gsl::index begin) override {
     requireMutable();
-    if constexpr (std::is_const<typename T::value_type>::value) {
+    if constexpr (std::is_const<typename T::element_type>::value) {
       static_cast<void>(dim);
       static_cast<void>(begin);
       return VariableView<value_type>(nullptr, 0, {}, {});
@@ -624,7 +624,7 @@ public:
   }
   VariableView<value_type> getReshaped(const Dimensions &dims) override {
     requireMutable();
-    if constexpr (std::is_const<typename T::value_type>::value) {
+    if constexpr (std::is_const<typename T::element_type>::value) {
       static_cast<void>(dims);
       return VariableView<value_type>(nullptr, 0, {}, {});
     } else {
@@ -645,7 +645,7 @@ public:
   }
   bool isView() const override { return true; }
   bool isConstView() const override {
-    return std::is_const<typename T::value_type>::value;
+    return std::is_const<typename T::element_type>::value;
   }
 
   gsl::index size() const override { return m_model.size(); }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1197,7 +1197,7 @@ Variable filter(const Variable &var, const Variable &filter) {
     throw std::runtime_error(
         "Cannot filter variable: The filter must by 1-dimensional.");
   const auto dim = filter.dimensions().labels()[0];
-  auto mask = filter.get<const Coord::Mask>();
+  auto mask = filter.get<Coord::Mask>();
 
   const gsl::index removed = std::count(mask.begin(), mask.end(), 0);
   if (removed == 0)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -514,11 +514,6 @@ public:
   }
 
   std::unique_ptr<VariableConcept>
-  cloneMutable(VariableConcept &) const override {
-    throw std::runtime_error("DataModel::cloneMutable() should not be called.");
-  }
-
-  std::unique_ptr<VariableConcept>
   clone(const Dimensions &dims) const override {
     return std::make_unique<DataModel<T>>(dims, T(dims.volume()));
   }
@@ -637,14 +632,6 @@ public:
 
   std::unique_ptr<VariableConcept> clone() const override {
     return std::make_unique<ViewModel<T>>(this->dimensions(), m_model);
-  }
-
-  std::unique_ptr<VariableConcept>
-  cloneMutable(VariableConcept &mutableData) const override {
-    auto *data =
-        dynamic_cast<conceptT_t<value_type> &>(mutableData).getSpan().data();
-    return std::make_unique<ViewModel<VariableView<value_type>>>(
-        this->dimensions(), m_model.createMutable(data));
   }
 
   std::unique_ptr<VariableConcept> clone(const Dimensions &) const override {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -883,7 +883,7 @@ Variable &Variable::operator/=(const double value) & {
   return divide_equals(*this, other);
 }
 
-template <class T> VariableSlice VariableSlice::assign(const T &other) {
+template <class T> VariableSlice VariableSlice::assign(const T &other) const {
   // TODO Should mismatching tags be allowed, as long as the type matches?
   if (tag() != other.tag())
     throw std::runtime_error("Cannot assign to slice: Type mismatch.");
@@ -897,52 +897,52 @@ template <class T> VariableSlice VariableSlice::assign(const T &other) {
   return *this;
 }
 
-template VariableSlice VariableSlice::assign(const Variable &);
-template VariableSlice VariableSlice::assign(const ConstVariableSlice &);
+template VariableSlice VariableSlice::assign(const Variable &) const;
+template VariableSlice VariableSlice::assign(const ConstVariableSlice &) const;
 
-VariableSlice VariableSlice::operator+=(const Variable &other) {
+VariableSlice VariableSlice::operator+=(const Variable &other) const {
   return plus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) const {
   return plus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator+=(const double value) {
+VariableSlice VariableSlice::operator+=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return plus_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator-=(const Variable &other) {
+VariableSlice VariableSlice::operator-=(const Variable &other) const {
   return minus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) const {
   return minus_equals(*this, other);
 }
-VariableSlice VariableSlice::operator-=(const double value) {
+VariableSlice VariableSlice::operator-=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return minus_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator*=(const Variable &other) {
+VariableSlice VariableSlice::operator*=(const Variable &other) const {
   return times_equals(*this, other);
 }
-VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) const {
   return times_equals(*this, other);
 }
-VariableSlice VariableSlice::operator*=(const double value) {
+VariableSlice VariableSlice::operator*=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
 }
 
-VariableSlice VariableSlice::operator/=(const Variable &other) {
+VariableSlice VariableSlice::operator/=(const Variable &other) const {
   return divide_equals(*this, other);
 }
-VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) {
+VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) const {
   return divide_equals(*this, other);
 }
-VariableSlice VariableSlice::operator/=(const double value) {
+VariableSlice VariableSlice::operator/=(const double value) const {
   Variable other(Data::Value{}, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return divide_equals(*this, other);
@@ -969,7 +969,7 @@ Variable ConstVariableSlice::operator-() const {
   return -copy;
 }
 
-void VariableSlice::setUnit(const Unit &unit) {
+void VariableSlice::setUnit(const Unit &unit) const {
   // TODO Should we forbid setting the unit altogether? I think it is useful in
   // particular since views onto subsets of dataset do not imply slicing of
   // variables but return slice views.

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -193,6 +193,8 @@ template <class T> class VariableConceptT : public concept_t<T> {
 public:
   VariableConceptT(const Dimensions &dimensions) : concept_t<T>(dimensions) {}
 
+  DType dtype() const noexcept override { return ::dtype<T>; }
+
   virtual gsl::span<T> getSpan() = 0;
   virtual gsl::span<T> getSpan(const Dim dim, const gsl::index begin,
                                const gsl::index end) = 0;
@@ -1006,6 +1008,8 @@ template <class T> VariableView<T> VariableSlice::cast() const {
   template VariableView<__VA_ARGS__> VariableSlice::cast() const;
 
 INSTANTIATE_SLICEVIEW(double);
+INSTANTIATE_SLICEVIEW(float);
+INSTANTIATE_SLICEVIEW(int64_t);
 INSTANTIATE_SLICEVIEW(int32_t);
 INSTANTIATE_SLICEVIEW(char);
 INSTANTIATE_SLICEVIEW(std::string);

--- a/src/variable.h
+++ b/src/variable.h
@@ -230,13 +230,7 @@ public:
     return gsl::make_span(cast<typename Tag::type>());
   }
 
-  template <class Tag>
-  auto get(std::enable_if_t<std::is_const<Tag>::value> * = nullptr) {
-    return const_cast<const Variable *>(this)->get<Tag>();
-  }
-
-  template <class Tag>
-  auto get(std::enable_if_t<!std::is_const<Tag>::value> * = nullptr) {
+  template <class Tag> auto get() {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return gsl::make_span(cast<typename Tag::type>());
@@ -420,13 +414,7 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class Tag>
-  auto get(std::enable_if_t<std::is_const<Tag>::value> * = nullptr) {
-    return const_cast<const VariableSlice *>(this)->get<Tag>();
-  }
-
-  template <class Tag>
-  auto get(std::enable_if_t<!std::is_const<Tag>::value> * = nullptr) {
+  template <class Tag> auto get() {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();

--- a/src/variable.h
+++ b/src/variable.h
@@ -436,21 +436,21 @@ public:
   // the Python exports to return `a` after calling `a += b` instead of
   // returning `a += b` but I am not sure how Pybind11 handles object lifetimes
   // (would this suffer from the same issue?).
-  template <class T> VariableSlice assign(const T &other);
-  VariableSlice operator+=(const Variable &other);
-  VariableSlice operator+=(const ConstVariableSlice &other);
-  VariableSlice operator+=(const double value);
-  VariableSlice operator-=(const Variable &other);
-  VariableSlice operator-=(const ConstVariableSlice &other);
-  VariableSlice operator-=(const double value);
-  VariableSlice operator*=(const Variable &other);
-  VariableSlice operator*=(const ConstVariableSlice &other);
-  VariableSlice operator*=(const double value);
-  VariableSlice operator/=(const Variable &other);
-  VariableSlice operator/=(const ConstVariableSlice &other);
-  VariableSlice operator/=(const double value);
+  template <class T> VariableSlice assign(const T &other) const;
+  VariableSlice operator+=(const Variable &other) const;
+  VariableSlice operator+=(const ConstVariableSlice &other) const;
+  VariableSlice operator+=(const double value) const;
+  VariableSlice operator-=(const Variable &other) const;
+  VariableSlice operator-=(const ConstVariableSlice &other) const;
+  VariableSlice operator-=(const double value) const;
+  VariableSlice operator*=(const Variable &other) const;
+  VariableSlice operator*=(const ConstVariableSlice &other) const;
+  VariableSlice operator*=(const double value) const;
+  VariableSlice operator/=(const Variable &other) const;
+  VariableSlice operator/=(const ConstVariableSlice &other) const;
+  VariableSlice operator/=(const double value) const;
 
-  void setUnit(const Unit &unit);
+  void setUnit(const Unit &unit) const;
 
 private:
   friend class Variable;

--- a/src/variable.h
+++ b/src/variable.h
@@ -12,7 +12,6 @@
 #include <gsl/gsl_util>
 #include <gsl/span>
 
-#include "cow_ptr.h"
 #include "dimensions.h"
 #include "tags.h"
 #include "unit.h"

--- a/src/variable.h
+++ b/src/variable.h
@@ -211,6 +211,7 @@ public:
   VariableConcept &data() && = delete;
   VariableConcept &data() & { return *m_object; }
 
+  DType dtype() const noexcept { return data().dtype(); }
   Tag tag() const { return m_tag; }
   bool isCoord() const {
     return m_tag < std::tuple_size<detail::CoordDef::tags>::value;
@@ -348,6 +349,7 @@ public:
     return strides;
   }
 
+  DType dtype() const noexcept { return data().dtype(); }
   Tag tag() const { return m_variable->tag(); }
   const VariableConcept &data() const && = delete;
   const VariableConcept &data() const & {

--- a/src/variable.h
+++ b/src/variable.h
@@ -233,6 +233,9 @@ public:
     return gsl::make_span(cast<typename Tag::type>());
   }
 
+  template <class T> auto span() const { return gsl::make_span(cast<T>()); }
+  template <class T> auto span() { return gsl::make_span(cast<T>()); }
+
   // ATTENTION: It is really important to delete any function returning a
   // (Const)VariableSlice for rvalue Variable. Otherwise the resulting slice
   // will point to free'ed memory.
@@ -272,6 +275,19 @@ private:
   deep_ptr<std::string> m_name;
   deep_ptr<VariableConcept> m_object;
 };
+
+template <class T, class TagT>
+Variable makeVariable(TagT tag, const Dimensions &dimensions) {
+  return Variable(tag, TagT::unit, std::move(dimensions),
+                  Vector<T>(dimensions.volume()));
+}
+
+template <class T, class TagT, class T2>
+Variable makeVariable(TagT tag, const Dimensions &dimensions,
+                      std::initializer_list<T2> values) {
+  return Variable(tag, TagT::unit, std::move(dimensions),
+                  Vector<T>(values.begin(), values.end()));
+}
 
 /// Non-mutable view into (a subset of) a Variable.
 class ConstVariableSlice {

--- a/src/variable.h
+++ b/src/variable.h
@@ -416,7 +416,7 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class Tag> auto get() {
+  template <class Tag> auto get() const {
     if (Tag{} != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();
@@ -457,10 +457,7 @@ private:
   template <class... Tags> friend class ZipView;
   template <class T1, class T2> friend T1 &plus_equals(T1 &, const T2 &);
 
-  // Special version creating const view from mutable view. Note that this does
-  // not return a reference but by value.
-  template <class T> VariableView<const T> cast() const;
-  template <class T> VariableView<T> cast();
+  template <class T> VariableView<T> cast() const;
 
   Variable *m_mutableVariable;
 };

--- a/src/variable.h
+++ b/src/variable.h
@@ -280,6 +280,10 @@ private:
   deep_ptr<VariableConcept> m_object;
 };
 
+// TODO TagT template argument is not actually required, provided that we
+// refactor tags so unit can be obtained from the `Tag` base class. If we do
+// this, we can probably also unify a good amount of code in the Python exports,
+// which is currently requiring exporting for all tags for many methods.
 template <class T, class TagT>
 Variable makeVariable(TagT tag, const Dimensions &dimensions) {
   return Variable(tag, TagT::unit, std::move(dimensions),

--- a/src/variable.h
+++ b/src/variable.h
@@ -32,6 +32,9 @@ class VariableConcept {
 public:
   VariableConcept(const Dimensions &dimensions);
   virtual ~VariableConcept() = default;
+
+  virtual DType dtype() const noexcept = 0;
+
   virtual std::unique_ptr<VariableConcept> clone() const = 0;
   virtual std::unique_ptr<VariableConcept>
   clone(const Dimensions &dims) const = 0;
@@ -369,6 +372,8 @@ public:
     return this->template cast<typename Tag::type>();
   }
 
+  template <class T> auto span() const { return cast<T>(); }
+
   bool operator==(const Variable &other) const;
   bool operator==(const ConstVariableSlice &other) const;
   bool operator!=(const Variable &other) const;
@@ -436,6 +441,8 @@ public:
       throw std::runtime_error("Attempt to access variable with wrong tag.");
     return this->template cast<typename Tag::type>();
   }
+
+  template <class T> auto span() { return cast<T>(); }
 
   // Note: We want to support things like `var(Dim::X, 0) += var2`, i.e., when
   // the left-hand-side is a temporary. This is ok since data is modified in

--- a/src/variable_view.h
+++ b/src/variable_view.h
@@ -18,7 +18,8 @@
 /// and broadcasting.
 template <class T> class VariableView {
 public:
-  using value_type = T;
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
 
   VariableView(T *variable, const gsl::index offset,
                const Dimensions &targetDimensions, const Dimensions &dimensions)

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -14,7 +14,7 @@
 
 TEST(EventWorkspace, EventList) {
   Dataset e;
-  e.insert<Data::Tof>("", {Dim::Event, 0}, 0);
+  e.insert(Data::Tof{}, "", {Dim::Event, 0}, 0);
   // `size()` gives number of variables, not the number of events in this case!
   // Do we need something like `count()`, returning the volume of the Dataset?
   EXPECT_EQ(e.size(), 1);
@@ -23,14 +23,14 @@ TEST(EventWorkspace, EventList) {
   // Cannot change size of Dataset easily right now, is that a problem here? Can
   // use concatenate, but there is no `push_back` or similar:
   Dataset e2;
-  e2.insert<Data::Tof>("", {Dim::Event, 3}, {1.1, 2.2, 3.3});
+  e2.insert(Data::Tof{}, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
   e = concatenate(e, e2, Dim::Event);
   e = concatenate(e, e2, Dim::Event);
   EXPECT_EQ(e.get<Data::Tof>().size(), 6);
 
   // Can insert pulse times if needed.
-  e.insert<Data::PulseTime>("", e(Data::Tof{}).dimensions(),
-                            {2.0, 1.0, 2.1, 1.1, 3.0, 1.2});
+  e.insert(Data::PulseTime{}, "", e(Data::Tof{}).dimensions(),
+           {2.0, 1.0, 2.1, 1.1, 3.0, 1.2});
 
   auto view = ranges::view::zip(e.get<Data::Tof>(), e.get<Data::PulseTime>());
   // Sort by Tof:
@@ -64,19 +64,19 @@ TEST(EventWorkspace, EventList) {
 
 TEST(EventWorkspace, basics) {
   Dataset d;
-  d.insert<Coord::SpectrumNumber>({Dim::Spectrum, 3}, {1, 2, 3});
+  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 3}, {1, 2, 3});
 
   // "X" axis (shared for all spectra).
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 1001), 1001);
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 1001), 1001);
 
   // EventList using Dataset. There are probably better solutions so this likely
   // to change, e.g., to use a proxy object.
   Dataset e;
-  e.insert<Data::Tof>("", {Dim::Event, 0}, 0);
-  e.insert<Data::PulseTime>("", {Dim::Event, 0}, 0);
+  e.insert(Data::Tof{}, "", {Dim::Event, 0}, 0);
+  e.insert(Data::PulseTime{}, "", {Dim::Event, 0}, 0);
 
   // Insert empty event lists.
-  d.insert<Data::Events>("", {Dim::Spectrum, 3}, 3, e);
+  d.insert(Data::Events{}, "", {Dim::Spectrum, 3}, 3, e);
 
   // Get event lists for all spectra.
   auto eventLists = d.get<Data::Events>();
@@ -84,15 +84,15 @@ TEST(EventWorkspace, basics) {
 
   // Modify individual event lists.
   Dataset e2;
-  e2.insert<Data::Tof>("", {Dim::Event, 3}, {1.1, 2.2, 3.3});
-  e2.insert<Data::PulseTime>("", {Dim::Event, 3}, 3);
+  e2.insert(Data::Tof{}, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
+  e2.insert(Data::PulseTime{}, "", {Dim::Event, 3}, 3);
   eventLists[1] = e2;
   eventLists[2] = concatenate(e2, e2, Dim::Event);
 
   // Insert variable for histogrammed data.
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
-  d.insert<Data::Value>("", dims, dims.volume());
-  d.insert<Data::Variance>("", dims, dims.volume());
+  d.insert(Data::Value{}, "", dims, dims.volume());
+  d.insert(Data::Variance{}, "", dims, dims.volume());
 
   // Make histograms.
   // Note that we could determine the correct X axis automatically, since the
@@ -121,11 +121,11 @@ TEST(EventWorkspace, plus) {
   Dataset d;
 
   Dataset e;
-  e.insert<Data::Tof>("", {Dim::Event, 10});
-  e.insert<Data::PulseTime>("", {Dim::Event, 10});
+  e.insert(Data::Tof{}, "", {Dim::Event, 10});
+  e.insert(Data::PulseTime{}, "", {Dim::Event, 10});
   auto e2 = concatenate(e, e, Dim::Event);
 
-  d.insert<Data::Events>("", {Dim::Spectrum, 2}, {e, e2});
+  d.insert(Data::Events{}, "", {Dim::Spectrum, 2}, {e, e2});
 
   EXPECT_THROW_MSG(d - d, std::runtime_error,
                    "Subtraction of events lists not implemented.");

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -18,7 +18,7 @@ TEST(EventWorkspace, EventList) {
   // `size()` gives number of variables, not the number of events in this case!
   // Do we need something like `count()`, returning the volume of the Dataset?
   EXPECT_EQ(e.size(), 1);
-  EXPECT_EQ(e.get<const Data::Tof>().size(), 0);
+  EXPECT_EQ(e.get<Data::Tof>().size(), 0);
 
   // Cannot change size of Dataset easily right now, is that a problem here? Can
   // use concatenate, but there is no `push_back` or similar:
@@ -26,7 +26,7 @@ TEST(EventWorkspace, EventList) {
   e2.insert<Data::Tof>("", {Dim::Event, 3}, {1.1, 2.2, 3.3});
   e = concatenate(e, e2, Dim::Event);
   e = concatenate(e, e2, Dim::Event);
-  EXPECT_EQ(e.get<const Data::Tof>().size(), 6);
+  EXPECT_EQ(e.get<Data::Tof>().size(), 6);
 
   // Can insert pulse times if needed.
   e.insert<Data::PulseTime>("", e(Data::Tof{}).dimensions(),
@@ -39,11 +39,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.first < b.first; });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {1.1, 1.1, 2.2, 2.2, 3.3, 3.3})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({2.0, 1.1, 1.0, 3.0, 2.1, 1.2})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
 
   // Sort by pulse time:
   ranges::sort(
@@ -51,11 +48,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.second < b.second; });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {2.2, 1.1, 3.3, 1.1, 3.3, 2.2})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({1.0, 1.1, 1.2, 2.0, 2.1, 3.0})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 
   // Sort by pulse time then tof:
   ranges::sort(view.begin(), view.end(),
@@ -64,11 +58,8 @@ TEST(EventWorkspace, EventList) {
                  return a.second < b.second && a.first < b.first;
                });
 
-  EXPECT_EQ(e.get<const Data::Tof>(), gsl::make_span(std::vector<double>(
-                                          {2.2, 1.1, 3.3, 1.1, 3.3, 2.2})));
-  EXPECT_EQ(
-      e.get<const Data::PulseTime>(),
-      gsl::make_span(std::vector<double>({1.0, 1.1, 1.2, 2.0, 2.1, 3.0})));
+  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 }
 
 TEST(EventWorkspace, basics) {
@@ -146,13 +137,13 @@ TEST(EventWorkspace, plus) {
 
   auto eventLists = sum.get<Data::Events>();
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<const Data::Tof>().size(), 2 * 10);
-  EXPECT_EQ(eventLists[1].get<const Data::Tof>().size(), 2 * 20);
+  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 2 * 10);
+  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 2 * 20);
 
   sum += d;
 
   eventLists = sum.get<Data::Events>();
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<const Data::Tof>().size(), 3 * 10);
-  EXPECT_EQ(eventLists[1].get<const Data::Tof>().size(), 3 * 20);
+  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 3 * 10);
+  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 3 * 20);
 }

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -60,50 +60,49 @@ TEST(Run, meta_data_propagation) {
   // are in different places in the internal dataset structure. For more
   // convenient access we should provide a view class that can be instantiated
   // on the fly.
-  const auto &run = d1.get<const Attr::ExperimentLog>("sample_log")[0];
+  const auto &run = d1.get<Attr::ExperimentLog>("sample_log")[0];
 
   // Example of a log entry that is accumulated:
-  EXPECT_EQ(run.get<const Data::Value>("total_counts").size(), 1);
-  EXPECT_EQ(run.get<const Data::Value>("total_counts")[0], 2111);
+  EXPECT_EQ(run.get<Data::Value>("total_counts").size(), 1);
+  EXPECT_EQ(run.get<Data::Value>("total_counts")[0], 2111);
 
   // Example of a log entry that is verified:
-  EXPECT_EQ(run.get<const Coord::Polarization>().size(), 1);
-  EXPECT_EQ(run.get<const Coord::Polarization>()[0], "Spin-Up");
+  EXPECT_EQ(run.get<Coord::Polarization>().size(), 1);
+  EXPECT_EQ(run.get<Coord::Polarization>()[0], "Spin-Up");
 
   // Example of a log entry that is verified with fuzzy matching:
-  EXPECT_EQ(run.get<const Coord::FuzzyTemperature>().size(), 1);
+  EXPECT_EQ(run.get<Coord::FuzzyTemperature>().size(), 1);
   // Note: No averaging happening here, it is simply checked to be in range.
-  EXPECT_EQ(run.get<const Coord::FuzzyTemperature>()[0],
+  EXPECT_EQ(run.get<Coord::FuzzyTemperature>()[0],
             ValueWithDelta<double>(4.2, 0.1));
 
   // Example of a log entry that is concatenated:
-  const auto comments =
-      run.get<const Data::Table>("comment")[0].get<const Data::String>();
+  const auto comments = run.get<Data::Table>("comment")[0].get<Data::String>();
   EXPECT_EQ(comments.size(), 2);
   EXPECT_EQ(comments[0], "first run");
   EXPECT_EQ(comments[1], "second run");
 
   // Example of a "time series" log entry that is concatenated:
-  const auto pressure_log = run.get<const Data::Table>("pressure_log")[0];
+  const auto pressure_log = run.get<Data::Table>("pressure_log")[0];
   EXPECT_EQ(pressure_log.dimensions().count(), 1);
   EXPECT_EQ(pressure_log.dimensions().label(0), Dim::Time);
   EXPECT_EQ(pressure_log.dimensions().size(0), 6);
   // No hidden magic here, it is simply concatenated, can do smarter processing
   // by hand afterwards.
   EXPECT_EQ(
-      pressure_log.get<const Data::Value>("pressure1"),
+      pressure_log.get<Data::Value>("pressure1"),
       gsl::make_span(std::vector<double>({1013, 900, 800, 1013, 900, 800})));
 
   // Example of an optional log entry, i.e., one that is not present in all
   // operands:
-  const auto generic_log = run.get<const Data::Table>("generic_log")[0];
+  const auto generic_log = run.get<Data::Table>("generic_log")[0];
   EXPECT_EQ(generic_log.dimensions().count(), 1);
   EXPECT_EQ(generic_log.dimensions().label(0), Dim::Row);
   EXPECT_EQ(generic_log.dimensions().size(0), 2);
-  const auto generic_log_run1 = generic_log.get<const Data::Table>("root")[0];
+  const auto generic_log_run1 = generic_log.get<Data::Table>("root")[0];
   // No entries from run 1.
   EXPECT_EQ(generic_log_run1.size(), 0);
-  const auto generic_log_run2 = generic_log.get<const Data::Table>("root")[1];
+  const auto generic_log_run2 = generic_log.get<Data::Table>("root")[1];
   // 1 entry from run 2.
   EXPECT_EQ(generic_log_run2.size(), 1);
   EXPECT_EQ(generic_log_run2[0].name(), "user comment");

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -12,21 +12,22 @@
 
 Dataset makeRun() {
   Dataset run;
-  run.insert<Data::Value>("total_counts", {}, {1000});
-  run.insert<Coord::Polarization>({}, {"Spin-Up"});
-  run.insert<Coord::FuzzyTemperature>({}, {ValueWithDelta<double>(4.2, 0.1)});
+  run.insert(Data::Value{}, "total_counts", {}, {1000});
+  run.insert(Coord::Polarization{}, {}, {"Spin-Up"});
+  run.insert(Coord::FuzzyTemperature{}, {}, {ValueWithDelta<double>(4.2, 0.1)});
   Dataset comment;
-  comment.insert<Data::String>("", {Dim::Row, 1}, {"first run"});
-  run.insert<Data::Table>("comment", {}, {comment});
+  comment.insert(Data::String{}, "", {Dim::Row, 1}, {"first run"});
+  run.insert(Data::Table{}, "comment", {}, {comment});
   Dataset timeSeriesLog;
-  timeSeriesLog.insert<Coord::Time>({Dim::Time, 3}, {0, 1000, 1500});
-  timeSeriesLog.insert<Data::Value>("pressure1", {Dim::Time, 3},
-                                    {1013, 900, 800});
-  timeSeriesLog.insert<Data::Value>("pressure2", {Dim::Time, 3}, {100, 90, 80});
-  run.insert<Data::Table>("pressure_log", {}, {timeSeriesLog});
+  timeSeriesLog.insert(Coord::Time{}, {Dim::Time, 3}, {0, 1000, 1500});
+  timeSeriesLog.insert(Data::Value{}, "pressure1", {Dim::Time, 3},
+                       {1013, 900, 800});
+  timeSeriesLog.insert(Data::Value{}, "pressure2", {Dim::Time, 3},
+                       {100, 90, 80});
+  run.insert(Data::Table{}, "pressure_log", {}, {timeSeriesLog});
   Dataset otherLogEntries;
-  otherLogEntries.insert<Data::Table>("root", {Dim::Row, 1});
-  run.insert<Data::Table>("generic_log", {Dim::Row, 1}, {otherLogEntries});
+  otherLogEntries.insert(Data::Table{}, "root", {Dim::Row, 1});
+  run.insert(Data::Table{}, "generic_log", {Dim::Row, 1}, {otherLogEntries});
   return run;
 }
 
@@ -34,7 +35,7 @@ TEST(Run, meta_data_propagation) {
   Dataset run1 = makeRun();
 
   Dataset d1;
-  d1.insert<Attr::ExperimentLog>("sample_log", {}, {run1});
+  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {run1});
 
   EXPECT_NO_THROW(d1 += d1);
 
@@ -42,14 +43,12 @@ TEST(Run, meta_data_propagation) {
   run2.get<Data::Value>("total_counts")[0] = 1111;
   run2.get<Coord::FuzzyTemperature>()[0] = ValueWithDelta<double>(4.15, 0.1);
   run2.get<Data::Table>("comment")[0].get<Data::String>()[0] = "second run";
-  run2.get<Data::Table>("generic_log")[0]
-      .get<Data::Table>("root")[0]
-      .insert<Data::String>(
-          "user comment", {},
-          {"Spider walked through beam, verify data before publishing."});
+  run2.get<Data::Table>("generic_log")[0].get<Data::Table>("root")[0].insert(
+      Data::String{}, "user comment", {},
+      {"Spider walked through beam, verify data before publishing."});
 
   Dataset d2;
-  d2.insert<Attr::ExperimentLog>("sample_log", {}, {run2});
+  d2.insert(Attr::ExperimentLog{}, "sample_log", {}, {run2});
 
   // Behavior of `Attr` variables is specific to the implementation of each
   // operation. In most cases we simply copy the first one, exceptions are
@@ -113,7 +112,7 @@ TEST(Run, meta_data_propagation) {
 
 TEST(Run, meta_data_fail_coord_mismatch) {
   Dataset d1;
-  d1.insert<Attr::ExperimentLog>("sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
   auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];
@@ -125,7 +124,7 @@ TEST(Run, meta_data_fail_coord_mismatch) {
 
 TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
   Dataset d1;
-  d1.insert<Attr::ExperimentLog>("sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
   auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];
@@ -137,7 +136,7 @@ TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
 
 TEST(Run, meta_data_fail_missing) {
   Dataset d1;
-  d1.insert<Attr::ExperimentLog>("sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
   auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -14,13 +14,13 @@
 std::vector<std::string> asStrings(const Variable &variable) {
   std::vector<std::string> strings;
   if (variable.tag() == Coord::RowLabel{})
-    for (const auto &value : variable.get<const Coord::RowLabel>())
+    for (const auto &value : variable.get<Coord::RowLabel>())
       strings.emplace_back(value);
   if (variable.tag() == Data::Value{})
-    for (const auto &value : variable.get<const Data::Value>())
+    for (const auto &value : variable.get<Data::Value>())
       strings.emplace_back(std::to_string(value));
   else if (variable.tag() == Data::String{})
-    for (const auto &value : variable.get<const Data::String>())
+    for (const auto &value : variable.get<Data::String>())
       strings.emplace_back(value);
   return strings;
 }
@@ -28,7 +28,7 @@ std::vector<std::string> asStrings(const Variable &variable) {
 TEST(TableWorkspace, basics) {
   Dataset table;
   table.insert(Coord::RowLabel{}, {Dim::Row, 3},
-                                Vector<std::string>{"a", "b", "c"});
+               Vector<std::string>{"a", "b", "c"});
   table.insert(Data::Value{}, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
   table.insert(Data::String{}, "", {Dim::Row, 3}, 3);
 
@@ -48,14 +48,14 @@ TEST(TableWorkspace, basics) {
   // Standard shape operations provide basic things required for tables:
   auto mergedTable = concatenate(table, table, Dim::Row);
   Dataset row = table(Dim::Row, 1, 2);
-  EXPECT_EQ(row.get<const Coord::RowLabel>()[0], "b");
+  EXPECT_EQ(row.get<Coord::RowLabel>()[0], "b");
 
   // Slice a range to obtain a new table with a subset of rows.
   Dataset rows = mergedTable(Dim::Row, 1, 4);
-  ASSERT_EQ(rows.get<const Coord::RowLabel>().size(), 3);
-  EXPECT_EQ(rows.get<const Coord::RowLabel>()[0], "b");
-  EXPECT_EQ(rows.get<const Coord::RowLabel>()[1], "c");
-  EXPECT_EQ(rows.get<const Coord::RowLabel>()[2], "a");
+  ASSERT_EQ(rows.get<Coord::RowLabel>().size(), 3);
+  EXPECT_EQ(rows.get<Coord::RowLabel>()[0], "b");
+  EXPECT_EQ(rows.get<Coord::RowLabel>()[1], "c");
+  EXPECT_EQ(rows.get<Coord::RowLabel>()[2], "a");
 
   // Can sort by arbitrary column.
   auto sortedTable = sort(table, Data::Value{});

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -27,10 +27,10 @@ std::vector<std::string> asStrings(const Variable &variable) {
 
 TEST(TableWorkspace, basics) {
   Dataset table;
-  table.insert<Coord::RowLabel>({Dim::Row, 3},
+  table.insert(Coord::RowLabel{}, {Dim::Row, 3},
                                 Vector<std::string>{"a", "b", "c"});
-  table.insert<Data::Value>("", {Dim::Row, 3}, {1.0, -2.0, 3.0});
-  table.insert<Data::String>("", {Dim::Row, 3}, 3);
+  table.insert(Data::Value{}, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
+  table.insert(Data::String{}, "", {Dim::Row, 3}, 3);
 
   // Modify table with know columns.
   MDZipView<const Data::Value, Data::String> view(table);

--- a/test/Workspace2D_test.cpp
+++ b/test/Workspace2D_test.cpp
@@ -131,10 +131,10 @@ TEST(Workspace2D, multiple_data) {
   // Note: If we want to also keep "background" we can use:
   // d["sample"] -= d["background"];
 
-  EXPECT_NO_THROW(d.get<const Data::Value>("sample"));
-  EXPECT_NO_THROW(d.get<const Data::Variance>("sample"));
-  // EXPECT_NO_THROW(d.get<const Data::Value>("monitor"));
-  EXPECT_ANY_THROW(d.get<const Data::Value>("background"));
+  EXPECT_NO_THROW(d.get<Data::Value>("sample"));
+  EXPECT_NO_THROW(d.get<Data::Variance>("sample"));
+  // EXPECT_NO_THROW(d.get<Data::Value>("monitor"));
+  EXPECT_ANY_THROW(d.get<Data::Value>("background"));
 }
 
 TEST(Workspace2D, scanning) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -17,9 +17,9 @@ TEST(Dataset, construct) { ASSERT_NO_THROW(Dataset d); }
 
 TEST(Dataset, insert_coords) {
   Dataset d;
-  d.insert<Coord::Tof>(Dimensions{}, {1.1});
-  d.insert<Coord::SpectrumNumber>(Dimensions{}, {2});
-  EXPECT_THROW_MSG(d.insert<Coord::SpectrumNumber>(Dimensions{}, {2}),
+  d.insert(Coord::Tof{}, Dimensions{}, {1.1});
+  d.insert(Coord::SpectrumNumber{}, Dimensions{}, {2});
+  EXPECT_THROW_MSG(d.insert(Coord::SpectrumNumber{}, Dimensions{}, {2}),
                    std::runtime_error,
                    "Attempt to insert duplicate coordinate.");
   ASSERT_EQ(d.size(), 2);
@@ -27,9 +27,9 @@ TEST(Dataset, insert_coords) {
 
 TEST(Dataset, insert_data) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Int>("name2", Dimensions{}, {2});
-  EXPECT_THROW_MSG(d.insert<Data::Int>("name2", Dimensions{}, {2}),
+  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
+  EXPECT_THROW_MSG(d.insert(Data::Int{}, "name2", Dimensions{}, {2}),
                    std::runtime_error,
                    "Attempt to insert data of same type with duplicate name.");
   ASSERT_EQ(d.size(), 2);
@@ -37,8 +37,8 @@ TEST(Dataset, insert_data) {
 
 TEST(Dataset, insert_variables_with_dimensions) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions(Dim::Tof, 2), {1.1, 2.2});
-  d.insert<Data::Int>("name2", Dimensions{}, {2});
+  d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 2), {1.1, 2.2});
+  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
 }
 
 TEST(Dataset, insert_variables_different_order) {
@@ -53,55 +53,55 @@ TEST(Dataset, insert_variables_different_order) {
   yz.add(Dim::Z, 3);
 
   Dataset xyz;
-  xyz.insert<Data::Value>("name1", xy, 2);
-  EXPECT_NO_THROW(xyz.insert<Data::Value>("name2", yz, 6));
-  EXPECT_NO_THROW(xyz.insert<Data::Value>("name3", xz, 3));
+  xyz.insert(Data::Value{}, "name1", xy, 2);
+  EXPECT_NO_THROW(xyz.insert(Data::Value{}, "name2", yz, 6));
+  EXPECT_NO_THROW(xyz.insert(Data::Value{}, "name3", xz, 3));
 
   Dataset xzy;
-  xzy.insert<Data::Value>("name1", xz, 3);
-  EXPECT_NO_THROW(xzy.insert<Data::Value>("name2", xy, 2));
-  EXPECT_NO_THROW(xzy.insert<Data::Value>("name3", yz, 6));
+  xzy.insert(Data::Value{}, "name1", xz, 3);
+  EXPECT_NO_THROW(xzy.insert(Data::Value{}, "name2", xy, 2));
+  EXPECT_NO_THROW(xzy.insert(Data::Value{}, "name3", yz, 6));
 }
 
 TEST(Dataset, insert_edges) {
   Dataset d;
-  d.insert<Data::Value>("name1", {Dim::Tof, 2});
+  d.insert(Data::Value{}, "name1", {Dim::Tof, 2});
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
-  EXPECT_NO_THROW(d.insert<Coord::Tof>({Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
 }
 
 TEST(Dataset, insert_edges_first) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert<Coord::Tof>({Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
-  EXPECT_NO_THROW(d.insert<Data::Value>("name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
 }
 
 TEST(Dataset, insert_edges_first_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert<Coord::Tof>({Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
-  EXPECT_NO_THROW(d.insert<Data::Value>("name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
   // Once we have edges and non-edges dimensions cannot change further.
   EXPECT_THROW_MSG(
-      d.insert<Data::Value>("name2", {Dim::Tof, 1}), std::runtime_error,
+      d.insert(Data::Value{}, "name2", {Dim::Tof, 1}), std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
-  EXPECT_THROW_MSG(d.insert<Coord::Tof>({Dim::Tof, 4}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 4}), std::runtime_error,
                    "Attempt to insert duplicate coordinate.");
 }
 
 TEST(Dataset, insert_edges_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert<Data::Value>("name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
-  EXPECT_THROW_MSG(d.insert<Coord::Tof>({Dim::Tof, 4}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 4}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
                    "dimension coordiante, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
-  EXPECT_THROW_MSG(d.insert<Coord::Tof>({Dim::Tof, 1}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 1}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
                    "dimension coordiante, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
@@ -109,33 +109,53 @@ TEST(Dataset, insert_edges_fail) {
 
 TEST(Dataset, insert_edges_reverse_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert<Coord::Tof>({Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
   EXPECT_THROW_MSG(
-      d.insert<Data::Value>("name1", Dimensions(Dim::Tof, 1)),
+      d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 1)),
       std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
   EXPECT_THROW_MSG(
-      d.insert<Data::Value>("name1", Dimensions(Dim::Tof, 4)),
+      d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 4)),
       std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
 }
 
 TEST(Dataset, can_use_normal_insert_to_copy_edges) {
   Dataset d;
-  d.insert<Data::Value>("", {Dim::X, 2});
-  d.insert<Coord::X>({Dim::X, 3});
+  d.insert(Data::Value{}, "", {Dim::X, 2});
+  d.insert(Coord::X{}, {Dim::X, 3});
 
   Dataset copy;
   for (auto var : d)
     EXPECT_NO_THROW(copy.insert(var));
 }
 
+TEST(Dataset, custom_type) {
+  Dataset d;
+  d.insert<float>(Data::Value{}, "", {Dim::Tof, 2});
+  EXPECT_EQ(d(Data::Value{}, "").dtype(), dtype<float>);
+  EXPECT_TRUE(
+      (std::is_same<decltype(d(Data::Value{}, "").span<float>())::element_type,
+                    float>::value));
+}
+
+TEST(Dataset, mixed_type_operations_fails_currently) {
+  // This *currently* fails, but we would eventually want to support this.
+  Dataset d1;
+  d1.insert<float>(Data::Value{}, "", {});
+  Dataset d2;
+  d2.insert<double>(Data::Value{}, "", {});
+  EXPECT_NO_THROW(d1 += d1);
+  EXPECT_NO_THROW(d2 += d2);
+  EXPECT_ANY_THROW(d1 += d2);
+}
+
 TEST(Dataset, get_variable_view) {
   Dataset d;
-  d.insert<Data::Value>("", {});
-  d.insert<Data::Value>("name", {});
-  d.insert<Coord::X>({});
+  d.insert(Data::Value{}, "", {});
+  d.insert(Data::Value{}, "name", {});
+  d.insert(Coord::X{}, {});
 
   EXPECT_EQ(d(Coord::X{}).tag(), Coord::X{});
   EXPECT_EQ(d(Data::Value{}, "").tag(), Data::Value{});
@@ -149,9 +169,9 @@ TEST(Dataset, get_variable_view) {
 
 TEST(Dataset, extract) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Variance>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Int>("name2", Dimensions{}, {2});
+  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Variance{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
   EXPECT_EQ(d.size(), 3);
   auto name1 = d.extract("name1");
   EXPECT_EQ(d.size(), 1);
@@ -163,9 +183,9 @@ TEST(Dataset, extract) {
 
 TEST(Dataset, merge) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Variance>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Int>("name2", Dimensions{}, {2});
+  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Variance{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
 
   Dataset merged;
   merged.merge(d);
@@ -174,19 +194,19 @@ TEST(Dataset, merge) {
                    "Attempt to insert data of same type with duplicate name.");
 
   Dataset d2;
-  d2.insert<Data::Value>("name3", Dimensions{}, {1.1});
+  d2.insert(Data::Value{}, "name3", Dimensions{}, {1.1});
   merged.merge(d2);
   EXPECT_EQ(merged.size(), 4);
 }
 
 TEST(Dataset, merge_matching_coordinates) {
   Dataset d1;
-  d1.insert<Coord::X>({Dim::X, 2}, {1.1, 2.2});
-  d1.insert<Data::Value>("data1", {Dim::X, 2});
+  d1.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
+  d1.insert(Data::Value{}, "data1", {Dim::X, 2});
 
   Dataset d2;
-  d2.insert<Coord::X>({Dim::X, 2}, {1.1, 2.2});
-  d2.insert<Data::Value>("data2", {Dim::X, 2});
+  d2.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
+  d2.insert(Data::Value{}, "data2", {Dim::X, 2});
 
   ASSERT_NO_THROW(d1.merge(d2));
   EXPECT_EQ(d1.size(), 3);
@@ -194,12 +214,12 @@ TEST(Dataset, merge_matching_coordinates) {
 
 TEST(Dataset, merge_coord_mismatch_fail) {
   Dataset d1;
-  d1.insert<Coord::X>({Dim::X, 2}, {1.1, 2.2});
-  d1.insert<Data::Value>("data1", {Dim::X, 2});
+  d1.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
+  d1.insert(Data::Value{}, "data1", {Dim::X, 2});
 
   Dataset d2;
-  d2.insert<Coord::X>({Dim::X, 2}, {1.1, 2.3});
-  d2.insert<Data::Value>("data2", {Dim::X, 2});
+  d2.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.3});
+  d2.insert(Data::Value{}, "data2", {Dim::X, 2});
 
   EXPECT_THROW_MSG(d1.merge(d2), std::runtime_error,
                    "Cannot merge: Coordinates do not match.");
@@ -207,8 +227,8 @@ TEST(Dataset, merge_coord_mismatch_fail) {
 
 TEST(Dataset, const_get) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions{}, {1.1});
-  d.insert<Data::Int>("", Dimensions{}, {2});
+  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "", Dimensions{}, {2});
   const auto &const_d(d);
   auto view = const_d.get<Data::Value>();
   // No non-const access to variable if Dataset is const, will not compile:
@@ -221,8 +241,8 @@ TEST(Dataset, const_get) {
 
 TEST(Dataset, get) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions{}, {1.1});
-  d.insert<Data::Int>("", Dimensions{}, {2});
+  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "", Dimensions{}, {2});
   auto view = d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
@@ -232,8 +252,8 @@ TEST(Dataset, get) {
 
 TEST(Dataset, get_const) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions{}, {1.1});
-  d.insert<Data::Int>("", Dimensions{}, {2});
+  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "", Dimensions{}, {2});
   auto view = d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
@@ -243,8 +263,8 @@ TEST(Dataset, get_const) {
 
 TEST(Dataset, get_fail) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Value>("name2", Dimensions{}, {1.1});
+  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Value{}, "name2", Dimensions{}, {1.1});
   EXPECT_THROW_MSG(d.get<Data::Value>(), std::runtime_error,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Value and name ``.");
@@ -255,8 +275,8 @@ TEST(Dataset, get_fail) {
 
 TEST(Dataset, get_named) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  d.insert<Data::Value>("name2", Dimensions{}, {2.2});
+  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  d.insert(Data::Value{}, "name2", Dimensions{}, {2.2});
   auto var1 = d.get<Data::Value>("name1");
   ASSERT_EQ(var1.size(), 1);
   EXPECT_EQ(var1[0], 1.1);
@@ -267,8 +287,8 @@ TEST(Dataset, get_named) {
 
 TEST(Dataset, operator_plus_equal) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   a += a;
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
   EXPECT_EQ(a.get<Data::Value>()[0], 4.4);
@@ -276,12 +296,13 @@ TEST(Dataset, operator_plus_equal) {
 
 TEST(Dataset, operator_plus_equal_broadcast) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "",
+           Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("", Dimensions({{Dim::Z, 3}}), {0.1, 0.2, 0.3});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "", Dimensions({{Dim::Z, 3}}), {0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
@@ -295,13 +316,14 @@ TEST(Dataset, operator_plus_equal_broadcast) {
 
 TEST(Dataset, operator_plus_equal_transpose) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "",
+           Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("", Dimensions({{Dim::Y, 2}, {Dim::Z, 3}}),
-                        {0.1, 0.2, 0.3, 0.1, 0.2, 0.3});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "", Dimensions({{Dim::Y, 2}, {Dim::Z, 3}}),
+           {0.1, 0.2, 0.3, 0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
@@ -315,12 +337,12 @@ TEST(Dataset, operator_plus_equal_transpose) {
 
 TEST(Dataset, operator_plus_equal_different_content) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("name1", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "name1", {Dim::X, 1}, {2.2});
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("name1", {Dim::X, 1}, {2.2});
-  b.insert<Data::Value>("name2", {Dim::X, 1}, {3.3});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {2.2});
+  b.insert(Data::Value{}, "name2", {Dim::X, 1}, {3.3});
   EXPECT_THROW_MSG(a += b, std::runtime_error,
                    "Right-hand-side in binary operation contains variable that "
                    "is not present in left-hand-side.");
@@ -329,11 +351,11 @@ TEST(Dataset, operator_plus_equal_different_content) {
 
 TEST(Dataset, operator_plus_equal_with_attributes) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   Dataset logs;
-  logs.insert<Data::String>("comments", {}, {std::string("test")});
-  a.insert<Attr::ExperimentLog>("", {}, {logs});
+  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
   a += a;
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
   EXPECT_EQ(a.get<Data::Value>()[0], 4.4);
@@ -344,8 +366,8 @@ TEST(Dataset, operator_plus_equal_with_attributes) {
 
 TEST(Dataset, operator_times_equal) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {3.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
   a *= a;
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
   EXPECT_EQ(a.get<Data::Value>()[0], 9.0);
@@ -353,11 +375,11 @@ TEST(Dataset, operator_times_equal) {
 
 TEST(Dataset, operator_times_equal_with_attributes) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {3.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
   Dataset logs;
-  logs.insert<Data::String>("comments", {}, {std::string("test")});
-  a.insert<Attr::ExperimentLog>("", {}, {logs});
+  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
   a *= a;
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
   EXPECT_EQ(a.get<Data::Value>()[0], 9.0);
@@ -366,13 +388,13 @@ TEST(Dataset, operator_times_equal_with_attributes) {
 
 TEST(Dataset, operator_times_equal_with_uncertainty) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {3.0});
-  a.insert<Data::Variance>("", {Dim::X, 1}, {2.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
+  a.insert(Data::Variance{}, "", {Dim::X, 1}, {2.0});
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("", {Dim::X, 1}, {4.0});
-  b.insert<Data::Variance>("", {Dim::X, 1}, {3.0});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "", {Dim::X, 1}, {4.0});
+  b.insert(Data::Variance{}, "", {Dim::X, 1}, {3.0});
   a *= b;
   EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
   EXPECT_EQ(a.get<Data::Value>()[0], 12.0);
@@ -381,15 +403,15 @@ TEST(Dataset, operator_times_equal_with_uncertainty) {
 
 TEST(Dataset, operator_times_equal_uncertainty_failures) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("name1", {Dim::X, 1}, {3.0});
-  a.insert<Data::Variance>("name1", {Dim::X, 1}, {2.0});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "name1", {Dim::X, 1}, {3.0});
+  a.insert(Data::Variance{}, "name1", {Dim::X, 1}, {2.0});
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("name1", {Dim::X, 1}, {4.0});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {4.0});
   Dataset c;
-  c.insert<Coord::X>({Dim::X, 1}, {0.1});
-  c.insert<Data::Variance>("name1", {Dim::X, 1}, {2.0});
+  c.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  c.insert(Data::Variance{}, "name1", {Dim::X, 1}, {2.0});
   EXPECT_THROW_MSG(a *= b, std::runtime_error,
                    "Either both or none of the operands must have a variance "
                    "for their values.");
@@ -415,7 +437,7 @@ TEST(Dataset, operator_times_equal_uncertainty_failures) {
 
 TEST(Dataset, operator_times_equal_with_units) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
   Variable values(Data::Value{}, Dimensions({{Dim::X, 1}}), {3.0});
   values.setUnit(Unit::Id::Length);
   Variable variances(Data::Variance{}, Dimensions({{Dim::X, 1}}), {2.0});
@@ -430,7 +452,7 @@ TEST(Dataset, operator_times_equal_with_units) {
 
 TEST(Dataset, operator_times_equal_histogram_data) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
   Variable values(Data::Value{}, Dimensions({{Dim::X, 1}}), {3.0});
   values.setName("name1");
   values.setUnit(Unit::Id::Counts);
@@ -441,9 +463,9 @@ TEST(Dataset, operator_times_equal_histogram_data) {
   a.insert(variances);
 
   Dataset b;
-  b.insert<Coord::X>({Dim::X, 1}, {0.1});
-  b.insert<Data::Value>("name1", {Dim::X, 1}, {4.0});
-  b.insert<Data::Variance>("name1", {Dim::X, 1}, {4.0});
+  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {4.0});
+  b.insert(Data::Variance{}, "name1", {Dim::X, 1}, {4.0});
 
   // Counts (aka "histogram data") times counts not possible.
   EXPECT_THROW_MSG(a *= a, std::runtime_error, "Unsupported unit on LHS");
@@ -457,7 +479,7 @@ TEST(Dataset, operator_times_equal_histogram_data) {
 
 TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
   Dataset a;
-  a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   const auto a2(a);
   const auto b(a);
 
@@ -472,9 +494,9 @@ TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
 
 TEST(Dataset, slice) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, {0.0, 0.1});
-  d.insert<Data::Value>("", {{Dim::Y, 3}, {Dim::X, 2}},
-                        {0.0, 1.0, 2.0, 3.0, 4.0, 5.0});
+  d.insert(Coord::X{}, {Dim::X, 2}, {0.0, 0.1});
+  d.insert(Data::Value{}, "", {{Dim::Y, 3}, {Dim::X, 2}},
+           {0.0, 1.0, 2.0, 3.0, 4.0, 5.0});
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i);
     ASSERT_EQ(sliceX.size(), 1);
@@ -511,8 +533,8 @@ TEST(Dataset, slice) {
 
 TEST(Dataset, concatenate_constant_dimension_broken) {
   Dataset a;
-  a.insert<Data::Value>("name1", Dimensions{}, {1.1});
-  a.insert<Data::Value>("name2", Dimensions{}, {2.2});
+  a.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
+  a.insert(Data::Value{}, "name2", Dimensions{}, {2.2});
   auto d = concatenate(a, a, Dim::X);
   // TODO Special case: No variable depends on X so the result does not contain
   // this dimension either. Change this behavior?!
@@ -521,8 +543,8 @@ TEST(Dataset, concatenate_constant_dimension_broken) {
 
 TEST(Dataset, concatenate) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
   EXPECT_EQ(x.get<Coord::X>().size(), 2);
@@ -546,18 +568,18 @@ TEST(Dataset, concatenate) {
 
 TEST(Dataset, concatenate_with_bin_edges) {
   Dataset ds;
-  ds.insert<Coord::X>({Dim::X, 2}, {0.1, 0.2});
-  ds.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  ds.insert(Coord::X{}, {Dim::X, 2}, {0.1, 0.2});
+  ds.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   EXPECT_NO_THROW(concatenate(ds, ds, Dim::Y));
 
   Dataset not_edge;
-  not_edge.insert<Coord::X>({Dim::X, 1}, {0.3});
-  not_edge.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  not_edge.insert(Coord::X{}, {Dim::X, 1}, {0.3});
+  not_edge.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   EXPECT_THROW_MSG(
       concatenate(ds, not_edge, Dim::X), std::runtime_error,
       "Cannot concatenate: Second variable is not an edge variable.");
   not_edge.erase(Coord::X{});
-  not_edge.insert<Coord::X>({}, {0.3});
+  not_edge.insert(Coord::X{}, {}, {0.3});
   EXPECT_THROW_MSG(concatenate(ds, not_edge, Dim::X),
                    dataset::except::DimensionNotFoundError,
                    "Expected dimension to be in {}, got Dim::X.");
@@ -567,8 +589,8 @@ TEST(Dataset, concatenate_with_bin_edges) {
                    "does not match first bin edge of second edge variable.");
 
   Dataset ds2;
-  ds2.insert<Coord::X>({Dim::X, 2}, {0.2, 0.3});
-  ds2.insert<Data::Value>("", {Dim::X, 1}, {3.3});
+  ds2.insert(Coord::X{}, {Dim::X, 2}, {0.2, 0.3});
+  ds2.insert(Data::Value{}, "", {Dim::X, 1}, {3.3});
 
   Dataset merged;
   EXPECT_NO_THROW(merged = concatenate(ds, ds2, Dim::X));
@@ -580,12 +602,12 @@ TEST(Dataset, concatenate_with_bin_edges) {
 
 TEST(Dataset, concatenate_with_varying_bin_edges) {
   Dataset ds;
-  ds.insert<Coord::X>({{Dim::Y, 2}, {Dim::X, 2}}, {0.1, 0.2, 0.11, 0.21});
-  ds.insert<Data::Value>("", {{Dim::Y, 2}, {Dim::X, 1}}, {2.2, 3.3});
+  ds.insert(Coord::X{}, {{Dim::Y, 2}, {Dim::X, 2}}, {0.1, 0.2, 0.11, 0.21});
+  ds.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 1}}, {2.2, 3.3});
 
   Dataset ds2;
-  ds2.insert<Coord::X>({{Dim::Y, 2}, {Dim::X, 2}}, {0.2, 0.3, 0.21, 0.31});
-  ds2.insert<Data::Value>("", {{Dim::Y, 2}, {Dim::X, 1}}, {4.4, 5.5});
+  ds2.insert(Coord::X{}, {{Dim::Y, 2}, {Dim::X, 2}}, {0.2, 0.3, 0.21, 0.31});
+  ds2.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 1}}, {4.4, 5.5});
 
   Dataset merged;
   merged = concatenate(ds, ds2, Dim::X);
@@ -602,11 +624,11 @@ TEST(Dataset, concatenate_with_varying_bin_edges) {
 
 TEST(Dataset, concatenate_with_attributes) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 1}, {0.1});
-  a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   Dataset logs;
-  logs.insert<Data::String>("comments", {}, {std::string("test")});
-  a.insert<Attr::ExperimentLog>("", {}, {logs});
+  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
 
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
@@ -674,7 +696,7 @@ TEST(Dataset, rebin_failures) {
                    "histogram data first.");
   d.erase(Coord::X{});
   d.insert(coord);
-  d.insert<Data::Value>("badAuxDim", Dimensions({{Dim::X, 2}, {Dim::Y, 2}}));
+  d.insert(Data::Value{}, "badAuxDim", Dimensions({{Dim::X, 2}, {Dim::Y, 2}}));
   Variable badAuxDim(Coord::X{}, Dimensions({{Dim::X, 3}, {Dim::Y, 3}}));
   EXPECT_THROW_MSG(rebin(d, badAuxDim), std::runtime_error,
                    "Size mismatch in auxiliary dimension of new coordinate.");
@@ -682,7 +704,7 @@ TEST(Dataset, rebin_failures) {
 
 TEST(Dataset, rebin) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 3}, {1.0, 3.0, 5.0});
+  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 3.0, 5.0});
   Variable coordNew(Coord::X{}, {Dim::X, 2}, {1.0, 5.0});
   // With only the coord in the dataset there is no way to tell it is an edge,
   // so this fails.
@@ -691,7 +713,7 @@ TEST(Dataset, rebin) {
                    "coordinate. Use `resample` instead of rebin or convert to "
                    "histogram data first.");
 
-  d.insert<Data::Value>("", {Dim::X, 2}, {10.0, 20.0});
+  d.insert(Data::Value{}, "", {Dim::X, 2}, {10.0, 20.0});
   auto rebinned = rebin(d, coordNew);
   EXPECT_EQ(rebinned.get<Data::Value>().size(), 1);
   EXPECT_EQ(rebinned.get<Data::Value>()[0], 30.0);
@@ -699,11 +721,11 @@ TEST(Dataset, rebin) {
 
 Dataset makeEvents() {
   Dataset e1;
-  e1.insert<Data::Tof>("", {Dim::Event, 5}, {1, 2, 3, 4, 5});
+  e1.insert(Data::Tof{}, "", {Dim::Event, 5}, {1, 2, 3, 4, 5});
   Dataset e2;
-  e2.insert<Data::Tof>("", {Dim::Event, 7}, {1, 2, 3, 4, 4, 5, 7});
+  e2.insert(Data::Tof{}, "", {Dim::Event, 7}, {1, 2, 3, 4, 4, 5, 7});
   Dataset d;
-  d.insert<Data::Events>("sample1", {Dim::Spectrum, 2}, {e1, e2});
+  d.insert(Data::Events{}, "sample1", {Dim::Spectrum, 2}, {e1, e2});
   return d;
 }
 
@@ -778,9 +800,9 @@ TEST(Dataset, histogram_2D_transpose_coord) {
 
 TEST(Dataset, sort) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1.0, 0.9});
-  d.insert<Data::Value>("", {Dim::X, 4}, {1.0, 2.0, 3.0, 4.0});
+  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value{}, "", {Dim::X, 4}, {1.0, 2.0, 3.0, 4.0});
 
   auto sorted = sort(d, Coord::X{});
 
@@ -803,10 +825,10 @@ TEST(Dataset, sort) {
 
 TEST(Dataset, sort_2D) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1.0, 0.9});
-  d.insert<Data::Value>("", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
 
   auto sorted = sort(d, Coord::X{});
 
@@ -833,10 +855,10 @@ TEST(Dataset, sort_2D) {
 
 TEST(Dataset, filter) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1.0, 0.9});
-  d.insert<Data::Value>("", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
   Variable select(Coord::Mask{}, {Dim::X, 4}, {false, true, false, true});
 
   auto filtered = filter(d, select);
@@ -858,8 +880,8 @@ TEST(Dataset, filter) {
 
 TEST(Dataset, integrate) {
   Dataset ds;
-  ds.insert<Coord::X>({Dim::X, 3}, {0.1, 0.2, 0.4});
-  ds.insert<Data::Value>("", {Dim::X, 2}, {10.0, 20.0});
+  ds.insert(Coord::X{}, {Dim::X, 3}, {0.1, 0.2, 0.4});
+  ds.insert(Data::Value{}, "", {Dim::X, 2}, {10.0, 20.0});
 
   Dataset integral;
   EXPECT_NO_THROW(integral = integrate(ds, Dim::X));
@@ -872,12 +894,12 @@ TEST(Dataset, integrate) {
 
 TEST(DatasetSlice, basics) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4});
-  d.insert<Coord::Y>({Dim::Y, 2});
-  d.insert<Data::Value>("a", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert<Data::Value>("b", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert<Data::Variance>("a", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert<Data::Variance>("b", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Coord::X{}, {Dim::X, 4});
+  d.insert(Coord::Y{}, {Dim::Y, 2});
+  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}});
 
   ConstDatasetSlice viewA(d, "a");
   ConstDatasetSlice viewB(d, "b");
@@ -902,12 +924,12 @@ TEST(DatasetSlice, basics) {
 
 TEST(DatasetSlice, minus_equals) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4});
-  d.insert<Coord::Y>({Dim::Y, 2});
-  d.insert<Data::Value>("a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert<Data::Value>("b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert<Data::Variance>("a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert<Data::Variance>("b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Coord::X{}, {Dim::X, 4});
+  d.insert(Coord::Y{}, {Dim::Y, 2});
+  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
 
   EXPECT_NO_THROW(d -= d["a"]);
 
@@ -928,12 +950,12 @@ TEST(DatasetSlice, minus_equals) {
 
 TEST(DatasetSlice, slice_spatial) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {1, 2, 3, 4});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1, 2});
-  d.insert<Data::Value>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Variance>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Coord::X{}, {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_x13 = d(Dim::X, 1, 3);
   ASSERT_EQ(view_x13.size(), 4);
@@ -945,16 +967,16 @@ TEST(DatasetSlice, slice_spatial) {
 
 TEST(DatasetSlice, subset_slice_spatial) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {1, 2, 3, 4});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1, 2});
-  d.insert<Data::Value>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Value>("b", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Variance>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                           {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Variance>("b", {{Dim::Y, 2}, {Dim::X, 4}},
-                           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Coord::X{}, {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_a_x0 = d["a"](Dim::X, 0);
 
@@ -993,16 +1015,16 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
 TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 5}, {1, 2, 3, 4, 5});
-  d.insert<Coord::Y>({Dim::Y, 2}, {1, 2});
-  d.insert<Data::Value>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Value>("b", {{Dim::Y, 2}, {Dim::X, 4}},
-                        {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Variance>("a", {{Dim::Y, 2}, {Dim::X, 4}},
-                           {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert<Data::Variance>("b", {{Dim::Y, 2}, {Dim::X, 4}},
-                           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Coord::X{}, {Dim::X, 5}, {1, 2, 3, 4, 5});
+  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
+  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+           {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_a_x0 = d["a"](Dim::X, 0);
 
@@ -1060,11 +1082,11 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
 TEST(Dataset, unary_minus) {
   Dataset a;
-  a.insert<Coord::X>({Dim::X, 2}, {1, 2});
-  a.insert<Data::Value>("a", {Dim::X, 2}, {1, 2});
-  a.insert<Data::Value>("b", {}, {3});
-  a.insert<Data::Variance>("a", {Dim::X, 2}, {4, 5});
-  a.insert<Data::Variance>("b", {}, {6});
+  a.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
+  a.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
+  a.insert(Data::Value{}, "b", {}, {3});
+  a.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
+  a.insert(Data::Variance{}, "b", {}, {6});
 
   auto b = -a;
   EXPECT_EQ(b(Coord::X{}), a(Coord::X{}));
@@ -1077,11 +1099,11 @@ TEST(Dataset, unary_minus) {
 
 TEST(Dataset, binary_assign_with_scalar) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("d1", {Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("d2", {}, {3});
-  d.insert<Data::Variance>("d1", {Dim::X, 2}, {4, 5});
-  d.insert<Data::Variance>("d2", {}, {6});
+  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "d1", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "d2", {}, {3});
+  d.insert(Data::Variance{}, "d1", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance{}, "d2", {}, {6});
 
   d += 1;
   EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {2, 3}));
@@ -1107,11 +1129,11 @@ TEST(Dataset, binary_assign_with_scalar) {
 
 TEST(DatasetSlice, binary_assign_with_scalar) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("a", {Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("b", {}, {3});
-  d.insert<Data::Variance>("a", {Dim::X, 2}, {4, 5});
-  d.insert<Data::Variance>("b", {}, {6});
+  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "b", {}, {3});
+  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance{}, "b", {}, {6});
 
   auto slice = d(Dim::X, 1);
 
@@ -1143,11 +1165,11 @@ TEST(DatasetSlice, binary_assign_with_scalar) {
 
 TEST(Dataset, binary_with_scalar) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("a", {Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("b", {}, {3});
-  d.insert<Data::Variance>("a", {Dim::X, 2}, {4, 5});
-  d.insert<Data::Variance>("b", {}, {6});
+  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "b", {}, {3});
+  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance{}, "b", {}, {6});
 
   auto sum = d + 1;
   EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {2, 3}));
@@ -1185,11 +1207,11 @@ TEST(Dataset, binary_with_scalar) {
 
 TEST(DatasetSlice, binary_with_scalar) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("a", {Dim::X, 2}, {1, 2});
-  d.insert<Data::Value>("b", {}, {3});
-  d.insert<Data::Variance>("a", {Dim::X, 2}, {4, 5});
-  d.insert<Data::Variance>("b", {}, {6});
+  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value{}, "b", {}, {3});
+  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance{}, "b", {}, {6});
 
   auto slice = d(Dim::X, 1);
 
@@ -1233,20 +1255,19 @@ TEST(DatasetSlice, binary_with_scalar) {
 Dataset makeTofDataForUnitConversion() {
   Dataset tof;
 
-  tof.insert<Coord::Tof>({Dim::Tof, 4}, {1000, 2000, 3000, 4000});
+  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1000, 2000, 3000, 4000});
 
   Dataset components;
   // Source and sample
-  components.insert<Coord::Position>(
-      {Dim::Component, 2},
+  components.insert(
+      Coord::Position{}, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert<Coord::ComponentInfo>({}, {components});
-  tof.insert<Coord::Position>(
-      {Dim::Spectrum, 2},
-      {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.1, 0.0, 1.0}});
+  tof.insert(Coord::ComponentInfo{}, {}, {components});
+  tof.insert(Coord::Position{}, {Dim::Spectrum, 2},
+             {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert<Data::Value>("", {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
-                          {1, 2, 3, 4, 5, 6});
+  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
+             {1, 2, 3, 4, 5, 6});
   return tof;
 }
 
@@ -1300,14 +1321,14 @@ TEST(Dataset, convert_to_energy_fails_for_inelastic) {
   // Note these conversion fail only because they are not implemented. It should
   // definitely be possible to support this.
 
-  tof.insert<Coord::Ei>({}, {1});
+  tof.insert(Coord::Ei{}, {}, {1});
   EXPECT_THROW_MSG(convert(tof, Dim::Tof, Dim::Energy), std::runtime_error,
                    "Dataset contains Coord::Ei or Coord::Ef. However, "
                    "conversion to Dim::Energy is currently only supported for "
                    "elastic scattering.");
   tof.erase(Coord::Ei{});
 
-  tof.insert<Coord::Ef>({Dim::Spectrum, 2}, {1.0, 1.5});
+  tof.insert(Coord::Ef{}, {Dim::Spectrum, 2}, {1.0, 1.5});
   EXPECT_THROW_MSG(convert(tof, Dim::Tof, Dim::Energy), std::runtime_error,
                    "Dataset contains Coord::Ei or Coord::Ef. However, "
                    "conversion to Dim::Energy is currently only supported for "
@@ -1320,23 +1341,22 @@ TEST(Dataset, convert_to_energy_fails_for_inelastic) {
 TEST(Dataset, convert_direct_inelastic) {
   Dataset tof;
 
-  tof.insert<Coord::Tof>({Dim::Tof, 4}, {1, 2, 3, 4});
+  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1, 2, 3, 4});
 
   Dataset components;
   // Source and sample
-  components.insert<Coord::Position>(
-      {Dim::Component, 2},
+  components.insert(
+      Coord::Position{}, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert<Coord::ComponentInfo>({}, {components});
-  tof.insert<Coord::Position>({Dim::Spectrum, 3},
-                              {Eigen::Vector3d{0.0, 0.0, 1.0},
-                               Eigen::Vector3d{0.0, 0.0, 1.0},
-                               Eigen::Vector3d{0.1, 0.0, 1.0}});
+  tof.insert(Coord::ComponentInfo{}, {}, {components});
+  tof.insert(Coord::Position{}, {Dim::Spectrum, 3},
+             {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.0, 0.0, 1.0},
+              Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert<Data::Value>("", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
-                          {1, 2, 3, 4, 5, 6, 7, 8, 9});
+  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
+             {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-  tof.insert<Coord::Ei>({}, {1});
+  tof.insert(Coord::Ei{}, {}, {1});
 
   auto energy = convert(tof, Dim::Tof, Dim::DeltaE);
 
@@ -1371,25 +1391,24 @@ TEST(Dataset, convert_direct_inelastic) {
 TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   Dataset tof;
 
-  tof.insert<Coord::Tof>({Dim::Tof, 4}, {1, 2, 3, 4});
+  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1, 2, 3, 4});
 
   Dataset components;
   // Source and sample
-  components.insert<Coord::Position>(
-      {Dim::Component, 2},
+  components.insert(
+      Coord::Position{}, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert<Coord::ComponentInfo>({}, {components});
-  tof.insert<Coord::Position>({Dim::Spectrum, 3},
-                              {Eigen::Vector3d{0.0, 0.0, 1.0},
-                               Eigen::Vector3d{0.0, 0.0, 1.0},
-                               Eigen::Vector3d{0.1, 0.0, 1.0}});
+  tof.insert(Coord::ComponentInfo{}, {}, {components});
+  tof.insert(Coord::Position{}, {Dim::Spectrum, 3},
+             {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.0, 0.0, 1.0},
+              Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert<Data::Value>("", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
-                          {1, 2, 3, 4, 5, 6, 7, 8, 9});
+  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
+             {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
   // In practice not every spectrum would have a different Ei, more likely we
   // would have an extra dimension, Dim::Ei in addition to Dim::Spectrum.
-  tof.insert<Coord::Ei>({Dim::Spectrum, 3}, {1.0, 1.5, 2.0});
+  tof.insert(Coord::Ei{}, {Dim::Spectrum, 3}, {1.0, 1.5, 2.0});
 
   auto energy = convert(tof, Dim::Tof, Dim::DeltaE);
 

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -534,10 +534,6 @@ TEST(Dataset, concatenate) {
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
   EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
-  // Coord::X is shared since it it was the same in x and x2 and is thus
-  // "constant" along Dim::Y in xy.
-  EXPECT_EQ(&x.get<const Coord::X>()[0], &xy.get<const Coord::X>()[0]);
-  EXPECT_NE(&x.get<const Data::Value>()[0], &xy.get<const Data::Value>()[0]);
 
   xy = concatenate(xy, x, Dim::Y);
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
@@ -628,10 +624,6 @@ TEST(Dataset, concatenate_with_attributes) {
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
   EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
   EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
-  // Coord::X is shared since it it was the same in x and x2 and is thus
-  // "constant" along Dim::Y in xy.
-  EXPECT_EQ(&x.get<const Coord::X>()[0], &xy.get<const Coord::X>()[0]);
-  EXPECT_NE(&x.get<const Data::Value>()[0], &xy.get<const Data::Value>()[0]);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
   EXPECT_EQ(xy.get<const Attr::ExperimentLog>().size(), 2);
@@ -854,7 +846,8 @@ TEST(Dataset, filter) {
   EXPECT_EQ(filtered.get<const Coord::X>()[1], 0.0);
 
   ASSERT_EQ(filtered.get<const Coord::Y>().size(), 2);
-  ASSERT_EQ(&filtered.get<const Coord::Y>()[0], &d.get<const Coord::Y>()[0]);
+  EXPECT_EQ(filtered.get<const Coord::Y>()[0], 1.0);
+  EXPECT_EQ(filtered.get<const Coord::Y>()[1], 0.9);
 
   ASSERT_EQ(filtered.get<const Data::Value>().size(), 4);
   EXPECT_EQ(filtered.get<const Data::Value>()[0], 2.0);

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -210,7 +210,7 @@ TEST(Dataset, const_get) {
   d.insert<Data::Value>("", Dimensions{}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
   const auto &const_d(d);
-  auto view = const_d.get<const Data::Value>();
+  auto view = const_d.get<Data::Value>();
   // No non-const access to variable if Dataset is const, will not compile:
   // auto &view = const_d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
@@ -234,7 +234,7 @@ TEST(Dataset, get_const) {
   Dataset d;
   d.insert<Data::Value>("", Dimensions{}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
-  auto view = d.get<const Data::Value>();
+  auto view = d.get<Data::Value>();
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is now deduced to be const, so assignment will not compile:
@@ -465,7 +465,7 @@ TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
   auto sum = std::move(a) + b;
   EXPECT_EQ(&sum.get<Data::Value>()[0], addr);
 
-  const auto *addr2 = &a2.get<const Data::Value>()[0];
+  const auto *addr2 = &a2.get<Data::Value>()[0];
   auto sum2 = a2 + b;
   EXPECT_NE(&sum2.get<Data::Value>()[0], addr2);
 }
@@ -478,28 +478,28 @@ TEST(Dataset, slice) {
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i);
     ASSERT_EQ(sliceX.size(), 1);
-    ASSERT_EQ(sliceX.get<const Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i, i + 1);
     ASSERT_EQ(sliceX.size(), 2);
-    ASSERT_EQ(sliceX.get<const Coord::X>().size(), 1);
-    EXPECT_EQ(sliceX.get<const Coord::X>()[0], 0.1 * i);
-    ASSERT_EQ(sliceX.get<const Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get<Coord::X>().size(), 1);
+    EXPECT_EQ(sliceX.get<Coord::X>()[0], 0.1 * i);
+    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1, 2}) {
     Dataset sliceY = d(Dim::Y, i);
     ASSERT_EQ(sliceY.size(), 2);
-    ASSERT_EQ(sliceY.get<const Coord::X>(), d.get<const Coord::X>());
-    ASSERT_EQ(sliceY.get<const Data::Value>().size(), 2);
-    EXPECT_EQ(sliceY.get<const Data::Value>()[0], 0.0 + 2 * i);
-    EXPECT_EQ(sliceY.get<const Data::Value>()[1], 1.0 + 2 * i);
+    ASSERT_EQ(sliceY.get<Coord::X>(), d.get<Coord::X>());
+    ASSERT_EQ(sliceY.get<Data::Value>().size(), 2);
+    EXPECT_EQ(sliceY.get<Data::Value>()[0], 0.0 + 2 * i);
+    EXPECT_EQ(sliceY.get<Data::Value>()[1], 1.0 + 2 * i);
   }
   EXPECT_THROW_MSG(
       d(Dim::Z, 0), std::runtime_error,
@@ -525,23 +525,23 @@ TEST(Dataset, concatenate) {
   a.insert<Data::Value>("", {Dim::X, 1}, {2.2});
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<const Data::Value>().size(), 2);
+  EXPECT_EQ(x.get<Coord::X>().size(), 2);
+  EXPECT_EQ(x.get<Data::Value>().size(), 2);
   auto x2(x);
   x2.get<Data::Value>()[0] = 100.0;
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
 
   xy = concatenate(xy, x, Dim::Y);
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 6);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 6);
 
   xy = concatenate(xy, xy, Dim::Y);
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 12);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 12);
 }
 
 TEST(Dataset, concatenate_with_bin_edges) {
@@ -574,8 +574,8 @@ TEST(Dataset, concatenate_with_bin_edges) {
   EXPECT_NO_THROW(merged = concatenate(ds, ds2, Dim::X));
   EXPECT_EQ(merged.dimensions().count(), 1);
   EXPECT_TRUE(merged.dimensions().contains(Dim::X));
-  EXPECT_TRUE(equals(merged.get<const Coord::X>(), {0.1, 0.2, 0.3}));
-  EXPECT_TRUE(equals(merged.get<const Data::Value>(), {2.2, 3.3}));
+  EXPECT_TRUE(equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3}));
+  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 3.3}));
 }
 
 TEST(Dataset, concatenate_with_varying_bin_edges) {
@@ -596,8 +596,8 @@ TEST(Dataset, concatenate_with_varying_bin_edges) {
   EXPECT_EQ(merged.dimensions()[Dim::X], 2);
   EXPECT_EQ(merged.dimensions()[Dim::Y], 2);
   EXPECT_TRUE(
-      equals(merged.get<const Coord::X>(), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
-  EXPECT_TRUE(equals(merged.get<const Data::Value>(), {2.2, 4.4, 3.3, 5.5}));
+      equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
+  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 4.4, 3.3, 5.5}));
 }
 
 TEST(Dataset, concatenate_with_attributes) {
@@ -610,10 +610,10 @@ TEST(Dataset, concatenate_with_attributes) {
 
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<const Data::Value>().size(), 2);
-  EXPECT_EQ(x.get<const Attr::ExperimentLog>().size(), 1);
-  EXPECT_EQ(x.get<const Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(x.get<Coord::X>().size(), 2);
+  EXPECT_EQ(x.get<Data::Value>().size(), 2);
+  EXPECT_EQ(x.get<Attr::ExperimentLog>().size(), 1);
+  EXPECT_EQ(x.get<Attr::ExperimentLog>()[0], logs);
 
   auto x2(x);
   x2.get<Data::Value>()[0] = 100.0;
@@ -622,12 +622,12 @@ TEST(Dataset, concatenate_with_attributes) {
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<const Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
+  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
-  EXPECT_EQ(xy.get<const Attr::ExperimentLog>().size(), 2);
-  EXPECT_EQ(xy.get<const Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(xy.get<Attr::ExperimentLog>().size(), 2);
+  EXPECT_EQ(xy.get<Attr::ExperimentLog>()[0], logs);
 
   EXPECT_NO_THROW(concatenate(xy, xy, Dim::X));
 
@@ -693,8 +693,8 @@ TEST(Dataset, rebin) {
 
   d.insert<Data::Value>("", {Dim::X, 2}, {10.0, 20.0});
   auto rebinned = rebin(d, coordNew);
-  EXPECT_EQ(rebinned.get<const Data::Value>().size(), 1);
-  EXPECT_EQ(rebinned.get<const Data::Value>()[0], 30.0);
+  EXPECT_EQ(rebinned.get<Data::Value>().size(), 1);
+  EXPECT_EQ(rebinned.get<Data::Value>()[0], 30.0);
 }
 
 Dataset makeEvents() {
@@ -740,8 +740,8 @@ TEST(Dataset, histogram) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 1, 4}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 1, 4}));
 }
 
 TEST(Dataset, histogram_2D_coord) {
@@ -754,8 +754,8 @@ TEST(Dataset, histogram_2D_coord) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, histogram_2D_transpose_coord) {
@@ -772,8 +772,8 @@ TEST(Dataset, histogram_2D_transpose_coord) {
   // dimension will almost be the innermost one.
   ASSERT_EQ(hist(Data::Value{}, "sample1").dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Tof, 2}}));
-  EXPECT_TRUE(equals(hist.get<const Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<const Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, sort) {
@@ -784,21 +784,21 @@ TEST(Dataset, sort) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<const Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<const Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
+  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
 
-  ASSERT_EQ(sorted.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(sorted.get<const Data::Value>().size(), 4);
-  EXPECT_EQ(sorted.get<const Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[3], 1.0);
+  ASSERT_EQ(sorted.get<Data::Value>().size(), 4);
+  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
 }
 
 TEST(Dataset, sort_2D) {
@@ -810,25 +810,25 @@ TEST(Dataset, sort_2D) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<const Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<const Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
+  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
 
-  ASSERT_EQ(sorted.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(sorted.get<const Data::Value>().size(), 8);
-  EXPECT_EQ(sorted.get<const Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[3], 1.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[4], 8.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[5], 6.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[6], 7.0);
-  EXPECT_EQ(sorted.get<const Data::Value>()[7], 5.0);
+  ASSERT_EQ(sorted.get<Data::Value>().size(), 8);
+  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[4], 8.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[5], 6.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[6], 7.0);
+  EXPECT_EQ(sorted.get<Data::Value>()[7], 5.0);
 }
 
 TEST(Dataset, filter) {
@@ -841,19 +841,19 @@ TEST(Dataset, filter) {
 
   auto filtered = filter(d, select);
 
-  ASSERT_EQ(filtered.get<const Coord::X>().size(), 2);
-  EXPECT_EQ(filtered.get<const Coord::X>()[0], 1.0);
-  EXPECT_EQ(filtered.get<const Coord::X>()[1], 0.0);
+  ASSERT_EQ(filtered.get<Coord::X>().size(), 2);
+  EXPECT_EQ(filtered.get<Coord::X>()[0], 1.0);
+  EXPECT_EQ(filtered.get<Coord::X>()[1], 0.0);
 
-  ASSERT_EQ(filtered.get<const Coord::Y>().size(), 2);
-  EXPECT_EQ(filtered.get<const Coord::Y>()[0], 1.0);
-  EXPECT_EQ(filtered.get<const Coord::Y>()[1], 0.9);
+  ASSERT_EQ(filtered.get<Coord::Y>().size(), 2);
+  EXPECT_EQ(filtered.get<Coord::Y>()[0], 1.0);
+  EXPECT_EQ(filtered.get<Coord::Y>()[1], 0.9);
 
-  ASSERT_EQ(filtered.get<const Data::Value>().size(), 4);
-  EXPECT_EQ(filtered.get<const Data::Value>()[0], 2.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[1], 4.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[2], 6.0);
-  EXPECT_EQ(filtered.get<const Data::Value>()[3], 8.0);
+  ASSERT_EQ(filtered.get<Data::Value>().size(), 4);
+  EXPECT_EQ(filtered.get<Data::Value>()[0], 2.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[1], 4.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[2], 6.0);
+  EXPECT_EQ(filtered.get<Data::Value>()[3], 8.0);
 }
 
 TEST(Dataset, integrate) {
@@ -867,7 +867,7 @@ TEST(Dataset, integrate) {
   EXPECT_FALSE(integral.contains(Coord::X{}));
   // Note: The current implementation assumes that Data::Value is counts,
   // handling of other data is not implemented yet.
-  EXPECT_TRUE(equals(integral.get<const Data::Value>(), {30.0}));
+  EXPECT_TRUE(equals(integral.get<Data::Value>(), {30.0}));
 }
 
 TEST(DatasetSlice, basics) {
@@ -911,19 +911,19 @@ TEST(DatasetSlice, minus_equals) {
 
   EXPECT_NO_THROW(d -= d["a"]);
 
-  EXPECT_EQ(d.get<const Data::Value>("a")[0], 0.0);
-  EXPECT_EQ(d.get<const Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<const Data::Variance>("a")[0], 2.0);
-  EXPECT_EQ(d.get<const Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Value>("a")[0], 0.0);
+  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Variance>("a")[0], 2.0);
+  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
 
   ASSERT_NO_THROW(d["a"] -= d["b"]);
 
   ASSERT_EQ(d.size(), 6);
   // Note: Variable not renamed when operating with slices.
-  EXPECT_EQ(d.get<const Data::Value>("a")[0], -1.0);
-  EXPECT_EQ(d.get<const Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<const Data::Variance>("a")[0], 3.0);
-  EXPECT_EQ(d.get<const Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Value>("a")[0], -1.0);
+  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
+  EXPECT_EQ(d.get<Data::Variance>("a")[0], 3.0);
+  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
 }
 
 TEST(DatasetSlice, slice_spatial) {
@@ -974,14 +974,12 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1, 2, 3, 4}));
-  EXPECT_TRUE(equals(d.get<const Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4}));
+  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1024,14 +1022,12 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1, 2, 3, 4, 5}));
-  EXPECT_TRUE(equals(d.get<const Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4, 5}));
+  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   auto view_a_x01 = d["a"](Dim::X, 0, 1);
   auto view_a_x12 = d["a"](Dim::X, 1, 2);
@@ -1039,8 +1035,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 1 so we get 2 edges.
   ASSERT_EQ(view_a_x01.dimensions()[Dim::X], 1);
   ASSERT_EQ(view_a_x01[0].dimensions()[Dim::X], 2);
-  EXPECT_TRUE(equals(view_a_x01[0].get<const Coord::X>(), {1, 2}));
-  EXPECT_TRUE(equals(view_a_x12[0].get<const Coord::X>(), {2, 3}));
+  EXPECT_TRUE(equals(view_a_x01[0].get<Coord::X>(), {1, 2}));
+  EXPECT_TRUE(equals(view_a_x12[0].get<Coord::X>(), {2, 3}));
 
   auto view_a_x02 = d["a"](Dim::X, 0, 2);
   auto view_a_x13 = d["a"](Dim::X, 1, 3);
@@ -1048,8 +1044,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 2 so we get 3 edges.
   ASSERT_EQ(view_a_x02.dimensions()[Dim::X], 2);
   ASSERT_EQ(view_a_x02[0].dimensions()[Dim::X], 3);
-  EXPECT_TRUE(equals(view_a_x02[0].get<const Coord::X>(), {1, 2, 3}));
-  EXPECT_TRUE(equals(view_a_x13[0].get<const Coord::X>(), {2, 3, 4}));
+  EXPECT_TRUE(equals(view_a_x02[0].get<Coord::X>(), {1, 2, 3}));
+  EXPECT_TRUE(equals(view_a_x13[0].get<Coord::X>(), {2, 3, 4}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1088,25 +1084,25 @@ TEST(Dataset, binary_assign_with_scalar) {
   d.insert<Data::Variance>("d2", {}, {6});
 
   d += 1;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {2, 3}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {2, 3}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
 
   d -= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {0, 1}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 1}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
 
   d *= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d1"), {0, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d1"), {16, 20}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("d2"), {24}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {16, 20}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {24}));
 }
 
 TEST(DatasetSlice, binary_assign_with_scalar) {
@@ -1120,29 +1116,29 @@ TEST(DatasetSlice, binary_assign_with_scalar) {
   auto slice = d(Dim::X, 1);
 
   slice += 1;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 3}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 3}));
   // TODO This behavior should be reconsidered and probably change: A slice
   // should not include variables that do not have the dimension, otherwise,
   // e.g., looping over slices will apply an operation to that variable more
   // than once.
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
 
   slice -= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 1}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
 
   slice *= 2;
-  EXPECT_TRUE(equals(d.get<const Data::Value>("a"), {1, 2}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 2}));
+  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("a"), {4, 20}));
-  EXPECT_TRUE(equals(d.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 20}));
+  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {24}));
 }
 
 TEST(Dataset, binary_with_scalar) {
@@ -1154,37 +1150,37 @@ TEST(Dataset, binary_with_scalar) {
   d.insert<Data::Variance>("b", {}, {6});
 
   auto sum = d + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {2, 3}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {2, 3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
   sum = 2 + d;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {3, 4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3, 4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
 
   auto diff = d - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {0, 1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0, 1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
   diff = 2 - d;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {1, 0}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1, 0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
 
   auto prod = d * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {2, 4}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {16, 20}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {2, 4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {16, 20}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
   prod = 3 * d;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {3, 6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {36, 45}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {3, 6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {36, 45}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
 }
 
 TEST(DatasetSlice, binary_with_scalar) {
@@ -1201,37 +1197,37 @@ TEST(DatasetSlice, binary_with_scalar) {
   // DatasetSlice to Dataset, so this test is actually testing that conversion,
   // not the binary operation iteself.
   auto sum = slice + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {3}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
   sum = 2 + slice;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(sum.get<const Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
 
   auto diff = slice - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
   diff = 2 - slice;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("a"), {0}));
-  EXPECT_TRUE(equals(diff.get<const Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<const Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
+  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
 
   auto prod = slice * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {20}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {20}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
   prod = 3 * slice;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("a"), {6}));
-  EXPECT_TRUE(equals(prod.get<const Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("a"), {45}));
-  EXPECT_TRUE(equals(prod.get<const Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {45}));
+  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
 }
 
 Dataset makeTofDataForUnitConversion() {
@@ -1271,11 +1267,11 @@ TEST(Dataset, convert) {
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 4}}));
   // TODO Check unit.
 
-  const auto values = coord.get<const Coord::Energy>();
+  const auto values = coord.get<Coord::Energy>();
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 437 * sqrt ( E[meV] )
   Variable tof_in_seconds = tof(Coord::Tof{}) * 1e-6;
-  const auto tofs = tof_in_seconds.get<const Coord::Tof>();
+  const auto tofs = tof_in_seconds.get<Coord::Tof>();
   // Spectrum 0 is 11 m from source
   EXPECT_NEAR(values[0], pow((11.0 / tofs[0]) / 437.0, 2), values[0] * 0.01);
   EXPECT_NEAR(values[1], pow((11.0 / tofs[1]) / 437.0, 2), values[1] * 0.01);
@@ -1292,7 +1288,7 @@ TEST(Dataset, convert) {
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
-  EXPECT_TRUE(equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1355,18 +1351,17 @@ TEST(Dataset, convert_direct_inelastic) {
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
-  EXPECT_FALSE(equals(coord.get<const Coord::DeltaE>(),
-                      {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+  EXPECT_FALSE(
+      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position see same deltaE.
-  EXPECT_EQ(coord(Dim::Spectrum, 0).get<const Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<const Coord::DeltaE>()[0]);
+  EXPECT_EQ(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
+            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(
-      equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1409,19 +1404,18 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
-  EXPECT_FALSE(equals(coord.get<const Coord::DeltaE>(),
-                      {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+  EXPECT_FALSE(
+      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position, but now their Ei differs, so deltaE is also
   // different (compare to test for single Ei above).
-  EXPECT_NE(coord(Dim::Spectrum, 0).get<const Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<const Coord::DeltaE>()[0]);
+  EXPECT_NE(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
+            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(
-      equals(data.get<const Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));

--- a/test/example_instrument_test.cpp
+++ b/test/example_instrument_test.cpp
@@ -14,9 +14,9 @@ TEST(ExampleInstrument, basics) {
   gsl::index ndet = 4;
 
   Dataset detectors;
-  detectors.insert<Coord::DetectorId>({Dim::Detector, ndet}, {1, 2, 3, 4});
-  detectors.insert<Coord::Position>({Dim::Detector, ndet}, ndet,
-                                    Eigen::Vector3d{0.0, 0.0, 2.0});
+  detectors.insert(Coord::DetectorId{}, {Dim::Detector, ndet}, {1, 2, 3, 4});
+  detectors.insert(Coord::Position{}, {Dim::Detector, ndet}, ndet,
+                   Eigen::Vector3d{0.0, 0.0, 2.0});
   MDZipView<const Coord::DetectorId, Coord::Position> view(detectors);
   for (auto &det : view) {
     det.get<Coord::Position>()[0] = 0.1 * det.get<Coord::DetectorId>();
@@ -34,16 +34,16 @@ TEST(ExampleInstrument, basics) {
 
   Dataset components;
   // Source and sample
-  components.insert<Coord::Position>(
-      {Dim::Component, 2},
+  components.insert(
+      Coord::Position{}, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
 
   Dataset d;
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {{0, 1},
                                                                     {2, 3}};
-  d.insert<Coord::DetectorGrouping>({Dim::Spectrum, 2}, grouping);
-  d.insert<Coord::DetectorInfo>({}, {detectors});
-  d.insert<Coord::ComponentInfo>({}, {components});
+  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 2}, grouping);
+  d.insert(Coord::DetectorInfo{}, {}, {detectors});
+  d.insert(Coord::ComponentInfo{}, {}, {components});
 
   EXPECT_ANY_THROW(static_cast<void>(MDZipView<Coord::Position>(d)));
   ASSERT_NO_THROW(static_cast<void>(MDZipView<const Coord::Position>(d)));

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -15,8 +15,8 @@
 
 TEST(MDZipView, construct) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions{}, {1.1});
-  d.insert<Data::Int>("", Dimensions{}, {2});
+  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
+  d.insert(Data::Int{}, "", Dimensions{}, {2});
   // Empty view forbidden by static_assert:
   // MDZipView<> view(d);
   ASSERT_NO_THROW(static_cast<void>(MDZipView<Data::Value>(d)));
@@ -28,8 +28,8 @@ TEST(MDZipView, construct) {
 
 TEST(MDZipView, construct_with_const_Dataset) {
   Dataset d;
-  d.insert<Data::Value>("", {Dim::X, 1}, {1.1});
-  d.insert<Data::Int>("", Dimensions{}, {2});
+  d.insert(Data::Value{}, "", {Dim::X, 1}, {1.1});
+  d.insert(Data::Int{}, "", Dimensions{}, {2});
   const auto const_d(d);
   EXPECT_NO_THROW(ConstMDZipView<Data::Value> view(const_d));
   EXPECT_NO_THROW(
@@ -41,8 +41,8 @@ TEST(MDZipView, construct_with_const_Dataset) {
 
 TEST(MDZipView, iterator) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions{Dim::X, 2}, {1.1, 1.2});
-  d.insert<Data::Int>("", Dimensions{Dim::X, 2}, {2, 3});
+  d.insert(Data::Value{}, "", Dimensions{Dim::X, 2}, {1.1, 1.2});
+  d.insert(Data::Int{}, "", Dimensions{Dim::X, 2}, {2, 3});
   MDZipView<Data::Value> view(d);
   ASSERT_NO_THROW(view.begin());
   ASSERT_NO_THROW(view.end());
@@ -65,8 +65,8 @@ TEST(MDZipView, iterator) {
 
 TEST(MDZipView, single_column) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions(Dim::Tof, 10), 10);
-  d.insert<Data::Int>("", Dimensions(Dim::Tof, 10), 10);
+  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 10), 10);
+  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 10), 10);
   auto var = d.get<Data::Value>();
   var[0] = 0.2;
   var[3] = 3.2;
@@ -86,8 +86,8 @@ TEST(MDZipView, single_column) {
 
 TEST(MDZipView, multi_column) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions(Dim::Tof, 2), 2);
-  d.insert<Data::Int>("", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get<Data::Value>();
   var[0] = 0.2;
   var[1] = 3.2;
@@ -103,8 +103,8 @@ TEST(MDZipView, multi_column) {
 
 TEST(MDZipView, multi_column_mixed_dimension) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions(Dim::Tof, 2), 2);
-  d.insert<Data::Int>("", Dimensions{}, 1);
+  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Int{}, "", Dimensions{}, 1);
   auto var = d.get<Data::Value>();
   var[0] = 0.2;
   var[1] = 3.2;
@@ -130,8 +130,8 @@ TEST(MDZipView, multi_column_transposed) {
   dimsYX.add(Dim::Y, 3);
   dimsYX.add(Dim::X, 2);
 
-  d.insert<Data::Value>("", dimsXY, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert<Data::Int>("", dimsYX, {1, 3, 5, 2, 4, 6});
+  d.insert(Data::Value{}, "", dimsXY, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  d.insert(Data::Int{}, "", dimsYX, {1, 3, 5, 2, 4, 6});
   // TODO Current dimension check is too strict and fails unless data with
   // transposed dimensions is accessed as const.
   MDZipView<Data::Value, const Data::Int> view(d);
@@ -145,8 +145,8 @@ TEST(MDZipView, multi_column_transposed) {
 
 TEST(MDZipView, multi_column_unrelated_dimension) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions(Dim::X, 2), 2);
-  d.insert<Data::Int>("", Dimensions(Dim::Y, 3), 3);
+  d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int{}, "", Dimensions(Dim::Y, 3), 3);
   MDZipView<Data::Value> view(d);
   auto it = view.begin();
   ASSERT_TRUE(it < view.end());
@@ -158,8 +158,8 @@ TEST(MDZipView, multi_column_unrelated_dimension) {
 
 TEST(MDZipView, multi_column_orthogonal_fail) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions(Dim::X, 2), 2);
-  d.insert<Data::Int>("", Dimensions(Dim::Y, 3), 3);
+  d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int{}, "", Dimensions(Dim::Y, 3), 3);
   EXPECT_THROW_MSG((MDZipView<Data::Value, Data::Int>(d)), std::runtime_error,
                    "Variables requested for iteration do not span a joint "
                    "space. In case one of the variables represents bin edges "
@@ -169,9 +169,9 @@ TEST(MDZipView, multi_column_orthogonal_fail) {
 
 TEST(MDZipView, nested_MDZipView) {
   Dataset d;
-  d.insert<Data::Value>("", {{Dim::Y, 3}, {Dim::X, 2}},
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert<Data::Int>("", {Dim::X, 2}, {10, 20});
+  d.insert(Data::Value{}, "", {{Dim::Y, 3}, {Dim::X, 2}},
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  d.insert(Data::Int{}, "", {Dim::X, 2}, {10, 20});
   MDZipView<MDZipView<const Data::Value>, const Data::Int> view(d, {Dim::Y});
   ASSERT_EQ(view.size(), 2);
   double base = 0.0;
@@ -188,10 +188,10 @@ TEST(MDZipView, nested_MDZipView) {
 
 TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}}),
-                        {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
-                         9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                         17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
+  d.insert(
+      Data::Value{}, "", Dimensions({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}}),
+      {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
+       13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
   MDZipView<MDZipView<const Data::Value>> viewX(d, {Dim::Y, Dim::Z});
   ASSERT_EQ(viewX.size(), 4);
@@ -294,9 +294,9 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
 
 TEST(MDZipView, nested_MDZipView_constant_variable) {
   Dataset d;
-  d.insert<Data::Value>("", Dimensions({{Dim::Z, 2}, {Dim::X, 4}}),
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
-  d.insert<Coord::X>({Dim::X, 4}, {10.0, 20.0, 30.0, 40.0});
+  d.insert(Data::Value{}, "", Dimensions({{Dim::Z, 2}, {Dim::X, 4}}),
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+  d.insert(Coord::X{}, {Dim::X, 4}, {10.0, 20.0, 30.0, 40.0});
 
   // Coord::X has fewer dimensions, throws if not const when not nested...
   EXPECT_THROW_MSG(
@@ -327,14 +327,14 @@ TEST(MDZipView, nested_MDZipView_constant_variable) {
 TEST(MDZipView, histogram_using_nested_MDZipView) {
   Dataset d;
   // Edges do not have Dim::Spectrum, "shared" by all histograms.
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 3), {10.0, 20.0, 30.0});
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), {10.0, 20.0, 30.0});
   Dimensions dims;
   dims.add(Dim::Tof, 2);
   dims.add(Dim::Spectrum, 4);
-  d.insert<Data::Value>("sample", dims,
-                        {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
-  d.insert<Data::Variance>("sample", dims, 8);
-  d.insert<Coord::SpectrumNumber>({Dim::Spectrum, 4}, {1, 2, 3, 4});
+  d.insert(Data::Value{}, "sample", dims,
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+  d.insert(Data::Variance{}, "sample", dims, 8);
+  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 4}, {1, 2, 3, 4});
 
   using HistogramView = MDZipView<Bin<Coord::Tof>, Data::Value, Data::Variance>;
   MDZipView<HistogramView, Coord::SpectrumNumber> view(d, "sample", {Dim::Tof});
@@ -370,8 +370,8 @@ TEST(MDZipView, histogram_using_nested_MDZipView) {
 
 TEST(MDZipView, single_column_edges) {
   Dataset d;
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 3), 3);
-  d.insert<Data::Int>("name2", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get<Coord::Tof>();
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
@@ -394,8 +394,8 @@ TEST(MDZipView, single_column_edges) {
 
 TEST(MDZipView, single_column_bins) {
   Dataset d;
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 3), 3);
-  d.insert<Data::Int>("name2", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get<Coord::Tof>();
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
@@ -413,8 +413,8 @@ TEST(MDZipView, single_column_bins) {
 
 TEST(MDZipView, multi_column_edges) {
   Dataset d;
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 3), 3);
-  d.insert<Data::Int>("", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get<Coord::Tof>();
   var[0] = 0.2;
   var[1] = 1.2;
@@ -438,12 +438,12 @@ TEST(MDZipView, multi_column_edges) {
 
 TEST(MDZipView, multi_dimensional_edges) {
   Dataset d;
-  d.insert<Coord::X>(Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
-                     {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  d.insert(Coord::X{}, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   // TODO There is currently a bug in MDZipView: If `Bin` iteration is
   // requested but the dataset contains only edges the shape calculation gives
   // wrong results.
-  d.insert<Data::Value>("", {Dim::X, 2});
+  d.insert(Data::Value{}, "", {Dim::X, 2});
 
   MDZipView<Bin<Coord::X>> view(d);
   ASSERT_EQ(view.size(), 4);
@@ -461,9 +461,9 @@ TEST(MDZipView, multi_dimensional_edges) {
 
 TEST(MDZipView, edges_are_not_inner_dimension) {
   Dataset d;
-  d.insert<Coord::Y>(Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
-                     {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert<Data::Value>("", {Dim::Y, 1});
+  d.insert(Coord::Y{}, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
+           {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  d.insert(Data::Value{}, "", {Dim::Y, 1});
 
   MDZipView<Bin<Coord::Y>> view(d);
   ASSERT_EQ(view.size(), 3);
@@ -479,7 +479,7 @@ TEST(MDZipView, edges_are_not_inner_dimension) {
 
 TEST(MDZipView, named_getter) {
   Dataset d;
-  d.insert<Coord::Tof>(Dimensions(Dim::Tof, 3), 3);
+  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
   auto var = d.get<Coord::Tof>();
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
@@ -496,8 +496,8 @@ TEST(MDZipView, named_getter) {
 
 TEST(MDZipView, duplicate_data_tag) {
   Dataset d;
-  d.insert<Data::Value>("name1", Dimensions{}, 1);
-  d.insert<Data::Value>("name2", Dimensions{}, 1);
+  d.insert(Data::Value{}, "name1", Dimensions{}, 1);
+  d.insert(Data::Value{}, "name2", Dimensions{}, 1);
 
   EXPECT_THROW_MSG(MDZipView<Data::Value> view(d), std::runtime_error,
                    "Dataset with 2 variables, could not find variable with tag "
@@ -507,8 +507,8 @@ TEST(MDZipView, duplicate_data_tag) {
 
 TEST(MDZipView, named_variable_and_coordinate) {
   Dataset d;
-  d.insert<Coord::X>(Dimensions{}, 1);
-  d.insert<Data::Value>("name", Dimensions{}, 1);
+  d.insert(Coord::X{}, Dimensions{}, 1);
+  d.insert(Data::Value{}, "name", Dimensions{}, 1);
 
   EXPECT_NO_THROW((MDZipView<Coord::X, Data::Value>(d, "name")));
   (MDZipView<Coord::X, Data::Value>(d, "name"));
@@ -516,16 +516,15 @@ TEST(MDZipView, named_variable_and_coordinate) {
 
 TEST(MDZipView, spectrum_position) {
   Dataset dets;
-  dets.insert<Coord::Position>(
-      {Dim::Detector, 4},
-      {Eigen::Vector3d{1.0, 0.0, 0.0}, Eigen::Vector3d{2.0, 0.0, 0.0},
-       Eigen::Vector3d{4.0, 0.0, 0.0}, Eigen::Vector3d{8.0, 0.0, 0.0}});
+  dets.insert(Coord::Position{}, {Dim::Detector, 4},
+              {Eigen::Vector3d{1.0, 0.0, 0.0}, Eigen::Vector3d{2.0, 0.0, 0.0},
+               Eigen::Vector3d{4.0, 0.0, 0.0}, Eigen::Vector3d{8.0, 0.0, 0.0}});
 
   Dataset d;
-  d.insert<Coord::DetectorInfo>({}, {dets});
+  d.insert(Coord::DetectorInfo{}, {}, {dets});
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {
       {0, 2}, {1}, {}};
-  d.insert<Coord::DetectorGrouping>({Dim::Spectrum, 3}, grouping);
+  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 3}, grouping);
 
   MDZipView<const Coord::Position> view(d);
   auto it = view.begin();
@@ -541,7 +540,7 @@ TEST(MDZipView, spectrum_position) {
 
 TEST(MDZipView, derived_standard_deviation) {
   Dataset d;
-  d.insert<Data::Variance>("", {Dim::X, 3}, {4.0, 9.0, -1.0});
+  d.insert(Data::Variance{}, "", {Dim::X, 3}, {4.0, 9.0, -1.0});
   MDZipView<Data::StdDev> view(d);
   auto it = view.begin();
   EXPECT_EQ(it->get<Data::StdDev>(), 2.0);
@@ -553,8 +552,8 @@ TEST(MDZipView, derived_standard_deviation) {
 
 TEST(MDZipView, type_sorting) {
   Dataset data;
-  data.insert<Coord::X>({}, 1);
-  data.insert<Coord::Y>({}, 1);
+  data.insert(Coord::X{}, {}, 1);
+  data.insert(Coord::Y{}, {}, 1);
   MDZipView<Coord::X, Coord::Y> a(data);
   MDZipView<Coord::Y, Coord::X> b(data);
   MDZipView<Coord::Y, const Coord::X> b_const(data);
@@ -564,8 +563,8 @@ TEST(MDZipView, type_sorting) {
 
 TEST(MDZipView, type_sorting_nested) {
   Dataset data;
-  data.insert<Coord::X>({}, 1);
-  data.insert<Coord::Y>({}, 1);
+  data.insert(Coord::X{}, {}, 1);
+  data.insert(Coord::Y{}, {}, 1);
   MDZipView<Coord::X, MDZipView<Coord::Y>> a(data);
   MDZipView<MDZipView<Coord::Y>, Coord::X> b(data);
   EXPECT_EQ(
@@ -577,15 +576,16 @@ TEST(MDZipView, type_sorting_nested) {
 
 TEST(MDZipView, type_sorting_two_nested) {
   Dataset data;
-  data.insert<Coord::X>({}, 1);
-  data.insert<Coord::Y>({}, 1);
-  data.insert<Coord::Z>({}, 1);
+  data.insert(Coord::X{}, {}, 1);
+  data.insert(Coord::Y{}, {}, 1);
+  data.insert(Coord::Z{}, {}, 1);
   MDZipView<Coord::X, MDZipView<Coord::Y, Coord::Z>> a(data);
   MDZipView<Coord::X, MDZipView<Coord::Z, Coord::Y>> b(data);
   MDZipView<MDZipView<Coord::Y, Coord::Z>, Coord::X> c(data);
   MDZipView<MDZipView<Coord::Z, Coord::Y>, Coord::X> d(data);
   EXPECT_EQ(typeid(decltype(a)),
-            typeid(MDZipViewImpl<Dataset, Coord::X, MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
+            typeid(MDZipViewImpl<Dataset, Coord::X,
+                                 MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(b)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(c)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(d)));

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -31,12 +31,12 @@ TEST(MDZipView, construct_with_const_Dataset) {
   d.insert<Data::Value>("", {Dim::X, 1}, {1.1});
   d.insert<Data::Int>("", Dimensions{}, {2});
   const auto const_d(d);
-  EXPECT_NO_THROW(MDZipView<const Data::Value> view(const_d));
+  EXPECT_NO_THROW(ConstMDZipView<Data::Value> view(const_d));
   EXPECT_NO_THROW(
-      MDZipView<MDZipView<const Data::Value>> nested(const_d, {Dim::X}));
-  EXPECT_NO_THROW(static_cast<void>(
-      MDZipView<MDZipView<const Data::Value>, const Data::Int>(const_d,
-                                                               {Dim::X})));
+      ConstMDZipView<ConstMDZipView<Data::Value>> nested(const_d, {Dim::X}));
+  EXPECT_NO_THROW(
+      static_cast<void>(ConstMDZipView<ConstMDZipView<Data::Value>, Data::Int>(
+          const_d, {Dim::X})));
 }
 
 TEST(MDZipView, iterator) {
@@ -568,8 +568,10 @@ TEST(MDZipView, type_sorting_nested) {
   data.insert<Coord::Y>({}, 1);
   MDZipView<Coord::X, MDZipView<Coord::Y>> a(data);
   MDZipView<MDZipView<Coord::Y>, Coord::X> b(data);
-  EXPECT_EQ(typeid(decltype(a)),
-            typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<Coord::Y>>));
+  EXPECT_EQ(
+      typeid(decltype(a)),
+      typeid(
+          MDZipViewImpl<Dataset, Coord::X, MDZipViewImpl<Dataset, Coord::Y>>));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(b)));
 }
 
@@ -583,12 +585,12 @@ TEST(MDZipView, type_sorting_two_nested) {
   MDZipView<MDZipView<Coord::Y, Coord::Z>, Coord::X> c(data);
   MDZipView<MDZipView<Coord::Z, Coord::Y>, Coord::X> d(data);
   EXPECT_EQ(typeid(decltype(a)),
-            typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<Coord::Y, Coord::Z>>));
+            typeid(MDZipViewImpl<Dataset, Coord::X, MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(b)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(c)));
   EXPECT_EQ(typeid(decltype(a)), typeid(decltype(d)));
-  MDZipView<Coord::X, MDZipView<const Coord::Y, Coord::Z>> a_const(data);
-  EXPECT_EQ(
-      typeid(decltype(a_const)),
-      typeid(MDZipViewImpl<Coord::X, MDZipViewImpl<const Coord::Y, Coord::Z>>));
+  MDZipView<Coord::X, MDZipView<Coord::Y, Coord::Z>> a_const(data);
+  EXPECT_EQ(typeid(decltype(a_const)),
+            typeid(MDZipViewImpl<Dataset, Coord::X,
+                                 MDZipViewImpl<Dataset, Coord::Y, Coord::Z>>));
 }

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -63,26 +63,6 @@ TEST(MDZipView, iterator) {
   ASSERT_EQ(it, view.end());
 }
 
-TEST(MDZipView, copy_on_write) {
-  Dataset d;
-  d.insert<Coord::X>({Dim::X, 2}, 2);
-  d.insert<Coord::Y>({Dim::X, 2}, 2);
-  const auto copy(d);
-
-  MDZipView<const Coord::X> const_view(d);
-  EXPECT_EQ(&const_view.begin()->get<Coord::X>(),
-            &copy.get<const Coord::X>()[0]);
-  // Again, just to confirm that the call to `copy.get` is not the reason for
-  // breaking sharing:
-  EXPECT_EQ(&const_view.begin()->get<Coord::X>(),
-            &copy.get<const Coord::X>()[0]);
-
-  MDZipView<Coord::X, const Coord::Y> view(d);
-  EXPECT_NE(&view.begin()->get<Coord::X>(), &copy.get<const Coord::X>()[0]);
-  // Breaks sharing only for the non-const variables:
-  EXPECT_EQ(&view.begin()->get<Coord::Y>(), &copy.get<const Coord::Y>()[0]);
-}
-
 TEST(MDZipView, single_column) {
   Dataset d;
   d.insert<Data::Value>("", Dimensions(Dim::Tof, 10), 10);
@@ -342,57 +322,6 @@ TEST(MDZipView, nested_MDZipView_constant_variable) {
       EXPECT_EQ(subitem.get<Data::Value>(), value);
     }
   }
-}
-
-TEST(MDZipView, nested_MDZipView_copy_on_write) {
-  Dataset d;
-  d.insert<Data::Value>("", Dimensions({{Dim::Y, 2}, {Dim::X, 2}}),
-                        {1.0, 2.0, 3.0, 4.0});
-  d.insert<Coord::X>(Dimensions({{Dim::Y, 2}, {Dim::X, 2}}),
-                     {10.0, 20.0, 30.0, 40.0});
-
-  auto copy(d);
-
-  MDZipView<MDZipView<const Data::Value, const Coord::X>> const_view(copy,
-                                                                     {Dim::X});
-
-  EXPECT_EQ(&d.get<const Data::Value>()[0],
-            &(const_view.begin()
-                  ->get<MDZipView<const Data::Value, const Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_EQ(&d.get<const Coord::X>()[0],
-            &(const_view.begin()
-                  ->get<MDZipView<const Data::Value, const Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
-
-  MDZipView<MDZipView<const Data::Value, Coord::X>> partially_const_view(
-      copy, {Dim::X});
-
-  EXPECT_EQ(&d.get<const Data::Value>()[0],
-            &(partially_const_view.begin()
-                  ->get<MDZipView<const Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_NE(&d.get<const Coord::X>()[0],
-            &(partially_const_view.begin()
-                  ->get<MDZipView<const Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
-
-  MDZipView<MDZipView<Data::Value, Coord::X>> nonconst_view(copy, {Dim::X});
-
-  EXPECT_NE(&d.get<const Data::Value>()[0],
-            &(nonconst_view.begin()
-                  ->get<MDZipView<Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Data::Value>()));
-  EXPECT_NE(&d.get<const Coord::X>()[0],
-            &(nonconst_view.begin()
-                  ->get<MDZipView<Data::Value, Coord::X>>()
-                  .begin()
-                  ->get<Coord::X>()));
 }
 
 TEST(MDZipView, histogram_using_nested_MDZipView) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -56,6 +56,18 @@ TEST(Variable, makeVariable_custom_type_initializer_list) {
   ASSERT_NO_THROW(ints.span<int32_t>());
 }
 
+TEST(Variable, dtype) {
+  auto doubles = makeVariable<double>(Data::Value{}, {});
+  auto floats = makeVariable<float>(Data::Value{}, {});
+  EXPECT_EQ(doubles.data().dtype(), dtype<double>);
+  EXPECT_NE(doubles.data().dtype(), dtype<float>);
+  EXPECT_NE(floats.data().dtype(), dtype<double>);
+  EXPECT_EQ(floats.data().dtype(), dtype<float>);
+  EXPECT_EQ(doubles.data().dtype(), doubles.data().dtype());
+  EXPECT_EQ(floats.data().dtype(), floats.data().dtype());
+  EXPECT_NE(doubles.data().dtype(), floats.data().dtype());
+}
+
 TEST(Variable, span_references_Variable) {
   Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
   auto observer = a.get<Data::Value>();

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -59,13 +59,13 @@ TEST(Variable, makeVariable_custom_type_initializer_list) {
 TEST(Variable, dtype) {
   auto doubles = makeVariable<double>(Data::Value{}, {});
   auto floats = makeVariable<float>(Data::Value{}, {});
-  EXPECT_EQ(doubles.data().dtype(), dtype<double>);
-  EXPECT_NE(doubles.data().dtype(), dtype<float>);
-  EXPECT_NE(floats.data().dtype(), dtype<double>);
-  EXPECT_EQ(floats.data().dtype(), dtype<float>);
-  EXPECT_EQ(doubles.data().dtype(), doubles.data().dtype());
-  EXPECT_EQ(floats.data().dtype(), floats.data().dtype());
-  EXPECT_NE(doubles.data().dtype(), floats.data().dtype());
+  EXPECT_EQ(doubles.dtype(), dtype<double>);
+  EXPECT_NE(doubles.dtype(), dtype<float>);
+  EXPECT_NE(floats.dtype(), dtype<double>);
+  EXPECT_EQ(floats.dtype(), dtype<float>);
+  EXPECT_EQ(doubles.dtype(), doubles.dtype());
+  EXPECT_EQ(floats.dtype(), floats.dtype());
+  EXPECT_NE(doubles.dtype(), floats.dtype());
 }
 
 TEST(Variable, span_references_Variable) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -26,6 +26,36 @@ TEST(Variable, construct_fail) {
   ASSERT_ANY_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 3), 2));
 }
 
+TEST(Variable, makeVariable_custom_type) {
+  auto doubles = makeVariable<double>(Data::Value{}, {});
+  auto floats = makeVariable<float>(Data::Value{}, {});
+
+  ASSERT_NO_THROW(doubles.get<Data::Value>());
+  // Data::Value defaults to double, so this throws.
+  ASSERT_ANY_THROW(floats.get<Data::Value>());
+
+  ASSERT_NO_THROW(doubles.span<double>());
+  ASSERT_NO_THROW(floats.span<float>());
+
+  ASSERT_ANY_THROW(doubles.span<float>());
+  ASSERT_ANY_THROW(floats.span<double>());
+
+  ASSERT_TRUE((std::is_same<decltype(doubles.span<double>())::element_type,
+                            double>::value));
+  ASSERT_TRUE((std::is_same<decltype(floats.span<float>())::element_type,
+                            float>::value));
+}
+
+TEST(Variable, makeVariable_custom_type_initializer_list) {
+  Variable doubles(Data::Value{}, {Dim::X, 2}, {1, 2});
+  auto ints = makeVariable<int32_t>(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+
+  // Passed ints but uses default type based on tag.
+  ASSERT_NO_THROW(doubles.span<double>());
+  // Passed doubles but explicit type overrides.
+  ASSERT_NO_THROW(ints.span<int32_t>());
+}
+
 TEST(Variable, span_references_Variable) {
   Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
   auto observer = a.get<Data::Value>();

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -42,21 +42,13 @@ TEST(Variable, span_references_Variable) {
   EXPECT_EQ(observer[0], 1.0);
 }
 
-TEST(Variable, sharing) {
-  const Variable a1(Data::Value{}, {Dim::Tof, 2});
-  const auto a2(a1);
-  // TODO Should we require the use of `const` with the tag if Variable is
-  // const?
-  EXPECT_EQ(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
-}
-
 TEST(Variable, copy) {
   const Variable a1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
   const auto &data1 = a1.get<const Data::Value>();
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_EQ(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
+  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
   EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<Data::Value>()[0]);
   const auto &data2 = a2.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.1);
@@ -498,52 +490,17 @@ TEST(Variable, mean) {
 
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
   ConstVariableSlice view(var);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
+  EXPECT_EQ(var.get<const Coord::X>().data(),
             view.get<const Coord::X>().data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
   Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
   VariableSlice view(var);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
+  EXPECT_EQ(var.get<const Coord::X>().data(),
             view.get<const Coord::X>().data());
-  EXPECT_NE(copy.get<const Coord::X>().data(), view.get<Coord::X>().data());
-}
-
-TEST(VariableSlice,
-     copy_on_write_variable_from_full_view_shares_original_data) {
-  const Variable var(Coord::X{}, {{Dim::X, 3}});
-  ConstVariableSlice view(var);
-  Variable copy(view);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            var.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_const_view) {
-  const Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_mutable_view) {
-  Variable var(Coord::X{}, {{Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-}
-
-TEST(VariableSlice, copy_on_write_nested_mutable_view) {
-  Variable var(Coord::X{}, {{Dim::Y, 3}, {Dim::X, 3}});
-  auto copy(var);
-  auto view = var(Dim::X, 0)(Dim::Y, 0);
-  EXPECT_EQ(copy.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
+  EXPECT_EQ(var.get<const Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, strides) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -16,7 +16,7 @@ TEST(Variable, construct) {
   ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2)));
   ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2), 2));
   const Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  const auto &data = a.get<const Data::Value>();
+  const auto &data = a.get<Data::Value>();
   EXPECT_EQ(data.size(), 2);
 }
 
@@ -28,7 +28,7 @@ TEST(Variable, construct_fail) {
 
 TEST(Variable, span_references_Variable) {
   Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  auto observer = a.get<const Data::Value>();
+  auto observer = a.get<Data::Value>();
   // This line does not compile, const-correctness works:
   // observer[0] = 1.0;
 
@@ -44,12 +44,12 @@ TEST(Variable, span_references_Variable) {
 
 TEST(Variable, copy) {
   const Variable a1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
-  const auto &data1 = a1.get<const Data::Value>();
+  const auto &data1 = a1.get<Data::Value>();
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<const Data::Value>()[0]);
-  EXPECT_NE(&a1.get<const Data::Value>()[0], &a2.get<Data::Value>()[0]);
+  EXPECT_NE(&a1.get<Data::Value>()[0], &a2.get<Data::Value>()[0]);
+  EXPECT_NE(&a1.get<Data::Value>()[0], &a2.get<Data::Value>()[0]);
   const auto &data2 = a2.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.1);
   EXPECT_EQ(data2[1], 2.2);
@@ -78,18 +78,18 @@ TEST(Variable, operator_equals) {
 TEST(Variable, operator_unary_minus) {
   const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a;
-  EXPECT_EQ(a.get<const Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<const Data::Value>()[1], 2.2);
-  EXPECT_EQ(b.get<const Data::Value>()[0], -1.1);
-  EXPECT_EQ(b.get<const Data::Value>()[1], -2.2);
+  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
+  EXPECT_EQ(a.get<Data::Value>()[1], 2.2);
+  EXPECT_EQ(b.get<Data::Value>()[0], -1.1);
+  EXPECT_EQ(b.get<Data::Value>()[1], -2.2);
 }
 
 TEST(VariableSlice, unary_minus) {
   const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a(Dim::X, 1);
-  EXPECT_EQ(a.get<const Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<const Data::Value>()[1], 2.2);
-  EXPECT_EQ(b.get<const Data::Value>()[0], -2.2);
+  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
+  EXPECT_EQ(a.get<Data::Value>()[1], 2.2);
+  EXPECT_EQ(b.get<Data::Value>()[0], -2.2);
 }
 
 TEST(Variable, operator_plus_equal) {
@@ -265,18 +265,18 @@ TEST(Variable, slice) {
     Variable sliceX = parent(Dim::X, index);
     ASSERT_EQ(sliceX.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::Y, 2}}));
     auto base = static_cast<double>(index);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], base + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], base + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], base + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], base + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], base + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], base + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], base + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], base + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], base + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], base + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], base + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], base + 21.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index);
     ASSERT_EQ(sliceY.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::X, 4}}));
-    const auto &data = sliceY.get<const Data::Value>();
+    const auto &data = sliceY.get<Data::Value>();
     auto base = static_cast<double>(index);
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * base + 8 * static_cast<double>(z) + 1.0);
@@ -289,7 +289,7 @@ TEST(Variable, slice) {
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceZ = parent(Dim::Z, index);
     ASSERT_EQ(sliceZ.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -306,37 +306,37 @@ TEST(Variable, slice_range) {
     Variable sliceX = parent(Dim::X, index, index + 1);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], index + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], index + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], index + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], index + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], index + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], index + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], index + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], index + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], index + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], index + 21.0);
   }
 
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceX = parent(Dim::X, index, index + 2);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
-    EXPECT_EQ(sliceX.get<const Data::Value>()[0], index + 1.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[1], index + 2.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[2], index + 5.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[3], index + 6.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[4], index + 9.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[5], index + 10.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[6], index + 13.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[7], index + 14.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[8], index + 17.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[9], index + 18.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[10], index + 21.0);
-    EXPECT_EQ(sliceX.get<const Data::Value>()[11], index + 22.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[0], index + 1.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[1], index + 2.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[2], index + 5.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[3], index + 6.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[4], index + 9.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[5], index + 10.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[6], index + 13.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[7], index + 14.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[8], index + 17.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[9], index + 18.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[10], index + 21.0);
+    EXPECT_EQ(sliceX.get<Data::Value>()[11], index + 22.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index, index + 1);
     ASSERT_EQ(sliceY.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
-    const auto &data = sliceY.get<const Data::Value>();
+    const auto &data = sliceY.get<Data::Value>();
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * index + 8 * z + 1.0);
       EXPECT_EQ(data[4 * z + 1], 4 * index + 8 * z + 2.0);
@@ -354,7 +354,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 1);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -363,7 +363,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 2);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get<const Data::Value>();
+    const auto &data = sliceZ.get<Data::Value>();
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
     for (gsl::index xy = 0; xy < 8; ++xy)
@@ -387,14 +387,14 @@ TEST(Variable, concatenate) {
   const auto abba = concatenate(ab, ba, Dim::Q);
   ASSERT_EQ(abba.size(), 4);
   EXPECT_EQ(abba.dimensions().count(), 2);
-  const auto &data2 = abba.get<const Data::Value>();
+  const auto &data2 = abba.get<Data::Value>();
   EXPECT_EQ(data2[0], 1.0);
   EXPECT_EQ(data2[1], 2.0);
   EXPECT_EQ(data2[2], 2.0);
   EXPECT_EQ(data2[3], 1.0);
   const auto ababbaba = concatenate(abba, abba, Dim::Tof);
   ASSERT_EQ(ababbaba.size(), 8);
-  const auto &data3 = ababbaba.get<const Data::Value>();
+  const auto &data3 = ababbaba.get<Data::Value>();
   EXPECT_EQ(data3[0], 1.0);
   EXPECT_EQ(data3[1], 2.0);
   EXPECT_EQ(data3[2], 1.0);
@@ -405,7 +405,7 @@ TEST(Variable, concatenate) {
   EXPECT_EQ(data3[7], 1.0);
   const auto abbaabba = concatenate(abba, abba, Dim::Q);
   ASSERT_EQ(abbaabba.size(), 8);
-  const auto &data4 = abbaabba.get<const Data::Value>();
+  const auto &data4 = abbaabba.get<Data::Value>();
   EXPECT_EQ(data4[0], 1.0);
   EXPECT_EQ(data4[1], 2.0);
   EXPECT_EQ(data4[2], 2.0);
@@ -464,43 +464,41 @@ TEST(Variable, rebin) {
   auto rebinned = rebin(var, oldEdge, newEdge);
   ASSERT_EQ(rebinned.dimensions().count(), 1);
   ASSERT_EQ(rebinned.dimensions().volume(), 1);
-  ASSERT_EQ(rebinned.get<const Data::Value>().size(), 1);
-  EXPECT_EQ(rebinned.get<const Data::Value>()[0], 3.0);
+  ASSERT_EQ(rebinned.get<Data::Value>().size(), 1);
+  EXPECT_EQ(rebinned.get<Data::Value>()[0], 3.0);
 }
 
 TEST(Variable, sum) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto sumX = sum(var, Dim::X);
   ASSERT_EQ(sumX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(sumX.get<const Data::Value>(), {3.0, 7.0}));
+  EXPECT_TRUE(equals(sumX.get<Data::Value>(), {3.0, 7.0}));
   auto sumY = sum(var, Dim::Y);
   ASSERT_EQ(sumY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(sumY.get<const Data::Value>(), {4.0, 6.0}));
+  EXPECT_TRUE(equals(sumY.get<Data::Value>(), {4.0, 6.0}));
 }
 
 TEST(Variable, mean) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto meanX = mean(var, Dim::X);
   ASSERT_EQ(meanX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(meanX.get<const Data::Value>(), {1.5, 3.5}));
+  EXPECT_TRUE(equals(meanX.get<Data::Value>(), {1.5, 3.5}));
   auto meanY = mean(var, Dim::Y);
   ASSERT_EQ(meanY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(meanY.get<const Data::Value>(), {2.0, 3.0}));
+  EXPECT_TRUE(equals(meanY.get<Data::Value>(), {2.0, 3.0}));
 }
 
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X{}, {{Dim::X, 3}});
   ConstVariableSlice view(var);
-  EXPECT_EQ(var.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
   Variable var(Coord::X{}, {{Dim::X, 3}});
   VariableSlice view(var);
-  EXPECT_EQ(var.get<const Coord::X>().data(),
-            view.get<const Coord::X>().data());
-  EXPECT_EQ(var.get<const Coord::X>().data(), view.get<Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
+  EXPECT_EQ(var.get<Coord::X>().data(), view.get<Coord::X>().data());
 }
 
 TEST(VariableSlice, strides) {
@@ -528,7 +526,7 @@ TEST(VariableSlice, strides) {
 
 TEST(VariableSlice, get) {
   const Variable var(Data::Value{}, {Dim::X, 3}, {1, 2, 3});
-  EXPECT_EQ(var(Dim::X, 1, 2).get<const Data::Value>()[0], 2.0);
+  EXPECT_EQ(var(Dim::X, 1, 2).get<Data::Value>()[0], 2.0);
 }
 
 TEST(VariableSlice, slicing_does_not_transpose) {
@@ -550,7 +548,7 @@ TEST(VariableSlice, self_overlapping_view_operation) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var -= var(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   // This is the critical part: After subtracting for y=0 the view points to
@@ -565,7 +563,7 @@ TEST(VariableSlice, minus_equals_slice_const_outer) {
   const auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -582,7 +580,7 @@ TEST(VariableSlice, minus_equals_slice_outer) {
   auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -599,7 +597,7 @@ TEST(VariableSlice, minus_equals_slice_inner) {
   auto copy(var);
 
   var -= copy(Dim::X, 0);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 1.0);
   EXPECT_EQ(data[2], 0.0);
@@ -616,7 +614,7 @@ TEST(VariableSlice, minus_equals_slice_of_slice) {
   auto copy(var);
 
   var -= copy(Dim::X, 1)(Dim::Y, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -629,7 +627,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 0, 2);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], -21.0);
@@ -638,7 +636,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 0, 2);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -12.0);
     EXPECT_EQ(data[1], -13.0);
     EXPECT_EQ(data[2], -22.0);
@@ -647,7 +645,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -21.0);
     EXPECT_EQ(data[1], -22.0);
     EXPECT_EQ(data[2], -31.0);
@@ -656,7 +654,7 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
   {
     Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -22.0);
     EXPECT_EQ(data[1], -23.0);
     EXPECT_EQ(data[2], -32.0);
@@ -668,7 +666,7 @@ TEST(VariableSlice, slice_inner_minus_equals) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::X, 0) -= var(Dim::X, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -1.0);
   EXPECT_EQ(data[1], 2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -679,7 +677,7 @@ TEST(VariableSlice, slice_outer_minus_equals) {
   Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::Y, 0) -= var(Dim::Y, 1);
-  const auto data = var.get<const Data::Value>();
+  const auto data = var.get<Data::Value>();
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], 3.0);
@@ -692,7 +690,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -708,7 +706,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -724,7 +722,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -740,7 +738,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -759,7 +757,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -775,7 +773,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -791,7 +789,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -807,7 +805,7 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get<const Data::Value>();
+    const auto data = target.get<Data::Value>();
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -828,7 +826,7 @@ TEST(VariableSlice, slice_minus_lower_dimensional) {
 
   target(Dim::Y, 1, 2) -= source;
 
-  const auto data = target.get<const Data::Value>();
+  const auto data = target.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], -1.0);
@@ -841,19 +839,19 @@ TEST(VariableSlice, variable_copy_from_slice) {
 
   Variable target1(source(Dim::X, 0, 2)(Dim::Y, 0, 2));
   EXPECT_EQ(target1.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target1.get<const Data::Value>(), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target1.get<Data::Value>(), {11, 12, 21, 22}));
 
   Variable target2(source(Dim::X, 1, 3)(Dim::Y, 0, 2));
   EXPECT_EQ(target2.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target2.get<const Data::Value>(), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target2.get<Data::Value>(), {12, 13, 22, 23}));
 
   Variable target3(source(Dim::X, 0, 2)(Dim::Y, 1, 3));
   EXPECT_EQ(target3.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target3.get<const Data::Value>(), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target3.get<Data::Value>(), {21, 22, 31, 32}));
 
   Variable target4(source(Dim::X, 1, 3)(Dim::Y, 1, 3));
   EXPECT_EQ(target4.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target4.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target4.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_assign_from_slice) {
@@ -863,19 +861,19 @@ TEST(VariableSlice, variable_assign_from_slice) {
 
   target = source(Dim::X, 0, 2)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {11, 12, 21, 22}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {12, 13, 22, 23}));
 
   target = source(Dim::X, 0, 2)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {21, 22, 31, 32}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_self_assign_via_slice) {
@@ -886,7 +884,7 @@ TEST(VariableSlice, variable_self_assign_via_slice) {
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get<const Data::Value>(), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get<Data::Value>(), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, slice_assign_from_variable) {
@@ -899,29 +897,29 @@ TEST(VariableSlice, slice_assign_from_variable) {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {11, 12, 0, 21, 22, 0, 0, 0, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 11, 12, 0, 21, 22, 0, 0, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 0, 0, 11, 12, 0, 21, 22, 0}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
   }
   {
     Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
-    EXPECT_TRUE(equals(target.get<const Data::Value>(),
-                       {0, 0, 0, 0, 11, 12, 0, 21, 22}));
+    EXPECT_TRUE(
+        equals(target.get<Data::Value>(), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
   }
 }
 
@@ -935,10 +933,10 @@ TEST(VariableSlice, slice_binary_operations) {
   auto difference = v(Dim::X, 0) - v(Dim::X, 1);
   auto product = v(Dim::X, 0) * v(Dim::X, 1);
   auto ratio = v(Dim::X, 0) / v(Dim::X, 1);
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 7}));
-  EXPECT_TRUE(equals(difference.get<const Data::Value>(), {-1, -1}));
-  EXPECT_TRUE(equals(product.get<const Data::Value>(), {2, 12}));
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {1.0 / 2.0, 3.0 / 4.0}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {3, 7}));
+  EXPECT_TRUE(equals(difference.get<Data::Value>(), {-1, -1}));
+  EXPECT_TRUE(equals(product.get<Data::Value>(), {2, 12}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {1.0 / 2.0, 3.0 / 4.0}));
 }
 
 TEST(Variable, reshape) {
@@ -947,12 +945,12 @@ TEST(Variable, reshape) {
   auto view = var.reshape({Dim::Row, 6});
   ASSERT_EQ(view.size(), 6);
   ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
-  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 
   auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
   ASSERT_EQ(view2.size(), 6);
   ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(view2.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view2.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, reshape_temporary) {
@@ -961,7 +959,7 @@ TEST(Variable, reshape_temporary) {
   auto reshaped = sum(var, Dim::X).reshape({{Dim::Y, 2}, {Dim::Z, 2}});
   ASSERT_EQ(reshaped.size(), 4);
   ASSERT_EQ(reshaped.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(reshaped.get<const Data::Value>(), {6, 8, 10, 12}));
+  EXPECT_TRUE(equals(reshaped.get<Data::Value>(), {6, 8, 10, 12}));
 
   // This is not a temporary, we get a view into `var`.
   EXPECT_EQ(typeid(decltype(std::move(var).reshape({}))),
@@ -980,7 +978,7 @@ TEST(Variable, reshape_and_slice) {
 
   auto slice =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
-  EXPECT_TRUE(equals(slice.get<const Data::Value>(), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(slice.get<Data::Value>(), {6, 7, 10, 11}));
 
   Variable center =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
@@ -988,7 +986,7 @@ TEST(Variable, reshape_and_slice) {
 
   ASSERT_EQ(center.size(), 4);
   ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
-  EXPECT_TRUE(equals(center.get<const Data::Value>(), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(center.get<Data::Value>(), {6, 7, 10, 11}));
 }
 
 TEST(Variable, reshape_mutable) {
@@ -998,9 +996,9 @@ TEST(Variable, reshape_mutable) {
   auto view = var.reshape({Dim::Row, 6});
   view.get<Data::Value>()[3] = 0;
 
-  EXPECT_TRUE(equals(view.get<const Data::Value>(), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(copy.get<const Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get<Data::Value>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(copy.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, access_typed_view) {
@@ -1043,24 +1041,24 @@ TEST(Variable, non_in_place_scalar_operations) {
   Variable var(Data::Value{}, {{Dim::X, 2}}, {1, 2});
 
   auto sum = var + 1;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {2, 3}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {2, 3}));
   sum = 2 + var;
-  EXPECT_TRUE(equals(sum.get<const Data::Value>(), {3, 4}));
+  EXPECT_TRUE(equals(sum.get<Data::Value>(), {3, 4}));
 
   auto diff = var - 1;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {0, 1}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>(), {0, 1}));
   diff = 2 - var;
-  EXPECT_TRUE(equals(diff.get<const Data::Value>(), {1, 0}));
+  EXPECT_TRUE(equals(diff.get<Data::Value>(), {1, 0}));
 
   auto prod = var * 2;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {2, 4}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>(), {2, 4}));
   prod = 3 * var;
-  EXPECT_TRUE(equals(prod.get<const Data::Value>(), {3, 6}));
+  EXPECT_TRUE(equals(prod.get<Data::Value>(), {3, 6}));
 
   auto ratio = var / 2;
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {1.0 / 2.0, 1.0}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {1.0 / 2.0, 1.0}));
   ratio = 3 / var;
-  EXPECT_TRUE(equals(ratio.get<const Data::Value>(), {3.0, 1.5}));
+  EXPECT_TRUE(equals(ratio.get<Data::Value>(), {3.0, 1.5}));
 }
 
 TEST(VariableSlice, scalar_operations) {
@@ -1068,15 +1066,15 @@ TEST(VariableSlice, scalar_operations) {
                {11, 12, 13, 21, 22, 23});
 
   var(Dim::X, 0) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 22, 22, 23}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 13, 22, 22, 23}));
   var(Dim::Y, 1) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 13, 23, 23, 24}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 13, 23, 23, 24}));
   var(Dim::X, 1, 3) += 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 13, 14, 23, 24, 25}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 13, 14, 23, 24, 25}));
   var(Dim::X, 1) -= 1;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 14, 23, 23, 25}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 14, 23, 23, 25}));
   var(Dim::X, 2) *= 0;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {12, 12, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {12, 12, 0, 23, 23, 0}));
   var(Dim::Y, 0) /= 2;
-  EXPECT_TRUE(equals(var.get<const Data::Value>(), {6, 6, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get<Data::Value>(), {6, 6, 0, 23, 23, 0}));
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -205,6 +205,18 @@ TEST(Variable, operator_plus_equal_scalar) {
   EXPECT_EQ(a.get<Data::Value>()[1], 3.2);
 }
 
+TEST(Variable, operator_plus_equal_custom_type) {
+  auto a = makeVariable<float>(Data::Value{}, {Dim::X, 2}, {1.1f, 2.2f});
+
+  EXPECT_NO_THROW(a += a);
+  EXPECT_EQ(a.span<float>()[0], 2.2f);
+  EXPECT_EQ(a.span<float>()[1], 4.4f);
+
+  auto different_name(a);
+  different_name.setName("test");
+  EXPECT_NO_THROW(a += different_name);
+}
+
 TEST(Variable, operator_times_equal) {
   Variable a(Coord::X{}, {Dim::X, 2}, {2.0, 3.0});
 

--- a/test/zip_view_test.cpp
+++ b/test/zip_view_test.cpp
@@ -16,33 +16,33 @@
 TEST(ZipView, construct_fail) {
   Dataset d;
 
-  d.insert<Coord::X>({Dim::X, 3});
-  d.insert<Data::Value>("", {Dim::X, 3});
+  d.insert(Coord::X{}, {Dim::X, 3});
+  d.insert(Data::Value{}, "", {Dim::X, 3});
   EXPECT_THROW_MSG(
       ZipView<Coord::X> view(d), std::runtime_error,
       "ZipView must be constructed based on *all* variables in a dataset.");
   d.erase(Data::Value{});
 
-  d.insert<Data::Value>("", {});
+  d.insert(Data::Value{}, "", {});
   EXPECT_THROW_MSG((ZipView<Coord::X, Data::Value>(d)), std::runtime_error,
                    "ZipView supports only datasets where all variables are "
                    "1-dimensional.");
   d.erase(Data::Value{});
 
-  d.insert<Coord::Y>({Dim::Y, 3});
+  d.insert(Coord::Y{}, {Dim::Y, 3});
   EXPECT_THROW_MSG((ZipView<Coord::X, Coord::Y>(d)), std::runtime_error,
                    "ZipView supports only 1-dimensional datasets.");
 }
 
 TEST(ZipView, construct) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 3});
+  d.insert(Coord::X{}, {Dim::X, 3});
   EXPECT_NO_THROW(ZipView<Coord::X> view(d));
 }
 
 TEST(ZipView, push_back_1_variable) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 3});
+  d.insert(Coord::X{}, {Dim::X, 3});
   ZipView<Coord::X> view(d);
   view.push_back({1.1});
   ASSERT_EQ(d.get<const Coord::X>().size(), 4);
@@ -60,8 +60,8 @@ TEST(ZipView, push_back_1_variable) {
 
 TEST(ZipView, push_back_2_variables) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 2});
-  d.insert<Data::Value>("", {Dim::X, 2});
+  d.insert(Coord::X{}, {Dim::X, 2});
+  d.insert(Data::Value{}, "", {Dim::X, 2});
   ZipView<Coord::X, Data::Value> view(d);
   view.push_back({1.1, 1.2});
   ASSERT_EQ(d.get<const Coord::X>().size(), 3);
@@ -84,8 +84,8 @@ TEST(ZipView, push_back_2_variables) {
 
 TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 0});
-  d.insert<Data::Value>("", {Dim::X, 0});
+  d.insert(Coord::X{}, {Dim::X, 0});
+  d.insert(Data::Value{}, "", {Dim::X, 0});
 
   ZipView<Coord::X, Data::Value> view(d);
 
@@ -115,7 +115,7 @@ TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
 
 TEST(ZipView, iterator_1_variable) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
+  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
   ZipView<Coord::X> view(d);
   EXPECT_EQ(std::distance(view.begin(), view.end()), 3);
   auto it = view.begin();
@@ -127,8 +127,8 @@ TEST(ZipView, iterator_1_variable) {
 
 TEST(ZipView, iterator_modify) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
-  d.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  d.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
   ZipView<Coord::X, Data::Value> view(d);
 
   // Note this peculiarity: `item` is returned by value but it is a proxy
@@ -143,13 +143,13 @@ TEST(ZipView, iterator_modify) {
 
 TEST(ZipView, iterator_copy) {
   Dataset source;
-  source.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
-  source.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  source.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  source.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
   ZipView<Coord::X, Data::Value> source_view(source);
 
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 0});
-  d.insert<Data::Value>("", {Dim::X, 0});
+  d.insert(Coord::X{}, {Dim::X, 0});
+  d.insert(Data::Value{}, "", {Dim::X, 0});
   ZipView<Coord::X, Data::Value> view(d);
 
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
@@ -168,13 +168,13 @@ TEST(ZipView, iterator_copy) {
 
 TEST(ZipView, iterator_copy_if) {
   Dataset source;
-  source.insert<Coord::X>({Dim::X, 3}, {1.0, 2.0, 3.0});
-  source.insert<Data::Value>("", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  source.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  source.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
   ZipView<Coord::X, Data::Value> source_view(source);
 
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 0});
-  d.insert<Data::Value>("", {Dim::X, 0});
+  d.insert(Coord::X{}, {Dim::X, 0});
+  d.insert(Data::Value{}, "", {Dim::X, 0});
   ZipView<Coord::X, Data::Value> view(d);
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
@@ -192,7 +192,7 @@ TEST(ZipView, iterator_copy_if) {
 
 TEST(ZipView, iterator_sort) {
   Dataset d;
-  d.insert<Coord::X>({Dim::X, 4}, {3.0, 2.0, 1.0, 0.0});
+  d.insert(Coord::X{}, {Dim::X, 4}, {3.0, 2.0, 1.0, 0.0});
   ZipView<Coord::X> view(d);
 
   // Note: Unlike other std algorithms, std::sort does not work with these

--- a/test/zip_view_test.cpp
+++ b/test/zip_view_test.cpp
@@ -45,12 +45,12 @@ TEST(ZipView, push_back_1_variable) {
   d.insert(Coord::X{}, {Dim::X, 3});
   ZipView<Coord::X> view(d);
   view.push_back({1.1});
-  ASSERT_EQ(d.get<const Coord::X>().size(), 4);
+  ASSERT_EQ(d.get<Coord::X>().size(), 4);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
   view.push_back(2.2);
-  ASSERT_EQ(d.get<const Coord::X>().size(), 5);
+  ASSERT_EQ(d.get<Coord::X>().size(), 5);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  const auto data = d.get<const Coord::X>();
+  const auto data = d.get<Coord::X>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 0.0);
@@ -64,18 +64,18 @@ TEST(ZipView, push_back_2_variables) {
   d.insert(Data::Value{}, "", {Dim::X, 2});
   ZipView<Coord::X, Data::Value> view(d);
   view.push_back({1.1, 1.2});
-  ASSERT_EQ(d.get<const Coord::X>().size(), 3);
+  ASSERT_EQ(d.get<Coord::X>().size(), 3);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 3);
   view.push_back({2.2, 2.3});
-  ASSERT_EQ(d.get<const Coord::X>().size(), 4);
+  ASSERT_EQ(d.get<Coord::X>().size(), 4);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
 
-  const auto coord = d.get<const Coord::X>();
+  const auto coord = d.get<Coord::X>();
   EXPECT_EQ(coord[0], 0.0);
   EXPECT_EQ(coord[1], 0.0);
   EXPECT_EQ(coord[2], 1.1);
   EXPECT_EQ(coord[3], 2.2);
-  const auto data = d.get<const Data::Value>();
+  const auto data = d.get<Data::Value>();
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 1.2);
@@ -96,18 +96,18 @@ TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
     return std::make_tuple(x, v);
   });
 
-  ASSERT_EQ(d.get<const Coord::X>().size(), 5);
+  ASSERT_EQ(d.get<Coord::X>().size(), 5);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  ASSERT_EQ(d.get<const Data::Value>().size(), 5);
+  ASSERT_EQ(d.get<Data::Value>().size(), 5);
   ASSERT_EQ(d(Data::Value{}).dimensions().size(0), 5);
 
   rng = std::mt19937{};
-  for (const auto x : d.get<const Coord::X>()) {
+  for (const auto x : d.get<Coord::X>()) {
     rng();
     EXPECT_EQ(x, rng());
   }
   rng = std::mt19937{};
-  for (const auto v : d.get<const Data::Value>()) {
+  for (const auto v : d.get<Data::Value>()) {
     EXPECT_EQ(v, rng());
     rng();
   }
@@ -137,8 +137,8 @@ TEST(ZipView, iterator_modify) {
   for (auto item : view)
     std::get<1>(item) *= 2.0;
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>(), {2.2, 4.2, 6.2}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.2, 4.2, 6.2}));
 }
 
 TEST(ZipView, iterator_copy) {
@@ -155,15 +155,13 @@ TEST(ZipView, iterator_copy) {
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Value>(), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Data::Value>(), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
 
   std::copy(source_view.begin(), source_view.end(), view.begin() + 1);
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(
-      equals(d.get<const Data::Value>(), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Data::Value>(), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_copy_if) {
@@ -180,14 +178,14 @@ TEST(ZipView, iterator_copy_if) {
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>(), {2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.1, 3.1}));
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<const Data::Value>(), {2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_sort) {
@@ -202,5 +200,5 @@ TEST(ZipView, iterator_sort) {
     return std::get<0>(a) < std::get<0>(b);
   });
 
-  EXPECT_TRUE(equals(d.get<const Coord::X>(), {0.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get<Coord::X>(), {0.0, 1.0, 2.0, 3.0}));
 }


### PR DESCRIPTION
Previously a tag uniquely defined the type for a variable. For a variety of reasons decoupling the concept of tags and types seems like a better approach:
- Easier to be compatible with `numpy` and its `dtype` approach.
- Implementing mixed-precision code is more natural.
- [As analysed](doc/design-tag-considerations.md), tags are actually conceptually different from types and are rather required to describe the meaning of a variable in a dataset, such as whether it is a coordinate or whether it belong to a group of variables (such as a value and its uncertainty).

This PR is based on https://github.com/mantidproject/dataset/pull/20.

Refactoring the tag code is not complete yet. As follow-ups the tags are likely to be changed from types to `constexpr` values, such that we can avoid a lot of curly braces. This in turn depends on a refactor of `MDZipView`, where we currently need type-tags such that we can specify the `const`ness. When that is done, more cleanup in the Python exports will also become possible (avoiding explicit exports for each tag).