### PR TITLE
Change tags from types to constexpr values

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -18,7 +18,7 @@ static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
     d.insert(Data::Value{}, "name" + std::to_string(i), Dimensions{}, 1);
   d.insert(Data::Int{}, "name", Dimensions{}, 1);
   for (auto _ : state)
-    d.get<Data::Int>();
+    d.get(Data::Int{});
   state.SetItemsProcessed(state.iterations());
 }
 BENCHMARK(BM_Dataset_get_with_many_columns)
@@ -38,8 +38,8 @@ static void BM_Dataset_as_Histogram(benchmark::State &state) {
   for (gsl::index i = 0; i < nSpec; ++i) {
     auto hist(d);
     // Break sharing
-    hist.get<Data::Value>();
-    hist.get<Data::Variance>();
+    hist.get(Data::Value{});
+    hist.get(Data::Variance{});
     histograms.push_back(hist);
   }
 
@@ -241,7 +241,7 @@ Dataset makeBeamline(const gsl::index nDet) {
   dets.insert(Coord::DetectorId{}, {Dim::Detector, nDet});
   dets.insert(Coord::Mask{}, {Dim::Detector, nDet});
   dets.insert(Coord::Position{}, {Dim::Detector, nDet});
-  auto ids = dets.get<Coord::DetectorId>();
+  auto ids = dets.get(Coord::DetectorId{});
   std::iota(ids.begin(), ids.end(), 1);
 
   Dataset d;
@@ -256,10 +256,10 @@ Dataset makeSpectra(const gsl::index nSpec) {
 
   d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec});
   d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec});
-  auto groups = d.get<Coord::DetectorGrouping>();
+  auto groups = d.get(Coord::DetectorGrouping{});
   for (gsl::index i = 0; i < groups.size(); ++i)
     groups[i] = {i};
-  auto nums = d.get<Coord::SpectrumNumber>();
+  auto nums = d.get(Coord::SpectrumNumber{});
   std::iota(nums.begin(), nums.end(), 1);
 
   return d;
@@ -268,7 +268,7 @@ Dataset makeSpectra(const gsl::index nSpec) {
 Dataset makeData(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
   d.insert(Coord::Tof{}, {Dim::Tof, nPoint + 1});
-  auto tofs = d.get<Coord::Tof>();
+  auto tofs = d.get(Coord::Tof{});
   std::iota(tofs.begin(), tofs.end(), 0.0);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
   d.insert(Data::Value{}, "sample", dims);
@@ -310,8 +310,8 @@ static void BM_Dataset_Workspace2D_copy_and_write(benchmark::State &state) {
   auto d = makeWorkspace2D(nSpec, nPoint);
   for (auto _ : state) {
     auto copy(d);
-    copy.get<Data::Value>()[0] = 1.0;
-    copy.get<Data::Variance>()[0] = 1.0;
+    copy.get(Data::Value{})[0] = 1.0;
+    copy.get(Data::Variance{})[0] = 1.0;
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -358,7 +358,7 @@ Dataset makeEventWorkspace(const gsl::index nSpec, const gsl::index nEvent) {
   Dataset empty;
   empty.insert(Data::Tof{}, "", {Dim::Event, 0});
   empty.insert(Data::PulseTime{}, "", {Dim::Event, 0});
-  for (auto &eventList : d.get<Data::Events>()) {
+  for (auto &eventList : d.get(Data::Events{})) {
     // 1/4 of the event lists is empty
     gsl::index count = std::max(0l, dist(mt) - nEvent / 4);
     if (count == 0)
@@ -399,7 +399,7 @@ static void BM_Dataset_EventWorkspace_copy_and_write(benchmark::State &state) {
   auto d = makeEventWorkspace(nSpec, nEvent);
   for (auto _ : state) {
     auto copy(d);
-    auto eventLists = copy.get<Data::Events>();
+    auto eventLists = copy.get(Data::Events{});
     static_cast<void>(eventLists);
   }
   state.SetItemsProcessed(state.iterations());
@@ -417,7 +417,7 @@ static void BM_Dataset_EventWorkspace_plus(benchmark::State &state) {
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : d.get<Data::Events>())
+  for (auto &eventList : d.get(Data::Events{}))
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations());
   // 2 for Tof and PulseTime
@@ -437,13 +437,13 @@ static void BM_Dataset_EventWorkspace_grow(benchmark::State &state) {
   for (auto _ : state) {
     state.PauseTiming();
     auto sum(d);
-    static_cast<void>(sum.get<Data::Events>());
+    static_cast<void>(sum.get(Data::Events{}));
     state.ResumeTiming();
     sum += update;
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : update.get<Data::Events>())
+  for (auto &eventList : update.get(Data::Events{}))
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations() * actualEvents);
 }

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -15,10 +15,10 @@
 static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
   Dataset d;
   for (int i = 0; i < state.range(0); ++i)
-    d.insert(Data::Value{}, "name" + std::to_string(i), Dimensions{}, 1);
-  d.insert(Data::Int{}, "name", Dimensions{}, 1);
+    d.insert(Data::Value, "name" + std::to_string(i), Dimensions{}, 1);
+  d.insert(Data::Int, "name", Dimensions{}, 1);
   for (auto _ : state)
-    d.get(Data::Int{});
+    d.get(Data::Int);
   state.SetItemsProcessed(state.iterations());
 }
 BENCHMARK(BM_Dataset_get_with_many_columns)
@@ -30,16 +30,16 @@ BENCHMARK(BM_Dataset_get_with_many_columns)
 static void BM_Dataset_as_Histogram(benchmark::State &state) {
   gsl::index nPoint = state.range(0);
   Dataset d;
-  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
-  d.insert(Data::Value{}, "", {Dim::Tof, nPoint}, nPoint);
-  d.insert(Data::Variance{}, "", {Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Value, "", {Dim::Tof, nPoint}, nPoint);
+  d.insert(Data::Variance, "", {Dim::Tof, nPoint}, nPoint);
   std::vector<Dataset> histograms;
   gsl::index nSpec = std::min(1000000l, 10000000 / (nPoint + 1));
   for (gsl::index i = 0; i < nSpec; ++i) {
     auto hist(d);
     // Break sharing
-    hist.get(Data::Value{});
-    hist.get(Data::Variance{});
+    hist.get(Data::Value);
+    hist.get(Data::Variance);
     histograms.push_back(hist);
   }
 
@@ -56,11 +56,11 @@ BENCHMARK(BM_Dataset_as_Histogram)->RangeMultiplier(2)->Range(0, 2 << 14);
 
 static void BM_Dataset_as_Histogram_with_slice(benchmark::State &state) {
   Dataset d;
-  d.insert(Coord::Tof{}, {Dim::Tof, 1000}, 1000);
+  d.insert(Coord::Tof, {Dim::Tof, 1000}, 1000);
   gsl::index nSpec = 10000;
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value{}, "sample", dims, dims.volume());
-  d.insert(Data::Variance{}, "sample", dims, dims.volume());
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
 
   for (auto _ : state) {
     auto sum = d(Dim::Spectrum, 0);
@@ -76,15 +76,15 @@ BENCHMARK(BM_Dataset_as_Histogram_with_slice);
 Dataset makeSingleDataDataset(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
 
-  d.insert(Coord::DetectorId{}, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::Position{}, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec}, nSpec);
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
 
-  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value{}, "sample", dims, dims.volume());
-  d.insert(Data::Variance{}, "sample", dims, dims.volume());
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
 
   return d;
 }
@@ -92,17 +92,17 @@ Dataset makeSingleDataDataset(const gsl::index nSpec, const gsl::index nPoint) {
 Dataset makeDataset(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
 
-  d.insert(Coord::DetectorId{}, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::Position{}, {Dim::Detector, nSpec}, nSpec);
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec}, nSpec);
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::DetectorId, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::Position, {Dim::Detector, nSpec}, nSpec);
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec}, nSpec);
 
-  d.insert(Coord::Tof{}, {Dim::Tof, nPoint}, nPoint);
+  d.insert(Coord::Tof, {Dim::Tof, nPoint}, nPoint);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value{}, "sample", dims, dims.volume());
-  d.insert(Data::Variance{}, "sample", dims, dims.volume());
-  d.insert(Data::Value{}, "background", dims, dims.volume());
-  d.insert(Data::Variance{}, "background", dims, dims.volume());
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
+  d.insert(Data::Value, "background", dims, dims.volume());
+  d.insert(Data::Variance, "background", dims, dims.volume());
 
   return d;
 }
@@ -238,15 +238,15 @@ Dataset makeBeamline(const gsl::index nDet) {
   // would be higher.
   Dataset dets;
 
-  dets.insert(Coord::DetectorId{}, {Dim::Detector, nDet});
-  dets.insert(Coord::Mask{}, {Dim::Detector, nDet});
-  dets.insert(Coord::Position{}, {Dim::Detector, nDet});
-  auto ids = dets.get(Coord::DetectorId{});
+  dets.insert(Coord::DetectorId, {Dim::Detector, nDet});
+  dets.insert(Coord::Mask, {Dim::Detector, nDet});
+  dets.insert(Coord::Position, {Dim::Detector, nDet});
+  auto ids = dets.get(Coord::DetectorId);
   std::iota(ids.begin(), ids.end(), 1);
 
   Dataset d;
-  d.insert(Coord::DetectorInfo{}, {}, {dets});
-  d.insert(Attr::ExperimentLog{}, "NeXus logs", {});
+  d.insert(Coord::DetectorInfo, {}, {dets});
+  d.insert(Attr::ExperimentLog, "NeXus logs", {});
 
   return d;
 }
@@ -254,12 +254,12 @@ Dataset makeBeamline(const gsl::index nDet) {
 Dataset makeSpectra(const gsl::index nSpec) {
   Dataset d;
 
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, nSpec});
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, nSpec});
-  auto groups = d.get(Coord::DetectorGrouping{});
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, nSpec});
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, nSpec});
+  auto groups = d.get(Coord::DetectorGrouping);
   for (gsl::index i = 0; i < groups.size(); ++i)
     groups[i] = {i};
-  auto nums = d.get(Coord::SpectrumNumber{});
+  auto nums = d.get(Coord::SpectrumNumber);
   std::iota(nums.begin(), nums.end(), 1);
 
   return d;
@@ -267,12 +267,12 @@ Dataset makeSpectra(const gsl::index nSpec) {
 
 Dataset makeData(const gsl::index nSpec, const gsl::index nPoint) {
   Dataset d;
-  d.insert(Coord::Tof{}, {Dim::Tof, nPoint + 1});
-  auto tofs = d.get(Coord::Tof{});
+  d.insert(Coord::Tof, {Dim::Tof, nPoint + 1});
+  auto tofs = d.get(Coord::Tof);
   std::iota(tofs.begin(), tofs.end(), 0.0);
   Dimensions dims({{Dim::Tof, nPoint}, {Dim::Spectrum, nSpec}});
-  d.insert(Data::Value{}, "sample", dims);
-  d.insert(Data::Variance{}, "sample", dims);
+  d.insert(Data::Value, "sample", dims);
+  d.insert(Data::Variance, "sample", dims);
   return d;
 }
 
@@ -310,8 +310,8 @@ static void BM_Dataset_Workspace2D_copy_and_write(benchmark::State &state) {
   auto d = makeWorkspace2D(nSpec, nPoint);
   for (auto _ : state) {
     auto copy(d);
-    copy.get(Data::Value{})[0] = 1.0;
-    copy.get(Data::Variance{})[0] = 1.0;
+    copy.get(Data::Value)[0] = 1.0;
+    copy.get(Data::Variance)[0] = 1.0;
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -323,9 +323,9 @@ static void BM_Dataset_Workspace2D_rebin(benchmark::State &state) {
   gsl::index nSpec = state.range(0) * 1024;
   gsl::index nPoint = 1024;
 
-  Variable newCoord(Coord::Tof{}, {Dim::Tof, nPoint / 2});
+  Variable newCoord(Coord::Tof, {Dim::Tof, nPoint / 2});
   double value = 0.0;
-  for (auto &tof : newCoord.get(Coord::Tof{})) {
+  for (auto &tof : newCoord.get(Coord::Tof)) {
     tof = value;
     value += 3.0;
   }
@@ -349,23 +349,23 @@ Dataset makeEventWorkspace(const gsl::index nSpec, const gsl::index nEvent) {
   auto d = makeBeamline(nSpec);
   d.merge(makeSpectra(nSpec));
 
-  d.insert(Coord::Tof{}, {Dim::Tof, 2});
+  d.insert(Coord::Tof, {Dim::Tof, 2});
 
-  d.insert(Data::Events{}, "events", {Dim::Spectrum, nSpec});
+  d.insert(Data::Events, "events", {Dim::Spectrum, nSpec});
   std::random_device rd;
   std::mt19937 mt(rd());
   std::uniform_int_distribution<int> dist(0, nEvent);
   Dataset empty;
-  empty.insert(Data::Tof{}, "", {Dim::Event, 0});
-  empty.insert(Data::PulseTime{}, "", {Dim::Event, 0});
-  for (auto &eventList : d.get(Data::Events{})) {
+  empty.insert(Data::Tof, "", {Dim::Event, 0});
+  empty.insert(Data::PulseTime, "", {Dim::Event, 0});
+  for (auto &eventList : d.get(Data::Events)) {
     // 1/4 of the event lists is empty
     gsl::index count = std::max(0l, dist(mt) - nEvent / 4);
     if (count == 0)
       eventList = empty;
     else {
-      eventList.insert(Data::Tof{}, "", {Dim::Event, count});
-      eventList.insert(Data::PulseTime{}, "", {Dim::Event, count});
+      eventList.insert(Data::Tof, "", {Dim::Event, count});
+      eventList.insert(Data::PulseTime, "", {Dim::Event, count});
     }
   }
 
@@ -399,7 +399,7 @@ static void BM_Dataset_EventWorkspace_copy_and_write(benchmark::State &state) {
   auto d = makeEventWorkspace(nSpec, nEvent);
   for (auto _ : state) {
     auto copy(d);
-    auto eventLists = copy.get(Data::Events{});
+    auto eventLists = copy.get(Data::Events);
     static_cast<void>(eventLists);
   }
   state.SetItemsProcessed(state.iterations());
@@ -417,7 +417,7 @@ static void BM_Dataset_EventWorkspace_plus(benchmark::State &state) {
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : d.get(Data::Events{}))
+  for (auto &eventList : d.get(Data::Events))
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations());
   // 2 for Tof and PulseTime
@@ -437,13 +437,13 @@ static void BM_Dataset_EventWorkspace_grow(benchmark::State &state) {
   for (auto _ : state) {
     state.PauseTiming();
     auto sum(d);
-    static_cast<void>(sum.get(Data::Events{}));
+    static_cast<void>(sum.get(Data::Events));
     state.ResumeTiming();
     sum += update;
   }
 
   gsl::index actualEvents = 0;
-  for (auto &eventList : update.get(Data::Events{}))
+  for (auto &eventList : update.get(Data::Events))
     actualEvents += eventList.dimensions()[Dim::Event];
   state.SetItemsProcessed(state.iterations() * actualEvents);
 }

--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -325,7 +325,7 @@ static void BM_Dataset_Workspace2D_rebin(benchmark::State &state) {
 
   Variable newCoord(Coord::Tof{}, {Dim::Tof, nPoint / 2});
   double value = 0.0;
-  for (auto &tof : newCoord.get<Coord::Tof>()) {
+  for (auto &tof : newCoord.get(Coord::Tof{})) {
     tof = value;
     value += 3.0;
   }

--- a/benchmark/variable_benchmark.cpp
+++ b/benchmark/variable_benchmark.cpp
@@ -8,7 +8,7 @@
 #include "variable.h"
 
 static void BM_Variable_copy(benchmark::State &state) {
-  Variable var(Coord::X{}, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
 
   for (auto _ : state) {
     Variable copy(var);
@@ -17,7 +17,7 @@ static void BM_Variable_copy(benchmark::State &state) {
 BENCHMARK(BM_Variable_copy);
 
 static void BM_Variable_trivial_slice(benchmark::State &state) {
-  Variable var(Coord::X{}, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
 
   for (auto _ : state) {
     ConstVariableSlice view(var);
@@ -29,7 +29,7 @@ BENCHMARK(BM_Variable_trivial_slice);
 // The following two benchmarks "prove" that operator+ with a VariableSlice is
 // not unintentionally converting the second argument to a temporary Variable.
 static void BM_Variable_binary_with_Variable(benchmark::State &state) {
-  Variable var(Coord::X{}, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable var(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
   Variable a = var(Dim::Z, 0, 8);
 
   for (auto _ : state) {
@@ -38,7 +38,7 @@ static void BM_Variable_binary_with_Variable(benchmark::State &state) {
   }
 }
 static void BM_Variable_binary_with_VariableSlice(benchmark::State &state) {
-  Variable b(Coord::X{}, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
+  Variable b(Coord::X, {{Dim::Z, 10}, {Dim::Y, 20}, {Dim::X, 30}});
   Variable a = b(Dim::Z, 0, 8);
 
   for (auto _ : state) {

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -86,8 +86,10 @@ template <class Tag> struct MakeVariable {
 void insertCoord(
     Dataset &self, const Tag tag,
     const std::tuple<const std::vector<Dim> &, py::array &> &data) {
-  auto var = Call<Coord::X, Coord::Y, Coord::Z, Coord::Tof, Coord::Mask,
-                  Coord::SpectrumNumber>::apply<MakeVariable>(tag, data);
+  auto var =
+      Call<decltype(Coord::X), decltype(Coord::Y), decltype(Coord::Z),
+           decltype(Coord::Tof), decltype(Coord::Mask),
+           decltype(Coord::SpectrumNumber)>::apply<MakeVariable>(tag, data);
   self.insert(std::move(var));
 }
 
@@ -95,9 +97,8 @@ template <class T>
 void insertCoordT(
     Dataset &self, const Tag tag,
     const std::tuple<const std::vector<Dim> &, py::array_t<T> &> &data) {
-  auto var =
-      Call<Coord::X, Coord::Y, Coord::Z, Coord::Tof>::apply<MakeVariable>(tag,
-                                                                          data);
+  auto var = Call<decltype(Coord::X), decltype(Coord::Y), decltype(Coord::Z),
+                  decltype(Coord::Tof)>::apply<MakeVariable>(tag, data);
   self.insert(std::move(var));
 }
 
@@ -116,8 +117,10 @@ void insertCoord1D(Dataset &self, const Tag,
 void insertNamed(
     Dataset &self, const std::pair<Tag, const std::string &> &key,
     const std::tuple<const std::vector<Dim> &, py::array_t<double> &> &data) {
-  auto var = Call<Data::Value, Data::Variance>::apply<MakeVariable>(
-      std::get<Tag>(key), data);
+  auto var =
+      Call<decltype(Data::Value),
+           decltype(Data::Variance)>::apply<MakeVariable>(std::get<Tag>(key),
+                                                          data);
   var.setName(std::get<const std::string &>(key));
   self.insert(std::move(var));
 }
@@ -300,26 +303,26 @@ PYBIND11_MODULE(dataset, m) {
   py::class_<Tag>(m, "Tag").def(py::self == py::self);
 
   auto data_tags = m.def_submodule("Data");
-  py::class_<Data::Value, Tag>(data_tags, "_Value");
-  py::class_<Data::Variance, Tag>(data_tags, "_Variance");
-  data_tags.attr("Value") = Data::Value{};
-  data_tags.attr("Variance") = Data::Variance{};
+  // py::class_<Data::Value, Tag>(data_tags, "_Value");
+  // py::class_<Data::Variance, Tag>(data_tags, "_Variance");
+  data_tags.attr("Value") = Data::Value;
+  data_tags.attr("Variance") = Data::Variance;
 
   auto coord_tags = m.def_submodule("Coord");
-  py::class_<Coord::Mask, Tag>(coord_tags, "_Mask");
-  py::class_<Coord::X, Tag>(coord_tags, "_X");
-  py::class_<Coord::Y, Tag>(coord_tags, "_Y");
-  py::class_<Coord::Z, Tag>(coord_tags, "_Z");
-  py::class_<Coord::Tof, Tag>(coord_tags, "_Tof");
-  py::class_<Coord::RowLabel, Tag>(coord_tags, "_RowLabel");
-  py::class_<Coord::SpectrumNumber, Tag>(coord_tags, "_SpectrumNumber");
-  coord_tags.attr("Mask") = Coord::Mask{};
-  coord_tags.attr("X") = Coord::X{};
-  coord_tags.attr("Y") = Coord::Y{};
-  coord_tags.attr("Z") = Coord::Z{};
-  coord_tags.attr("Tof") = Coord::Tof{};
-  coord_tags.attr("RowLabel") = Coord::RowLabel{};
-  coord_tags.attr("SpectrumNumber") = Coord::SpectrumNumber{};
+  // py::class_<Coord::Mask, Tag>(coord_tags, "_Mask");
+  // py::class_<Coord::X, Tag>(coord_tags, "_X");
+  // py::class_<Coord::Y, Tag>(coord_tags, "_Y");
+  // py::class_<Coord::Z, Tag>(coord_tags, "_Z");
+  // py::class_<Coord::Tof, Tag>(coord_tags, "_Tof");
+  // py::class_<Coord::RowLabel, Tag>(coord_tags, "_RowLabel");
+  // py::class_<Coord::SpectrumNumber, Tag>(coord_tags, "_SpectrumNumber");
+  coord_tags.attr("Mask") = Coord::Mask;
+  coord_tags.attr("X") = Coord::X;
+  coord_tags.attr("Y") = Coord::Y;
+  coord_tags.attr("Z") = Coord::Z;
+  coord_tags.attr("Tof") = Coord::Tof;
+  coord_tags.attr("RowLabel") = Coord::RowLabel;
+  coord_tags.attr("SpectrumNumber") = Coord::SpectrumNumber;
 
   declare_span<double>(m, "double");
   declare_span<const double>(m, "double_const");
@@ -348,12 +351,12 @@ PYBIND11_MODULE(dataset, m) {
 
   py::class_<Variable>(m, "Variable")
       .def(py::init(&detail::makeVariableDefaultInit))
-      .def(py::init(&detail::makeVariable<Coord::Mask>))
-      .def(py::init(&detail::makeVariable<Coord::X>))
-      .def(py::init(&detail::makeVariable<Coord::Y>))
-      .def(py::init(&detail::makeVariable<Coord::Z>))
-      .def(py::init(&detail::makeVariable<Data::Value>))
-      .def(py::init(&detail::makeVariable<Data::Variance>))
+      .def(py::init(&detail::makeVariable<Coord::Mask_t>))
+      .def(py::init(&detail::makeVariable<Coord::X_t>))
+      .def(py::init(&detail::makeVariable<Coord::Y_t>))
+      .def(py::init(&detail::makeVariable<Coord::Z_t>))
+      .def(py::init(&detail::makeVariable<Data::Value_t>))
+      .def(py::init(&detail::makeVariable<Data::Variance_t>))
       .def(py::init<const VariableSlice &>())
       .def_property_readonly("tag", &Variable::tag)
       .def_property("name", [](const Variable &self) { return self.name(); },
@@ -395,8 +398,8 @@ PYBIND11_MODULE(dataset, m) {
            })
       // TODO Make these using py::array instead of py::array_t, then cast based
       // on tag?
-      .def("__setitem__", &setVariableSlice<Data::Value>)
-      .def("__setitem__", &setVariableSliceRange<Data::Value>)
+      .def("__setitem__", &setVariableSlice<Data::Value_t>)
+      .def("__setitem__", &setVariableSliceRange<Data::Value_t>)
       .def_property_readonly(
           "numpy",
           &as_py_array_t_variant<double, float, int64_t, int32_t, char>)
@@ -451,8 +454,8 @@ PYBIND11_MODULE(dataset, m) {
           [](DatasetSlice &self, const std::pair<Tag, const std::string> &key) {
             return self(key.first, key.second);
           })
-      .def("__setitem__", detail::setData<Data::Value, DatasetSlice>)
-      .def("__setitem__", detail::setData<Data::Variance, DatasetSlice>)
+      .def("__setitem__", detail::setData<Data::Value_t, DatasetSlice>)
+      .def("__setitem__", detail::setData<Data::Variance_t, DatasetSlice>)
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self *= py::self, py::call_guard<py::gil_scoped_release>());
@@ -518,20 +521,20 @@ PYBIND11_MODULE(dataset, m) {
              throw std::runtime_error("Non-self-assignment of Dataset slices "
                                       "is not implemented yet.\n");
            })
-      .def("__setitem__", detail::setData<Data::Value, Dataset>)
-      .def("__setitem__", detail::setData<Data::Variance, Dataset>)
+      .def("__setitem__", detail::setData<Data::Value_t, Dataset>)
+      .def("__setitem__", detail::setData<Data::Variance_t, Dataset>)
       .def("__setitem__", detail::insertCoord)
       // TODO: Overloaded to cover non-numpy data such as a scalar value. This
       // is handled by automatic conversion by PYbind11 when using py::array_t.
       // See also the py::array::forcecast argument, we need to minimize
       // implicit (and potentially expensive conversion).
       .def("__setitem__", detail::insertCoordT<double>)
-      .def("__setitem__", detail::insertCoord1D<Coord::RowLabel>)
+      .def("__setitem__", detail::insertCoord1D<Coord::RowLabel_t>)
       .def("__setitem__", detail::insertNamed)
-      .def("__setitem__", detail::insert<Data::Value, Variable>)
-      .def("__setitem__", detail::insert<Data::Variance, Variable>)
-      .def("__setitem__", detail::insert<Data::Value, VariableSlice>)
-      .def("__setitem__", detail::insert<Data::Variance, VariableSlice>)
+      .def("__setitem__", detail::insert<Data::Value_t, Variable>)
+      .def("__setitem__", detail::insert<Data::Variance_t, Variable>)
+      .def("__setitem__", detail::insert<Data::Value_t, VariableSlice>)
+      .def("__setitem__", detail::insert<Data::Variance_t, VariableSlice>)
       .def("__setitem__", detail::insertDefaultInit)
       // TODO Make sure we have all overloads covered to avoid implicit
       // conversion of DatasetSlice to Dataset.

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -130,7 +130,7 @@ void insert(Dataset &self, const std::pair<Tag, const std::string &> &key,
   if (self.contains(tag, name))
     if (self(tag, name) == var)
       return;
-  const auto &data = var.template get<Tag>();
+  const auto &data = var.get(Tag{});
   self.insert(Tag{}, name, var.dimensions(), data.begin(), data.end());
 }
 
@@ -166,7 +166,7 @@ void setData(T &self, const std::pair<const Tag, const std::string> &key,
     throw std::runtime_error(
         "Shape mismatch when setting data from numpy array.");
 
-  auto buf = self[index].template get<Tag>();
+  auto buf = self[index].get(Tag{});
   double *ptr = (double *)info.ptr;
   std::copy(ptr, ptr + dims.volume(), buf.begin());
 }
@@ -222,7 +222,7 @@ void doSetVariableSlice(VariableSlice &slice,
     throw std::runtime_error(
         "Shape mismatch when setting data from numpy array.");
 
-  auto buf = slice.template get<Tag>();
+  auto buf = slice.get(Tag{});
   double *ptr = (double *)info.ptr;
   std::copy(ptr, ptr + dims.volume(), buf.begin());
 }

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -303,19 +303,19 @@ PYBIND11_MODULE(dataset, m) {
   py::class_<Tag>(m, "Tag").def(py::self == py::self);
 
   auto data_tags = m.def_submodule("Data");
-  // py::class_<Data::Value, Tag>(data_tags, "_Value");
-  // py::class_<Data::Variance, Tag>(data_tags, "_Variance");
+  py::class_<Data::Value_t, Tag>(data_tags, "_Value");
+  py::class_<Data::Variance_t, Tag>(data_tags, "_Variance");
   data_tags.attr("Value") = Data::Value;
   data_tags.attr("Variance") = Data::Variance;
 
   auto coord_tags = m.def_submodule("Coord");
-  // py::class_<Coord::Mask, Tag>(coord_tags, "_Mask");
-  // py::class_<Coord::X, Tag>(coord_tags, "_X");
-  // py::class_<Coord::Y, Tag>(coord_tags, "_Y");
-  // py::class_<Coord::Z, Tag>(coord_tags, "_Z");
-  // py::class_<Coord::Tof, Tag>(coord_tags, "_Tof");
-  // py::class_<Coord::RowLabel, Tag>(coord_tags, "_RowLabel");
-  // py::class_<Coord::SpectrumNumber, Tag>(coord_tags, "_SpectrumNumber");
+  py::class_<Coord::Mask_t, Tag>(coord_tags, "_Mask");
+  py::class_<Coord::X_t, Tag>(coord_tags, "_X");
+  py::class_<Coord::Y_t, Tag>(coord_tags, "_Y");
+  py::class_<Coord::Z_t, Tag>(coord_tags, "_Z");
+  py::class_<Coord::Tof_t, Tag>(coord_tags, "_Tof");
+  py::class_<Coord::RowLabel_t, Tag>(coord_tags, "_RowLabel");
+  py::class_<Coord::SpectrumNumber_t, Tag>(coord_tags, "_SpectrumNumber");
   coord_tags.attr("Mask") = Coord::Mask;
   coord_tags.attr("X") = Coord::X;
   coord_tags.attr("Y") = Coord::Y;

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -21,7 +21,7 @@ Dataset tofToEnergy(const Dataset &d) {
                              "only supported for elastic scattering.");
 
   // 1. Compute conversion factor
-  const auto &compPos = d.get<Coord::ComponentInfo>()[0].get<Coord::Position>();
+  const auto &compPos = d.get(Coord::ComponentInfo{})[0].get(Coord::Position{});
   // TODO Need a better mechanism to identify source and sample.
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
@@ -98,7 +98,7 @@ Dataset tofToDeltaE(const Dataset &d) {
                              "cannot have both for inelastic scattering.");
 
   // 1. Compute conversion factors
-  const auto &compPos = d.get<Coord::ComponentInfo>()[0].get<Coord::Position>();
+  const auto &compPos = d.get(Coord::ComponentInfo{})[0].get(Coord::Position{});
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
   const double l1 = (sourcePos - samplePos).norm();
@@ -114,7 +114,7 @@ Dataset tofToDeltaE(const Dataset &d) {
 
     // This is how we support multi-Ei data!
     tofShift.setDimensions(d(Coord::Ei{}).dimensions());
-    const auto &Ei = d.get<Coord::Ei>();
+    const auto &Ei = d.get(Coord::Ei{});
     std::transform(Ei.begin(), Ei.end(), tofShift.span<double>().begin(),
                    [&l1](const double Ei) { return l1 / sqrt(Ei); });
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -15,22 +15,22 @@ namespace tof {
 Dataset tofToEnergy(const Dataset &d) {
   // TODO Could in principle also support inelastic. Note that the conversion in
   // Mantid is wrong since it handles inelastic data as if it were elastic.
-  if (d.contains(Coord::Ei{}) || d.contains(Coord::Ef{}))
+  if (d.contains(Coord::Ei) || d.contains(Coord::Ef))
     throw std::runtime_error("Dataset contains Coord::Ei or Coord::Ef. "
                              "However, conversion to Dim::Energy is currently "
                              "only supported for elastic scattering.");
 
   // 1. Compute conversion factor
-  const auto &compPos = d.get(Coord::ComponentInfo{})[0].get(Coord::Position{});
+  const auto &compPos = d.get(Coord::ComponentInfo)[0].get(Coord::Position);
   // TODO Need a better mechanism to identify source and sample.
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
   const double l1 = (sourcePos - samplePos).norm();
 
-  const auto &dims = d.contains(Coord::Position{})
-                         ? d(Coord::Position{}).dimensions()
-                         : d(Coord::DetectorGrouping{}).dimensions();
-  Variable conversionFactor(Data::Value{}, dims);
+  const auto &dims = d.contains(Coord::Position)
+                         ? d(Coord::Position).dimensions()
+                         : d(Coord::DetectorGrouping).dimensions();
+  Variable conversionFactor(Data::Value, dims);
 
   // This scale factor should be obtained from the unit stored in the Tof
   // coordinate, something like mus2_to_s2 = pow(tof.unit().si_scale(), 2);
@@ -42,9 +42,9 @@ Dataset tofToEnergy(const Dataset &d) {
   auto physicalConstants =
       boost::units::si::constants::codata::m_n / (2.0 * meV * mus2_to_s2);
 
-  auto specPos = zipMD(d, MDRead(Coord::Position{}));
+  auto specPos = zipMD(d, MDRead(Coord::Position));
   const auto factor = [&](const auto &item) {
-    const auto &pos = item.template get<Coord::Position>();
+    const auto &pos = item.get(Coord::Position);
     double l_total = l1 + (samplePos - pos).norm();
     return l_total * l_total * physicalConstants.value();
   };
@@ -60,7 +60,7 @@ Dataset tofToEnergy(const Dataset &d) {
     auto varDims = var.dimensions();
     if (varDims.contains(Dim::Tof))
       varDims.relabel(varDims.index(Dim::Tof), Dim::Energy);
-    if (var.tag() == Coord::Tof{}) {
+    if (var.tag() == Coord::Tof) {
       // TODO Need to extend the broadcasting capabilities to broadcast to the
       // union of dimensions of both operands in a binary operation.
       auto dims = conversionFactor.dimensions();
@@ -68,13 +68,13 @@ Dataset tofToEnergy(const Dataset &d) {
         if (!dims.contains(dim))
           dims.addInner(dim, varDims[dim]);
       // TODO Should have a broadcasting assign method?
-      Variable energy(Coord::Energy{}, dims, dims.volume(), 1.0);
+      Variable energy(Coord::Energy, dims, dims.volume(), 1.0);
       energy *= conversionFactor;
       // The reshape is just to remap the dimension label, should probably do
       // this differently.
       energy /= (var * var).reshape(varDims);
       converted.insert(energy);
-    } else if (var.tag() == Data::Events{}) {
+    } else if (var.tag() == Data::Events) {
       throw std::runtime_error(
           "TODO Converting units of event data not implemented yet.");
     } else {
@@ -93,49 +93,49 @@ Dataset tofToDeltaE(const Dataset &d) {
 
   // There are two cases, direct inelastic and indirect inelastic. We can
   // distinguish them by the content of d.
-  if (d.contains(Coord::Ei{}) && d.contains(Coord::Ef{}))
+  if (d.contains(Coord::Ei) && d.contains(Coord::Ef))
     throw std::runtime_error("Dataset contains Coord::Ei as well as Coord::Ef, "
                              "cannot have both for inelastic scattering.");
 
   // 1. Compute conversion factors
-  const auto &compPos = d.get(Coord::ComponentInfo{})[0].get(Coord::Position{});
+  const auto &compPos = d.get(Coord::ComponentInfo)[0].get(Coord::Position);
   const auto &sourcePos = compPos[0];
   const auto &samplePos = compPos[1];
   const double l1 = (sourcePos - samplePos).norm();
 
-  const auto &dims = d.contains(Coord::Position{})
-                         ? d(Coord::Position{}).dimensions()
-                         : d(Coord::DetectorGrouping{}).dimensions();
-  Variable tofShift(Data::Value{}, {});
-  Variable scale(Data::Value{}, {});
+  const auto &dims = d.contains(Coord::Position)
+                         ? d(Coord::Position).dimensions()
+                         : d(Coord::DetectorGrouping).dimensions();
+  Variable tofShift(Data::Value, {});
+  Variable scale(Data::Value, {});
 
-  if (d.contains(Coord::Ei{})) {
+  if (d.contains(Coord::Ei)) {
     // Direct-inelastic.
 
     // This is how we support multi-Ei data!
-    tofShift.setDimensions(d(Coord::Ei{}).dimensions());
-    const auto &Ei = d.get(Coord::Ei{});
+    tofShift.setDimensions(d(Coord::Ei).dimensions());
+    const auto &Ei = d.get(Coord::Ei);
     std::transform(Ei.begin(), Ei.end(), tofShift.span<double>().begin(),
                    [&l1](const double Ei) { return l1 / sqrt(Ei); });
 
     scale.setDimensions(dims);
-    auto specPos = zipMD(d, MDRead(Coord::Position{}));
+    auto specPos = zipMD(d, MDRead(Coord::Position));
     std::transform(specPos.begin(), specPos.end(), scale.span<double>().begin(),
                    [&](const auto &item) {
-                     const auto &pos = item.template get<Coord::Position>();
+                     const auto &pos = item.get(Coord::Position);
                      const double l2 = (samplePos - pos).norm();
                      return l2 * l2;
                    });
-  } else if (d.contains(Coord::Ef{})) {
+  } else if (d.contains(Coord::Ef)) {
     // Indirect-inelastic.
 
     tofShift.setDimensions(dims);
     // Ef can be different for every spectrum so we access it also via a view.
-    auto geometry = zipMD(d, MDRead(Coord::Position{}), MDRead(Coord::Ef{}));
+    auto geometry = zipMD(d, MDRead(Coord::Position), MDRead(Coord::Ef));
     std::transform(geometry.begin(), geometry.end(),
                    tofShift.span<double>().begin(), [&](const auto &item) {
-                     const auto &pos = item.template get<Coord::Position>();
-                     const auto &Ef = item.template get<Coord::Ef>();
+                     const auto &pos = item.get(Coord::Position);
+                     const auto &Ef = item.get(Coord::Ef);
                      const double l2 = (samplePos - pos).norm();
                      return l2 * l2 / sqrt(Ef);
                    });
@@ -154,23 +154,23 @@ Dataset tofToDeltaE(const Dataset &d) {
     auto varDims = var.dimensions();
     if (varDims.contains(Dim::Tof))
       varDims.relabel(varDims.index(Dim::Tof), Dim::DeltaE);
-    if (var.tag() == Coord::Tof{}) {
+    if (var.tag() == Coord::Tof) {
       auto dims = scale.dimensions();
       for (const Dim dim : varDims.labels())
         if (!dims.contains(dim))
           dims.addInner(dim, varDims[dim]);
-      Variable E(Coord::DeltaE{}, dims, dims.volume(), 1.0);
+      Variable E(Coord::DeltaE, dims, dims.volume(), 1.0);
       E *= var.reshape(varDims);
       E -= tofShift;
       E *= E;
       E = 1.0 / std::move(E);
       E *= scale;
-      if (d.contains(Coord::Ei{})) {
-        converted.insert(-(std::move(E) - d(Coord::Ei{})));
+      if (d.contains(Coord::Ei)) {
+        converted.insert(-(std::move(E) - d(Coord::Ei)));
       } else {
-        converted.insert(std::move(E) - d(Coord::Ef{}));
+        converted.insert(std::move(E) - d(Coord::Ef));
       }
-    } else if (var.tag() == Data::Events{}) {
+    } else if (var.tag() == Data::Events) {
       throw std::runtime_error(
           "TODO Converting units of event data not implemented yet.");
     } else {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -671,7 +671,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
 
   // Counts has outer dimensions as input, with a new inner dimension given by
   // the binning dimensions. We iterate over all dimensions as a flat array.
-  auto counts = hist.get<Data::Value>(var.name());
+  auto counts = hist.get(Data::Value{}, var.name());
   gsl::index cur = 0;
   // The helper `getView` allows us to ignore the tag of coord, as long as the
   // underlying type is `double`. We view the edges with the same dimensions as
@@ -681,7 +681,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   const auto edges = getView<double>(coord, dims);
   auto edge = edges.begin();
   for (const auto &eventList : events) {
-    const auto tofs = eventList.get<Data::Tof>();
+    const auto tofs = eventList.get(Data::Tof{});
     if (!std::is_sorted(tofs.begin(), tofs.end()))
       throw std::runtime_error(
           "TODO: Histograms can currently only be created from sorted data.");
@@ -723,7 +723,7 @@ Dataset histogram(const Dataset &d, const Variable &coord) {
 // datasets that represent events lists, using ZipView.
 template <class Tag> struct Sort {
   static Dataset apply(const Dataset &d, const std::string &name) {
-    auto const_axis = d.get<Tag>(name);
+    auto const_axis = d.get(Tag{}, name);
     if (d(Tag{}, name).dimensions().count() != 1)
       throw std::runtime_error("Axis for sorting must be 1-dimensional.");
     const auto sortDim = d(Tag{}, name).dimensions().label(0);
@@ -734,7 +734,7 @@ template <class Tag> struct Sort {
 
     Dataset sorted;
     Variable axisVar = d(Tag{}, name);
-    auto axis = axisVar.template get(Tag{});
+    auto axis = axisVar.get(Tag{});
     std::vector<gsl::index> indices(axis.size());
     std::iota(indices.begin(), indices.end(), 0);
     auto view = ranges::view::zip(axis, indices);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -317,10 +317,10 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
             // TODO We are working with VariableSlice here, so get<> returns a
             // view, not a span, i.e., it is less efficient. May need to do this
             // differently for optimal performance.
-            auto v1 = var1.template get<Data::Value>();
-            const auto v2 = var2.template get<Data::Value>();
-            auto e1 = error1.template get<Data::Variance>();
-            const auto e2 = error2.template get<Data::Variance>();
+            auto v1 = var1.template span<double>();
+            const auto v2 = var2.template span<double>();
+            auto e1 = error1.template span<double>();
+            const auto e2 = error2.template span<double>();
             // TODO Need to ensure that data is contiguous!
             aligned::multiply(v1.size(), v1.data(), e1.data(), v2.data(),
                               e2.data());
@@ -636,7 +636,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // TODO Is there are more generic way to find "histogrammable" data, not
   // specific to (neutron) events? Something like Data::ValueVector, i.e., any
   // data variable that contains a vector of values at each point?
-  const auto &events = var.get<Data::Events>();
+  const auto &events = var.get(Data::Events{});
   // TODO This way of handling events (and their units) as nested Dataset feels
   // a bit unwieldy. Would it be a better option to store TOF (or any derived
   // values) as simple vectors in Data::Events? There would be a separate
@@ -734,7 +734,7 @@ template <class Tag> struct Sort {
 
     Dataset sorted;
     Variable axisVar = d(Tag{}, name);
-    auto axis = axisVar.template get<Tag>();
+    auto axis = axisVar.template get(Tag{});
     std::vector<gsl::index> indices(axis.size());
     std::iota(indices.begin(), indices.end(), 0);
     auto view = ranges::view::zip(axis, indices);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -208,7 +208,7 @@ T1 &binary_op_equals(Op op, T1 &dataset, const T2 &other) {
         // var2: var1 = var2;
       } else if (var1.isData()) {
         // Data variables are added
-        if (var1.tag() == Data::Variance{})
+        if (var1.tag() == Data::Variance)
           var1 += var2;
         else
           op(var1, var2);
@@ -228,7 +228,7 @@ T1 &binary_op_equals(Op op, T1 &dataset, const T2 &other) {
         for (auto var1 : dataset) {
           if (var1.tag() == var2.tag()) {
             ++count;
-            if (var1.tag() == Data::Variance{})
+            if (var1.tag() == Data::Variance)
               var1 += var2;
             else
               op(var1, var2);
@@ -278,10 +278,10 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
       throw std::runtime_error("Right-hand-side in addition contains variable "
                                "that is not present in left-hand-side.");
     }
-    if (var2.tag() == Data::Variance{}) {
+    if (var2.tag() == Data::Variance) {
       try {
-        find(dataset, Data::Value{}, var2.name());
-        find(other, Data::Value{}, var2.name());
+        find(dataset, Data::Value, var2.name());
+        find(other, Data::Value, var2.name());
       } catch (const std::runtime_error &) {
         throw std::runtime_error("Cannot multiply datasets that contain a "
                                  "variance but no corresponding value.");
@@ -295,14 +295,14 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
             "Coordinates of datasets do not match. Cannot perform addition");
     } else if (var1.isData()) {
       // Data variables are added
-      if (var2.tag() == Data::Value{}) {
-        if (count(dataset, Data::Variance{}, var2.name()) !=
-            count(other, Data::Variance{}, var2.name()))
+      if (var2.tag() == Data::Value) {
+        if (count(dataset, Data::Variance, var2.name()) !=
+            count(other, Data::Variance, var2.name()))
           throw std::runtime_error("Either both or none of the operands must "
                                    "have a variance for their values.");
-        if (count(dataset, Data::Variance{}, var2.name()) != 0) {
-          auto error_index1 = find(dataset, Data::Variance{}, var2.name());
-          auto error_index2 = find(other, Data::Variance{}, var2.name());
+        if (count(dataset, Data::Variance, var2.name()) != 0) {
+          auto error_index1 = find(dataset, Data::Variance, var2.name());
+          auto error_index2 = find(other, Data::Variance, var2.name());
           auto error1 = dataset[error_index1];
           const auto &error2 = other[error_index2];
           if ((var1.dimensions() == var2.dimensions()) &&
@@ -338,7 +338,7 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
           // No variance found, continue without.
           var1 *= var2;
         }
-      } else if (var2.tag() == Data::Variance{}) {
+      } else if (var2.tag() == Data::Variance) {
         // Do nothing, math for variance is done when processing corresponding
         // value.
       } else {
@@ -367,7 +367,7 @@ Dataset &Dataset::operator+=(const ConstDatasetSlice &other) {
 }
 Dataset &Dataset::operator+=(const double value) {
   for (auto &var : m_variables)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var += value;
   return *this;
 }
@@ -384,7 +384,7 @@ Dataset &Dataset::operator-=(const ConstDatasetSlice &other) {
 }
 Dataset &Dataset::operator-=(const double value) {
   for (auto &var : m_variables)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var -= value;
   return *this;
 }
@@ -397,9 +397,9 @@ Dataset &Dataset::operator*=(const ConstDatasetSlice &other) {
 }
 Dataset &Dataset::operator*=(const double value) {
   for (auto &var : m_variables)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var *= value;
-    else if (var.tag() == Data::Variance{})
+    else if (var.tag() == Data::Variance)
       var *= value * value;
   return *this;
 }
@@ -458,7 +458,7 @@ DatasetSlice DatasetSlice::operator+=(const ConstDatasetSlice &other) {
 }
 DatasetSlice DatasetSlice::operator+=(const double value) {
   for (auto var : *this)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var += value;
   return *this;
 }
@@ -474,7 +474,7 @@ DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) {
 }
 DatasetSlice DatasetSlice::operator-=(const double value) {
   for (auto var : *this)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var -= value;
   return *this;
 }
@@ -487,9 +487,9 @@ DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) {
 }
 DatasetSlice DatasetSlice::operator*=(const double value) {
   for (auto var : *this)
-    if (var.tag() == Data::Value{})
+    if (var.tag() == Data::Value)
       var *= value;
-    else if (var.tag() == Data::Variance{})
+    else if (var.tag() == Data::Variance)
       var *= value * value;
   return *this;
 }
@@ -636,7 +636,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // TODO Is there are more generic way to find "histogrammable" data, not
   // specific to (neutron) events? Something like Data::ValueVector, i.e., any
   // data variable that contains a vector of values at each point?
-  const auto &events = var.get(Data::Events{});
+  const auto &events = var.get(Data::Events);
   // TODO This way of handling events (and their units) as nested Dataset feels
   // a bit unwieldy. Would it be a better option to store TOF (or any derived
   // values) as simple vectors in Data::Events? There would be a separate
@@ -645,7 +645,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   // implementation of `histogram` would then also be simplified since we do not
   // need to distinguish between Data::Tof, etc. (which we are anyway not doing
   // currently).
-  dataset::expect::equals(events[0](Data::Tof{}).unit(), coord.unit());
+  dataset::expect::equals(events[0](Data::Tof).unit(), coord.unit());
 
   // TODO Can we reuse some code for bin handling from MDZipView?
   const auto binDim = coordDimension[coord.tag().value()];
@@ -667,11 +667,11 @@ Dataset histogram(const Variable &var, const Variable &coord) {
 
   Dataset hist;
   hist.insert(coord);
-  hist.insert(Data::Value{}, var.name(), dims);
+  hist.insert(Data::Value, var.name(), dims);
 
   // Counts has outer dimensions as input, with a new inner dimension given by
   // the binning dimensions. We iterate over all dimensions as a flat array.
-  auto counts = hist.get(Data::Value{}, var.name());
+  auto counts = hist.get(Data::Value, var.name());
   gsl::index cur = 0;
   // The helper `getView` allows us to ignore the tag of coord, as long as the
   // underlying type is `double`. We view the edges with the same dimensions as
@@ -681,7 +681,7 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   const auto edges = getView<double>(coord, dims);
   auto edge = edges.begin();
   for (const auto &eventList : events) {
-    const auto tofs = eventList.get(Data::Tof{});
+    const auto tofs = eventList.get(Data::Tof);
     if (!std::is_sorted(tofs.begin(), tofs.end()))
       throw std::runtime_error(
           "TODO: Histograms can currently only be created from sorted data.");
@@ -704,14 +704,14 @@ Dataset histogram(const Variable &var, const Variable &coord) {
   }
 
   // TODO Would need to add handling for weighted events etc. here.
-  hist.insert(Data::Variance{}, var.name(), dims, counts.begin(), counts.end());
+  hist.insert(Data::Variance, var.name(), dims, counts.begin(), counts.end());
   return hist;
 }
 
 Dataset histogram(const Dataset &d, const Variable &coord) {
   Dataset hist;
   for (const auto &var : d)
-    if (var.tag() == Data::Events{})
+    if (var.tag() == Data::Events)
       hist.merge(histogram(var, coord));
   if (hist.size() == 0)
     throw std::runtime_error("Dataset does not contain any variables with "
@@ -721,20 +721,21 @@ Dataset histogram(const Dataset &d, const Variable &coord) {
 
 // We can specialize this to switch to a more efficient variant when sorting
 // datasets that represent events lists, using ZipView.
-template <class Tag> struct Sort {
-  static Dataset apply(const Dataset &d, const std::string &name) {
-    auto const_axis = d.get(Tag{}, name);
-    if (d(Tag{}, name).dimensions().count() != 1)
+template <class T> struct Sort {
+  static Dataset apply(const Dataset &d, const Tag tag,
+                       const std::string &name) {
+    auto const_axis = d.span<T>(tag, name);
+    if (d(tag, name).dimensions().count() != 1)
       throw std::runtime_error("Axis for sorting must be 1-dimensional.");
-    const auto sortDim = d(Tag{}, name).dimensions().label(0);
+    const auto sortDim = d(tag, name).dimensions().label(0);
     if (const_axis.size() != d.dimensions()[sortDim])
       throw std::runtime_error("Axis for sorting cannot be a bin-edge axis.");
     if (std::is_sorted(const_axis.begin(), const_axis.end()))
       return d;
 
     Dataset sorted;
-    Variable axisVar = d(Tag{}, name);
-    auto axis = axisVar.get(Tag{});
+    Variable axisVar = d(tag, name);
+    auto axis = axisVar.span<T>();
     std::vector<gsl::index> indices(axis.size());
     std::iota(indices.begin(), indices.end(), 0);
     auto view = ranges::view::zip(axis, indices);
@@ -747,7 +748,7 @@ template <class Tag> struct Sort {
     for (const auto &var : d) {
       if (!var.dimensions().contains(sortDim))
         sorted.insert(var);
-      else if (var.tag() == Tag{} && var.name() == name)
+      else if (var.tag() == tag && var.name() == name)
         sorted.insert(axisVar);
       else
         sorted.insert(permute(var, sortDim, indices));
@@ -757,11 +758,8 @@ template <class Tag> struct Sort {
 };
 
 Dataset sort(const Dataset &d, const Tag t, const std::string &name) {
-  // Another helper `callForSortableTag` that could be added in tag_util.h would
-  // allow for generic support for all valid tags. Would simply need to filter
-  // all tags based on whether Tag::type has `operator<`, using some meta
-  // programming.
-  return Call<Coord::RowLabel, Coord::X, Data::Value>::apply<Sort>(t, d, name);
+  return CallDType<double, float, int64_t, int32_t, std::string>::apply<Sort>(
+      d(t, name).dtype(), d, t, name);
 }
 
 Dataset filter(const Dataset &d, const Variable &select) {
@@ -811,12 +809,12 @@ Dataset mean(const Dataset &d, const Dim dim) {
   for (auto var : d) {
     if (var.dimensions().contains(dim)) {
       if (var.isData()) {
-        if (var.tag() == Data::Variance{}) {
+        if (var.tag() == Data::Variance) {
           // Standard deviation of the mean has an extra 1/sqrt(N). Note that
           // this is not included by the stand-alone mean(Variable), since that
           // would be confusing.
           double scale = 1.0 / sqrt(static_cast<double>(var.dimensions()[dim]));
-          m.insert(mean(var, dim) * Variable(Data::Value{}, {}, {scale}));
+          m.insert(mean(var, dim) * Variable(Data::Value, {}, {scale}));
         } else {
           m.insert(mean(var, dim));
         }

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -176,17 +176,19 @@ public:
 
   void merge(const Dataset &other);
 
-  template <class Tag>
-  auto get(const std::string &name = std::string{}) const && = delete;
-  template <class Tag>
-  auto get(const std::string &name = std::string{}) const & {
-    return m_variables[find(Tag{}, name)].get(Tag{});
+  template <class TagT>
+  auto get(const TagT,
+           const std::string &name = std::string{}) const && = delete;
+  template <class TagT>
+  auto get(const TagT tag, const std::string &name = std::string{}) const & {
+    return m_variables[find(tag, name)].get(tag);
   }
 
-  template <class Tag>
-  auto get(const std::string &name = std::string{}) && = delete;
-  template <class Tag> auto get(const std::string &name = std::string{}) & {
-    return m_variables[find(Tag{}, name)].get(Tag{});
+  template <class TagT>
+  auto get(const TagT, const std::string &name = std::string{}) && = delete;
+  template <class TagT>
+  auto get(const TagT tag, const std::string &name = std::string{}) & {
+    return m_variables[find(tag, name)].get(tag);
   }
 
   template <class T>

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -180,13 +180,13 @@ public:
   auto get(const std::string &name = std::string{}) const && = delete;
   template <class Tag>
   auto get(const std::string &name = std::string{}) const & {
-    return m_variables[find(Tag{}, name)].template get<Tag>();
+    return m_variables[find(Tag{}, name)].get(Tag{});
   }
 
   template <class Tag>
   auto get(const std::string &name = std::string{}) && = delete;
   template <class Tag> auto get(const std::string &name = std::string{}) & {
-    return m_variables[find(Tag{}, name)].template get<Tag>();
+    return m_variables[find(Tag{}, name)].get(Tag{});
   }
 
   template <class T>

--- a/src/dataset_index.h
+++ b/src/dataset_index.h
@@ -13,7 +13,7 @@
 template <class Tag> class DatasetIndex {
 public:
   DatasetIndex(const Dataset &dataset) {
-    const auto &axis = dataset.get<Tag>();
+    const auto &axis = dataset.get(Tag{});
     gsl::index current = 0;
     for (auto item : axis)
       m_index[item] = current++;

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -57,27 +57,27 @@ std::string to_string(const Dim dim) {
 
 std::string to_string(const Tag tag) {
   switch (tag.value()) {
-  case Coord::Tof{}.value():
+  case Coord::Tof.value():
     return "Coord::Tof";
-  case Coord::Energy{}.value():
+  case Coord::Energy.value():
     return "Coord::Energy";
-  case Coord::DeltaE{}.value():
+  case Coord::DeltaE.value():
     return "Coord::DeltaE";
-  case Coord::X{}.value():
+  case Coord::X.value():
     return "Coord::X";
-  case Coord::Y{}.value():
+  case Coord::Y.value():
     return "Coord::Y";
-  case Coord::Z{}.value():
+  case Coord::Z.value():
     return "Coord::Z";
-  case Coord::Position{}.value():
+  case Coord::Position.value():
     return "Coord::Position";
-  case Coord::DetectorGrouping{}.value():
+  case Coord::DetectorGrouping.value():
     return "Coord::DetectorGrouping";
-  case Data::Value{}.value():
+  case Data::Value.value():
     return "Data::Value";
-  case Data::Variance{}.value():
+  case Data::Variance.value():
     return "Data::Variance";
-  case Data::Int{}.value():
+  case Data::Int.value():
     return "Data::Int";
   default:
     return "<unknown tag>";

--- a/src/md_zip_view.h
+++ b/src/md_zip_view.h
@@ -389,8 +389,7 @@ template <class D> struct UnitHelper<D, const Coord::Position> {
     static_cast<void>(name);
     if (dataset.contains(Coord::Position{}))
       return dataset(Coord::Position{}).unit();
-    return dataset.get<const Coord::DetectorInfo>()[0](Coord::Position{})
-        .unit();
+    return dataset.get(Coord::DetectorInfo{})[0](Coord::Position{}).unit();
   }
 };
 
@@ -502,9 +501,9 @@ template <class D, class Tag> struct DataHelper {
   static auto get(D &dataset, const Dimensions &,
                   const std::string &name = std::string{}) {
     if (is_coord<Tag>)
-      return dataset.template get<detail::value_type_t<Tag>>();
+      return dataset.get(detail::value_type_t<Tag>{});
     else
-      return dataset.template get<detail::value_type_t<Tag>>(name);
+      return dataset.get(detail::value_type_t<Tag>{}, name);
   }
 };
 
@@ -523,8 +522,8 @@ template <class D, class Tag> struct DataHelper<D, Bin<Tag>> {
       offset *= dims.size(i);
     }
 
-    return ref_type_t<D, Bin<Tag>>{
-        offset, dataset.get<const detail::value_type_t<Tag>>()};
+    return ref_type_t<D, Bin<Tag>>{offset,
+                                   dataset.get(detail::value_type_t<Tag>{})};
   }
 };
 
@@ -537,12 +536,12 @@ template <class D> struct DataHelper<D, const Coord::Position> {
     // think.
     if (dataset.contains(Coord::Position{}))
       return ref_type_t<D, const Coord::Position>(
-          dataset.get<detail::value_type_t<Coord::Position>>(),
+          dataset.get(detail::value_type_t<Coord::Position>{}),
           gsl::span<const typename Coord::DetectorGrouping::type>{});
-    const auto &detInfo = dataset.get<Coord::DetectorInfo>()[0];
+    const auto &detInfo = dataset.get(Coord::DetectorInfo{})[0];
     return ref_type_t<D, const Coord::Position>(
-        detInfo.get<detail::value_type_t<Coord::Position>>(),
-        dataset.get<detail::value_type_t<Coord::DetectorGrouping>>());
+        detInfo.get(detail::value_type_t<Coord::Position>{}),
+        dataset.get(detail::value_type_t<Coord::DetectorGrouping>{}));
   }
 };
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -255,11 +255,13 @@ struct Coord {
   using Ef_t = detail::TagImpl<detail::CoordDef::Ef>;
   using DetectorId_t = detail::TagImpl<detail::CoordDef::DetectorId>;
   using SpectrumNumber_t = detail::TagImpl<detail::CoordDef::SpectrumNumber>;
-  using DetectorGrouping_t = detail::TagImpl<detail::CoordDef::DetectorGrouping>;
+  using DetectorGrouping_t =
+      detail::TagImpl<detail::CoordDef::DetectorGrouping>;
   using RowLabel_t = detail::TagImpl<detail::CoordDef::RowLabel>;
   using Polarization_t = detail::TagImpl<detail::CoordDef::Polarization>;
   using Temperature_t = detail::TagImpl<detail::CoordDef::Temperature>;
-  using FuzzyTemperature_t = detail::TagImpl<detail::CoordDef::FuzzyTemperature>;
+  using FuzzyTemperature_t =
+      detail::TagImpl<detail::CoordDef::FuzzyTemperature>;
   using Time_t = detail::TagImpl<detail::CoordDef::Time>;
   using TimeInterval_t = detail::TagImpl<detail::CoordDef::TimeInterval>;
   using Mask_t = detail::TagImpl<detail::CoordDef::Mask>;

--- a/src/tags.h
+++ b/src/tags.h
@@ -372,6 +372,16 @@ make_coordinate_dimension(const std::tuple<Ts...> &) {
 constexpr auto isDimensionCoord = make_is_dimension_coordinate(detail::Tags{});
 constexpr auto coordDimension = make_coordinate_dimension(detail::Tags{});
 
+namespace detail {
+template <class... Ts>
+constexpr std::array<Unit::Id, std::tuple_size<detail::Tags>::value>
+make_unit_table(const std::tuple<Ts...> &) {
+  return {Ts::unit...};
+}
+constexpr auto unit_table = make_unit_table(detail::Tags{});
+} // namespace detail
+constexpr auto unit(const Tag tag) { return detail::unit_table[tag.value()]; }
+
 class DataBin {
 public:
   DataBin(const double left, const double right)

--- a/src/tags.h
+++ b/src/tags.h
@@ -242,45 +242,81 @@ template <class TagDefinition> struct TagImpl : public Tag, TagDefinition {
 } // namespace detail
 
 struct Coord {
-  using Monitor = detail::TagImpl<detail::CoordDef::Monitor>;
-  using DetectorInfo = detail::TagImpl<detail::CoordDef::DetectorInfo>;
-  using ComponentInfo = detail::TagImpl<detail::CoordDef::ComponentInfo>;
-  using X = detail::TagImpl<detail::CoordDef::X>;
-  using Y = detail::TagImpl<detail::CoordDef::Y>;
-  using Z = detail::TagImpl<detail::CoordDef::Z>;
-  using Tof = detail::TagImpl<detail::CoordDef::Tof>;
-  using Energy = detail::TagImpl<detail::CoordDef::Energy>;
-  using DeltaE = detail::TagImpl<detail::CoordDef::DeltaE>;
-  using Ei = detail::TagImpl<detail::CoordDef::Ei>;
-  using Ef = detail::TagImpl<detail::CoordDef::Ef>;
-  using DetectorId = detail::TagImpl<detail::CoordDef::DetectorId>;
-  using SpectrumNumber = detail::TagImpl<detail::CoordDef::SpectrumNumber>;
-  using DetectorGrouping = detail::TagImpl<detail::CoordDef::DetectorGrouping>;
-  using RowLabel = detail::TagImpl<detail::CoordDef::RowLabel>;
-  using Polarization = detail::TagImpl<detail::CoordDef::Polarization>;
-  using Temperature = detail::TagImpl<detail::CoordDef::Temperature>;
-  using FuzzyTemperature = detail::TagImpl<detail::CoordDef::FuzzyTemperature>;
-  using Time = detail::TagImpl<detail::CoordDef::Time>;
-  using TimeInterval = detail::TagImpl<detail::CoordDef::TimeInterval>;
-  using Mask = detail::TagImpl<detail::CoordDef::Mask>;
-  using Position = detail::TagImpl<detail::CoordDef::Position>;
+  using Monitor_t = detail::TagImpl<detail::CoordDef::Monitor>;
+  using DetectorInfo_t = detail::TagImpl<detail::CoordDef::DetectorInfo>;
+  using ComponentInfo_t = detail::TagImpl<detail::CoordDef::ComponentInfo>;
+  using X_t = detail::TagImpl<detail::CoordDef::X>;
+  using Y_t = detail::TagImpl<detail::CoordDef::Y>;
+  using Z_t = detail::TagImpl<detail::CoordDef::Z>;
+  using Tof_t = detail::TagImpl<detail::CoordDef::Tof>;
+  using Energy_t = detail::TagImpl<detail::CoordDef::Energy>;
+  using DeltaE_t = detail::TagImpl<detail::CoordDef::DeltaE>;
+  using Ei_t = detail::TagImpl<detail::CoordDef::Ei>;
+  using Ef_t = detail::TagImpl<detail::CoordDef::Ef>;
+  using DetectorId_t = detail::TagImpl<detail::CoordDef::DetectorId>;
+  using SpectrumNumber_t = detail::TagImpl<detail::CoordDef::SpectrumNumber>;
+  using DetectorGrouping_t = detail::TagImpl<detail::CoordDef::DetectorGrouping>;
+  using RowLabel_t = detail::TagImpl<detail::CoordDef::RowLabel>;
+  using Polarization_t = detail::TagImpl<detail::CoordDef::Polarization>;
+  using Temperature_t = detail::TagImpl<detail::CoordDef::Temperature>;
+  using FuzzyTemperature_t = detail::TagImpl<detail::CoordDef::FuzzyTemperature>;
+  using Time_t = detail::TagImpl<detail::CoordDef::Time>;
+  using TimeInterval_t = detail::TagImpl<detail::CoordDef::TimeInterval>;
+  using Mask_t = detail::TagImpl<detail::CoordDef::Mask>;
+  using Position_t = detail::TagImpl<detail::CoordDef::Position>;
+
+  static constexpr Monitor_t Monitor{};
+  static constexpr DetectorInfo_t DetectorInfo{};
+  static constexpr ComponentInfo_t ComponentInfo{};
+  static constexpr X_t X{};
+  static constexpr Y_t Y{};
+  static constexpr Z_t Z{};
+  static constexpr Tof_t Tof{};
+  static constexpr Energy_t Energy{};
+  static constexpr DeltaE_t DeltaE{};
+  static constexpr Ei_t Ei{};
+  static constexpr Ef_t Ef{};
+  static constexpr DetectorId_t DetectorId{};
+  static constexpr SpectrumNumber_t SpectrumNumber{};
+  static constexpr DetectorGrouping_t DetectorGrouping{};
+  static constexpr RowLabel_t RowLabel{};
+  static constexpr Polarization_t Polarization{};
+  static constexpr Temperature_t Temperature{};
+  static constexpr FuzzyTemperature_t FuzzyTemperature{};
+  static constexpr Time_t Time{};
+  static constexpr TimeInterval_t TimeInterval{};
+  static constexpr Mask_t Mask{};
+  static constexpr Position_t Position{};
 };
 
 struct Data {
-  using Tof = detail::TagImpl<detail::DataDef::Tof>;
-  using PulseTime = detail::TagImpl<detail::DataDef::PulseTime>;
-  using Value = detail::TagImpl<detail::DataDef::Value>;
-  using Variance = detail::TagImpl<detail::DataDef::Variance>;
-  using StdDev = detail::TagImpl<detail::DataDef::StdDev>;
-  using Int = detail::TagImpl<detail::DataDef::Int>;
-  using DimensionSize = detail::TagImpl<detail::DataDef::DimensionSize>;
-  using String = detail::TagImpl<detail::DataDef::String>;
-  using Events = detail::TagImpl<detail::DataDef::Events>;
-  using Table = detail::TagImpl<detail::DataDef::Table>;
+  using Tof_t = detail::TagImpl<detail::DataDef::Tof>;
+  using PulseTime_t = detail::TagImpl<detail::DataDef::PulseTime>;
+  using Value_t = detail::TagImpl<detail::DataDef::Value>;
+  using Variance_t = detail::TagImpl<detail::DataDef::Variance>;
+  using StdDev_t = detail::TagImpl<detail::DataDef::StdDev>;
+  using Int_t = detail::TagImpl<detail::DataDef::Int>;
+  using DimensionSize_t = detail::TagImpl<detail::DataDef::DimensionSize>;
+  using String_t = detail::TagImpl<detail::DataDef::String>;
+  using Events_t = detail::TagImpl<detail::DataDef::Events>;
+  using Table_t = detail::TagImpl<detail::DataDef::Table>;
+
+  static constexpr Tof_t Tof{};
+  static constexpr PulseTime_t PulseTime{};
+  static constexpr Value_t Value{};
+  static constexpr Variance_t Variance{};
+  static constexpr StdDev_t StdDev{};
+  static constexpr Int_t Int{};
+  static constexpr DimensionSize_t DimensionSize{};
+  static constexpr String_t String{};
+  static constexpr Events_t Events{};
+  static constexpr Table_t Table{};
 };
 
 struct Attr {
-  using ExperimentLog = detail::TagImpl<detail::AttrDef::ExperimentLog>;
+  using ExperimentLog_t = detail::TagImpl<detail::AttrDef::ExperimentLog>;
+
+  static constexpr ExperimentLog_t ExperimentLog{};
 };
 
 template <class T>

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1175,7 +1175,7 @@ Variable filter(const Variable &var, const Variable &filter) {
     throw std::runtime_error(
         "Cannot filter variable: The filter must by 1-dimensional.");
   const auto dim = filter.dimensions().labels()[0];
-  auto mask = filter.get<Coord::Mask>();
+  auto mask = filter.get(Coord::Mask{});
 
   const gsl::index removed = std::count(mask.begin(), mask.end(), 0);
   if (removed == 0)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -402,7 +402,7 @@ public:
   using ArithmeticVariableConceptT<T>::ArithmeticVariableConceptT;
 
   VariableConcept &reciprocal_times(const double value) override {
-    Variable other(Data::Value{}, {}, {value});
+    Variable other(Data::Value, {}, {value});
     return this->template apply<ReciprocalTimes>(other.data());
   }
 
@@ -771,7 +771,7 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   // element types is handled in DataModel::operator+=.
   // Different name is ok for addition.
   dataset::expect::equals(variable.unit(), other.unit());
-  if (variable.tag() != Data::Events{} && variable.tag() != Data::Table{}) {
+  if (variable.tag() != Data::Events && variable.tag() != Data::Table) {
     dataset::expect::contains(variable.dimensions(), other.dimensions());
     // Note: This will broadcast/transpose the RHS if required. We do not
     // support changing the dimensions of the LHS though!
@@ -818,14 +818,14 @@ Variable &Variable::operator+=(const double value) & {
   // TODO By not setting a unit here this operator is only usable if the
   // variable is dimensionless. Should we ignore the unit for scalar operations,
   // i.e., set the same unit as *this.unit()?
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   return plus_equals(*this, other);
 }
 
 template <class T1, class T2> T1 &minus_equals(T1 &variable, const T2 &other) {
   dataset::expect::equals(variable.unit(), other.unit());
   dataset::expect::contains(variable.dimensions(), other.dimensions());
-  if (variable.tag() == Data::Events{})
+  if (variable.tag() == Data::Events)
     throw std::runtime_error("Subtraction of events lists not implemented.");
   require<ArithmeticVariableConcept>(variable.data()) -= other.data();
   return variable;
@@ -838,13 +838,13 @@ Variable &Variable::operator-=(const ConstVariableSlice &other) & {
   return minus_equals(*this, other);
 }
 Variable &Variable::operator-=(const double value) & {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   return minus_equals(*this, other);
 }
 
 template <class T1, class T2> T1 &times_equals(T1 &variable, const T2 &other) {
   dataset::expect::contains(variable.dimensions(), other.dimensions());
-  if (variable.tag() == Data::Events{})
+  if (variable.tag() == Data::Events)
     throw std::runtime_error("Multiplication of events lists not implemented.");
   // setUnit is catching bad cases of changing units (if `variable` is a slice).
   variable.setUnit(variable.unit() * other.unit());
@@ -859,14 +859,14 @@ Variable &Variable::operator*=(const ConstVariableSlice &other) & {
   return times_equals(*this, other);
 }
 Variable &Variable::operator*=(const double value) & {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
 }
 
 template <class T1, class T2> T1 &divide_equals(T1 &variable, const T2 &other) {
   dataset::expect::contains(variable.dimensions(), other.dimensions());
-  if (variable.tag() == Data::Events{})
+  if (variable.tag() == Data::Events)
     throw std::runtime_error("Division of events lists not implemented.");
   // setUnit is catching bad cases of changing units (if `variable` is a slice).
   variable.setUnit(variable.unit() / other.unit());
@@ -881,7 +881,7 @@ Variable &Variable::operator/=(const ConstVariableSlice &other) & {
   return divide_equals(*this, other);
 }
 Variable &Variable::operator/=(const double value) & {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return divide_equals(*this, other);
 }
@@ -910,7 +910,7 @@ VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) const {
   return plus_equals(*this, other);
 }
 VariableSlice VariableSlice::operator+=(const double value) const {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return plus_equals(*this, other);
 }
@@ -922,7 +922,7 @@ VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) const {
   return minus_equals(*this, other);
 }
 VariableSlice VariableSlice::operator-=(const double value) const {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return minus_equals(*this, other);
 }
@@ -934,7 +934,7 @@ VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) const {
   return times_equals(*this, other);
 }
 VariableSlice VariableSlice::operator*=(const double value) const {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return times_equals(*this, other);
 }
@@ -946,7 +946,7 @@ VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) const {
   return divide_equals(*this, other);
 }
 VariableSlice VariableSlice::operator/=(const double value) const {
-  Variable other(Data::Value{}, {}, {value});
+  Variable other(Data::Value, {}, {value});
   other.setUnit(Unit::Id::Dimensionless);
   return divide_equals(*this, other);
 }
@@ -1175,7 +1175,7 @@ Variable filter(const Variable &var, const Variable &filter) {
     throw std::runtime_error(
         "Cannot filter variable: The filter must by 1-dimensional.");
   const auto dim = filter.dimensions().labels()[0];
-  auto mask = filter.get(Coord::Mask{});
+  auto mask = filter.get(Coord::Mask);
 
   const gsl::index removed = std::count(mask.begin(), mask.end(), 0);
   if (removed == 0)
@@ -1209,7 +1209,7 @@ Variable sum(const Variable &var, const Dim dim) {
 Variable mean(const Variable &var, const Dim dim) {
   auto summed = sum(var, dim);
   double scale = 1.0 / static_cast<double>(var.dimensions()[dim]);
-  return summed * Variable(Data::Value{}, {}, {scale});
+  return summed * Variable(Data::Value, {}, {scale});
 }
 
 template <>

--- a/src/variable.h
+++ b/src/variable.h
@@ -222,19 +222,19 @@ public:
   }
   bool isData() const { return !isCoord() && !isAttr(); }
 
-  template <class Tag> auto get() const {
+  template <class TagT> auto get(const TagT t) const {
     // For now we support only variables that are a std::vector. In principle we
     // could support anything that is convertible to gsl::span (or an adequate
     // replacement).
-    if (Tag{} != tag())
+    if (t != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return gsl::make_span(cast<typename Tag::type>());
+    return gsl::make_span(cast<typename TagT::type>());
   }
 
-  template <class Tag> auto get() {
-    if (Tag{} != tag())
+  template <class TagT> auto get(const TagT t) {
+    if (t != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return gsl::make_span(cast<typename Tag::type>());
+    return gsl::make_span(cast<typename TagT::type>());
   }
 
   template <class T> auto span() const { return gsl::make_span(cast<T>()); }
@@ -372,10 +372,10 @@ public:
   // and we do not need to delete the rvalue overload, unlike for many other
   // methods. The data is owned by the underlying variable so it will not be
   // deleted even if *this is a temporary and gets deleted.
-  template <class Tag> auto get() const {
-    if (Tag{} != tag())
+  template <class TagT> auto get(const TagT t) const {
+    if (t != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return this->template cast<typename Tag::type>();
+    return this->template cast<typename TagT::type>();
   }
 
   template <class T> auto span() const { return cast<T>(); }
@@ -442,10 +442,10 @@ public:
   }
 
   // Note: No need to delete rvalue overloads here, see ConstVariableSlice.
-  template <class Tag> auto get() const {
-    if (Tag{} != tag())
+  template <class TagT> auto get(const TagT t) const {
+    if (t != tag())
       throw std::runtime_error("Attempt to access variable with wrong tag.");
-    return this->template cast<typename Tag::type>();
+    return this->template cast<typename TagT::type>();
   }
 
   template <class T> auto span() { return cast<T>(); }

--- a/src/variable.h
+++ b/src/variable.h
@@ -280,20 +280,16 @@ private:
   deep_ptr<VariableConcept> m_object;
 };
 
-// TODO TagT template argument is not actually required, provided that we
-// refactor tags so unit can be obtained from the `Tag` base class. If we do
-// this, we can probably also unify a good amount of code in the Python exports,
-// which is currently requiring exporting for all tags for many methods.
-template <class T, class TagT>
-Variable makeVariable(TagT tag, const Dimensions &dimensions) {
-  return Variable(tag, TagT::unit, std::move(dimensions),
+template <class T>
+Variable makeVariable(Tag tag, const Dimensions &dimensions) {
+  return Variable(tag, unit(tag), std::move(dimensions),
                   Vector<T>(dimensions.volume()));
 }
 
-template <class T, class TagT, class T2>
-Variable makeVariable(TagT tag, const Dimensions &dimensions,
+template <class T, class T2>
+Variable makeVariable(Tag tag, const Dimensions &dimensions,
                       std::initializer_list<T2> values) {
-  return Variable(tag, TagT::unit, std::move(dimensions),
+  return Variable(tag, unit(tag), std::move(dimensions),
                   Vector<T>(values.begin(), values.end()));
 }
 

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -14,33 +14,33 @@
 
 TEST(EventWorkspace, EventList) {
   Dataset e;
-  e.insert(Data::Tof{}, "", {Dim::Event, 0}, 0);
+  e.insert(Data::Tof, "", {Dim::Event, 0}, 0);
   // `size()` gives number of variables, not the number of events in this case!
   // Do we need something like `count()`, returning the volume of the Dataset?
   EXPECT_EQ(e.size(), 1);
-  EXPECT_EQ(e.get(Data::Tof{}).size(), 0);
+  EXPECT_EQ(e.get(Data::Tof).size(), 0);
 
   // Cannot change size of Dataset easily right now, is that a problem here? Can
   // use concatenate, but there is no `push_back` or similar:
   Dataset e2;
-  e2.insert(Data::Tof{}, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
+  e2.insert(Data::Tof, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
   e = concatenate(e, e2, Dim::Event);
   e = concatenate(e, e2, Dim::Event);
-  EXPECT_EQ(e.get(Data::Tof{}).size(), 6);
+  EXPECT_EQ(e.get(Data::Tof).size(), 6);
 
   // Can insert pulse times if needed.
-  e.insert(Data::PulseTime{}, "", e(Data::Tof{}).dimensions(),
+  e.insert(Data::PulseTime, "", e(Data::Tof).dimensions(),
            {2.0, 1.0, 2.1, 1.1, 3.0, 1.2});
 
-  auto view = ranges::view::zip(e.get(Data::Tof{}), e.get(Data::PulseTime{}));
+  auto view = ranges::view::zip(e.get(Data::Tof), e.get(Data::PulseTime));
   // Sort by Tof:
   ranges::sort(
       view.begin(), view.end(),
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.first < b.first; });
 
-  EXPECT_TRUE(equals(e.get(Data::Tof{}), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
-  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
+  EXPECT_TRUE(equals(e.get(Data::Tof), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
 
   // Sort by pulse time:
   ranges::sort(
@@ -48,8 +48,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.second < b.second; });
 
-  EXPECT_TRUE(equals(e.get(Data::Tof{}), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
-  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
+  EXPECT_TRUE(equals(e.get(Data::Tof), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 
   // Sort by pulse time then tof:
   ranges::sort(view.begin(), view.end(),
@@ -58,53 +58,53 @@ TEST(EventWorkspace, EventList) {
                  return a.second < b.second && a.first < b.first;
                });
 
-  EXPECT_TRUE(equals(e.get(Data::Tof{}), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
-  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
+  EXPECT_TRUE(equals(e.get(Data::Tof), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 }
 
 TEST(EventWorkspace, basics) {
   Dataset d;
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 3}, {1, 2, 3});
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, 3}, {1, 2, 3});
 
   // "X" axis (shared for all spectra).
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 1001), 1001);
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 1001), 1001);
 
   // EventList using Dataset. There are probably better solutions so this likely
   // to change, e.g., to use a proxy object.
   Dataset e;
-  e.insert(Data::Tof{}, "", {Dim::Event, 0}, 0);
-  e.insert(Data::PulseTime{}, "", {Dim::Event, 0}, 0);
+  e.insert(Data::Tof, "", {Dim::Event, 0}, 0);
+  e.insert(Data::PulseTime, "", {Dim::Event, 0}, 0);
 
   // Insert empty event lists.
-  d.insert(Data::Events{}, "", {Dim::Spectrum, 3}, 3, e);
+  d.insert(Data::Events, "", {Dim::Spectrum, 3}, 3, e);
 
   // Get event lists for all spectra.
-  auto eventLists = d.get(Data::Events{});
+  auto eventLists = d.get(Data::Events);
   EXPECT_EQ(eventLists.size(), 3);
 
   // Modify individual event lists.
   Dataset e2;
-  e2.insert(Data::Tof{}, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
-  e2.insert(Data::PulseTime{}, "", {Dim::Event, 3}, 3);
+  e2.insert(Data::Tof, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
+  e2.insert(Data::PulseTime, "", {Dim::Event, 3}, 3);
   eventLists[1] = e2;
   eventLists[2] = concatenate(e2, e2, Dim::Event);
 
   // Insert variable for histogrammed data.
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
-  d.insert(Data::Value{}, "", dims, dims.volume());
-  d.insert(Data::Variance{}, "", dims, dims.volume());
+  d.insert(Data::Value, "", dims, dims.volume());
+  d.insert(Data::Variance, "", dims, dims.volume());
 
   // Make histograms.
   // Note that we could determine the correct X axis automatically, since the
   // event data type/unit imply which coordinate to use, in this case events
   // have type Data::Tof so the axis is Coord::Tof.
-  auto histLabel = MDNested(MDRead(Bin<Coord::Tof>{}), MDWrite(Data::Value{}),
-                            MDWrite(Data::Variance{}));
-  using Histogram = decltype(histLabel)::type;
-  auto view = zipMD(d, {Dim::Tof}, histLabel, MDRead(Data::Events{}));
+  auto histLabel = MDNested(MDRead(Bin<decltype(Coord::Tof)>{}),
+                            MDWrite(Data::Value), MDWrite(Data::Variance));
+  auto Histogram = decltype(histLabel)::type(d, {Dim::Spectrum});
+  auto view = zipMD(d, {Dim::Tof}, histLabel, MDRead(Data::Events));
   for (const auto &item : view) {
-    const auto &hist = item.get<Histogram>();
-    const auto &events = item.get<Data::Events>();
+    const auto &hist = item.get(Histogram);
+    const auto &events = item.get(Data::Events);
     static_cast<void>(hist);
     static_cast<void>(events);
     // TODO: Implement rebin (better name: `makeHistogram`?).
@@ -112,22 +112,22 @@ TEST(EventWorkspace, basics) {
   }
 
   // Can keep events but drop, e.g., pulse time if not needed anymore.
-  for (auto &e : d.get(Data::Events{}))
-    e.erase(Data::PulseTime{});
+  for (auto &e : d.get(Data::Events))
+    e.erase(Data::PulseTime);
 
   // Can delete events fully later.
-  d.erase(Data::Events{});
+  d.erase(Data::Events);
 }
 
 TEST(EventWorkspace, plus) {
   Dataset d;
 
   Dataset e;
-  e.insert(Data::Tof{}, "", {Dim::Event, 10});
-  e.insert(Data::PulseTime{}, "", {Dim::Event, 10});
+  e.insert(Data::Tof, "", {Dim::Event, 10});
+  e.insert(Data::PulseTime, "", {Dim::Event, 10});
   auto e2 = concatenate(e, e, Dim::Event);
 
-  d.insert(Data::Events{}, "", {Dim::Spectrum, 2}, {e, e2});
+  d.insert(Data::Events, "", {Dim::Spectrum, 2}, {e, e2});
 
   EXPECT_THROW_MSG(d - d, std::runtime_error,
                    "Subtraction of events lists not implemented.");
@@ -137,15 +137,15 @@ TEST(EventWorkspace, plus) {
   // Special handling: Adding datasets *concatenates* the event lists.
   auto sum = d + d;
 
-  auto eventLists = sum.get(Data::Events{});
+  auto eventLists = sum.get(Data::Events);
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get(Data::Tof{}).size(), 2 * 10);
-  EXPECT_EQ(eventLists[1].get(Data::Tof{}).size(), 2 * 20);
+  EXPECT_EQ(eventLists[0].get(Data::Tof).size(), 2 * 10);
+  EXPECT_EQ(eventLists[1].get(Data::Tof).size(), 2 * 20);
 
   sum += d;
 
-  eventLists = sum.get(Data::Events{});
+  eventLists = sum.get(Data::Events);
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get(Data::Tof{}).size(), 3 * 10);
-  EXPECT_EQ(eventLists[1].get(Data::Tof{}).size(), 3 * 20);
+  EXPECT_EQ(eventLists[0].get(Data::Tof).size(), 3 * 10);
+  EXPECT_EQ(eventLists[1].get(Data::Tof).size(), 3 * 20);
 }

--- a/test/EventWorkspace_test.cpp
+++ b/test/EventWorkspace_test.cpp
@@ -18,7 +18,7 @@ TEST(EventWorkspace, EventList) {
   // `size()` gives number of variables, not the number of events in this case!
   // Do we need something like `count()`, returning the volume of the Dataset?
   EXPECT_EQ(e.size(), 1);
-  EXPECT_EQ(e.get<Data::Tof>().size(), 0);
+  EXPECT_EQ(e.get(Data::Tof{}).size(), 0);
 
   // Cannot change size of Dataset easily right now, is that a problem here? Can
   // use concatenate, but there is no `push_back` or similar:
@@ -26,21 +26,21 @@ TEST(EventWorkspace, EventList) {
   e2.insert(Data::Tof{}, "", {Dim::Event, 3}, {1.1, 2.2, 3.3});
   e = concatenate(e, e2, Dim::Event);
   e = concatenate(e, e2, Dim::Event);
-  EXPECT_EQ(e.get<Data::Tof>().size(), 6);
+  EXPECT_EQ(e.get(Data::Tof{}).size(), 6);
 
   // Can insert pulse times if needed.
   e.insert(Data::PulseTime{}, "", e(Data::Tof{}).dimensions(),
            {2.0, 1.0, 2.1, 1.1, 3.0, 1.2});
 
-  auto view = ranges::view::zip(e.get<Data::Tof>(), e.get<Data::PulseTime>());
+  auto view = ranges::view::zip(e.get(Data::Tof{}), e.get(Data::PulseTime{}));
   // Sort by Tof:
   ranges::sort(
       view.begin(), view.end(),
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.first < b.first; });
 
-  EXPECT_TRUE(equals(e.get<Data::Tof>(), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
-  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
+  EXPECT_TRUE(equals(e.get(Data::Tof{}), {1.1, 1.1, 2.2, 2.2, 3.3, 3.3}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {2.0, 1.1, 1.0, 3.0, 2.1, 1.2}));
 
   // Sort by pulse time:
   ranges::sort(
@@ -48,8 +48,8 @@ TEST(EventWorkspace, EventList) {
       [](const std::pair<double, double> &a,
          const std::pair<double, double> &b) { return a.second < b.second; });
 
-  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
-  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
+  EXPECT_TRUE(equals(e.get(Data::Tof{}), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 
   // Sort by pulse time then tof:
   ranges::sort(view.begin(), view.end(),
@@ -58,8 +58,8 @@ TEST(EventWorkspace, EventList) {
                  return a.second < b.second && a.first < b.first;
                });
 
-  EXPECT_TRUE(equals(e.get<Data::Tof>(), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
-  EXPECT_TRUE(equals(e.get<Data::PulseTime>(), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
+  EXPECT_TRUE(equals(e.get(Data::Tof{}), {2.2, 1.1, 3.3, 1.1, 3.3, 2.2}));
+  EXPECT_TRUE(equals(e.get(Data::PulseTime{}), {1.0, 1.1, 1.2, 2.0, 2.1, 3.0}));
 }
 
 TEST(EventWorkspace, basics) {
@@ -79,7 +79,7 @@ TEST(EventWorkspace, basics) {
   d.insert(Data::Events{}, "", {Dim::Spectrum, 3}, 3, e);
 
   // Get event lists for all spectra.
-  auto eventLists = d.get<Data::Events>();
+  auto eventLists = d.get(Data::Events{});
   EXPECT_EQ(eventLists.size(), 3);
 
   // Modify individual event lists.
@@ -112,7 +112,7 @@ TEST(EventWorkspace, basics) {
   }
 
   // Can keep events but drop, e.g., pulse time if not needed anymore.
-  for (auto &e : d.get<Data::Events>())
+  for (auto &e : d.get(Data::Events{}))
     e.erase(Data::PulseTime{});
 
   // Can delete events fully later.
@@ -137,15 +137,15 @@ TEST(EventWorkspace, plus) {
   // Special handling: Adding datasets *concatenates* the event lists.
   auto sum = d + d;
 
-  auto eventLists = sum.get<Data::Events>();
+  auto eventLists = sum.get(Data::Events{});
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 2 * 10);
-  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 2 * 20);
+  EXPECT_EQ(eventLists[0].get(Data::Tof{}).size(), 2 * 10);
+  EXPECT_EQ(eventLists[1].get(Data::Tof{}).size(), 2 * 20);
 
   sum += d;
 
-  eventLists = sum.get<Data::Events>();
+  eventLists = sum.get(Data::Events{});
   EXPECT_EQ(eventLists.size(), 2);
-  EXPECT_EQ(eventLists[0].get<Data::Tof>().size(), 3 * 10);
-  EXPECT_EQ(eventLists[1].get<Data::Tof>().size(), 3 * 20);
+  EXPECT_EQ(eventLists[0].get(Data::Tof{}).size(), 3 * 10);
+  EXPECT_EQ(eventLists[1].get(Data::Tof{}).size(), 3 * 20);
 }

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -12,22 +12,21 @@
 
 Dataset makeRun() {
   Dataset run;
-  run.insert(Data::Value{}, "total_counts", {}, {1000});
-  run.insert(Coord::Polarization{}, {}, {"Spin-Up"});
-  run.insert(Coord::FuzzyTemperature{}, {}, {ValueWithDelta<double>(4.2, 0.1)});
+  run.insert(Data::Value, "total_counts", {}, {1000});
+  run.insert(Coord::Polarization, {}, {"Spin-Up"});
+  run.insert(Coord::FuzzyTemperature, {}, {ValueWithDelta<double>(4.2, 0.1)});
   Dataset comment;
-  comment.insert(Data::String{}, "", {Dim::Row, 1}, {"first run"});
-  run.insert(Data::Table{}, "comment", {}, {comment});
+  comment.insert(Data::String, "", {Dim::Row, 1}, {"first run"});
+  run.insert(Data::Table, "comment", {}, {comment});
   Dataset timeSeriesLog;
-  timeSeriesLog.insert(Coord::Time{}, {Dim::Time, 3}, {0, 1000, 1500});
-  timeSeriesLog.insert(Data::Value{}, "pressure1", {Dim::Time, 3},
+  timeSeriesLog.insert(Coord::Time, {Dim::Time, 3}, {0, 1000, 1500});
+  timeSeriesLog.insert(Data::Value, "pressure1", {Dim::Time, 3},
                        {1013, 900, 800});
-  timeSeriesLog.insert(Data::Value{}, "pressure2", {Dim::Time, 3},
-                       {100, 90, 80});
-  run.insert(Data::Table{}, "pressure_log", {}, {timeSeriesLog});
+  timeSeriesLog.insert(Data::Value, "pressure2", {Dim::Time, 3}, {100, 90, 80});
+  run.insert(Data::Table, "pressure_log", {}, {timeSeriesLog});
   Dataset otherLogEntries;
-  otherLogEntries.insert(Data::Table{}, "root", {Dim::Row, 1});
-  run.insert(Data::Table{}, "generic_log", {Dim::Row, 1}, {otherLogEntries});
+  otherLogEntries.insert(Data::Table, "root", {Dim::Row, 1});
+  run.insert(Data::Table, "generic_log", {Dim::Row, 1}, {otherLogEntries});
   return run;
 }
 
@@ -35,21 +34,20 @@ TEST(Run, meta_data_propagation) {
   Dataset run1 = makeRun();
 
   Dataset d1;
-  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {run1});
+  d1.insert(Attr::ExperimentLog, "sample_log", {}, {run1});
 
   EXPECT_NO_THROW(d1 += d1);
 
   auto run2(run1);
-  run2.get(Data::Value{}, "total_counts")[0] = 1111;
-  run2.get(Coord::FuzzyTemperature{})[0] = ValueWithDelta<double>(4.15, 0.1);
-  run2.get(Data::Table{}, "comment")[0].get(Data::String{})[0] = "second run";
-  run2.get(Data::Table{}, "generic_log")[0]
-      .get(Data::Table{}, "root")[0]
-      .insert(Data::String{}, "user comment", {},
-              {"Spider walked through beam, verify data before publishing."});
+  run2.get(Data::Value, "total_counts")[0] = 1111;
+  run2.get(Coord::FuzzyTemperature)[0] = ValueWithDelta<double>(4.15, 0.1);
+  run2.get(Data::Table, "comment")[0].get(Data::String)[0] = "second run";
+  run2.get(Data::Table, "generic_log")[0].get(Data::Table, "root")[0].insert(
+      Data::String, "user comment", {},
+      {"Spider walked through beam, verify data before publishing."});
 
   Dataset d2;
-  d2.insert(Attr::ExperimentLog{}, "sample_log", {}, {run2});
+  d2.insert(Attr::ExperimentLog, "sample_log", {}, {run2});
 
   // Behavior of `Attr` variables is specific to the implementation of each
   // operation. In most cases we simply copy the first one, exceptions are
@@ -61,50 +59,49 @@ TEST(Run, meta_data_propagation) {
   // are in different places in the internal dataset structure. For more
   // convenient access we should provide a view class that can be instantiated
   // on the fly.
-  const auto &run = d1.get(Attr::ExperimentLog{}, "sample_log")[0];
+  const auto &run = d1.get(Attr::ExperimentLog, "sample_log")[0];
 
   // Example of a log entry that is accumulated:
-  EXPECT_EQ(run.get(Data::Value{}, "total_counts").size(), 1);
-  EXPECT_EQ(run.get(Data::Value{}, "total_counts")[0], 2111);
+  EXPECT_EQ(run.get(Data::Value, "total_counts").size(), 1);
+  EXPECT_EQ(run.get(Data::Value, "total_counts")[0], 2111);
 
   // Example of a log entry that is verified:
-  EXPECT_EQ(run.get(Coord::Polarization{}).size(), 1);
-  EXPECT_EQ(run.get(Coord::Polarization{})[0], "Spin-Up");
+  EXPECT_EQ(run.get(Coord::Polarization).size(), 1);
+  EXPECT_EQ(run.get(Coord::Polarization)[0], "Spin-Up");
 
   // Example of a log entry that is verified with fuzzy matching:
-  EXPECT_EQ(run.get(Coord::FuzzyTemperature{}).size(), 1);
+  EXPECT_EQ(run.get(Coord::FuzzyTemperature).size(), 1);
   // Note: No averaging happening here, it is simply checked to be in range.
-  EXPECT_EQ(run.get(Coord::FuzzyTemperature{})[0],
+  EXPECT_EQ(run.get(Coord::FuzzyTemperature)[0],
             ValueWithDelta<double>(4.2, 0.1));
 
   // Example of a log entry that is concatenated:
-  const auto comments =
-      run.get(Data::Table{}, "comment")[0].get(Data::String{});
+  const auto comments = run.get(Data::Table, "comment")[0].get(Data::String);
   EXPECT_EQ(comments.size(), 2);
   EXPECT_EQ(comments[0], "first run");
   EXPECT_EQ(comments[1], "second run");
 
   // Example of a "time series" log entry that is concatenated:
-  const auto pressure_log = run.get(Data::Table{}, "pressure_log")[0];
+  const auto pressure_log = run.get(Data::Table, "pressure_log")[0];
   EXPECT_EQ(pressure_log.dimensions().count(), 1);
   EXPECT_EQ(pressure_log.dimensions().label(0), Dim::Time);
   EXPECT_EQ(pressure_log.dimensions().size(0), 6);
   // No hidden magic here, it is simply concatenated, can do smarter processing
   // by hand afterwards.
   EXPECT_EQ(
-      pressure_log.get(Data::Value{}, "pressure1"),
+      pressure_log.get(Data::Value, "pressure1"),
       gsl::make_span(std::vector<double>({1013, 900, 800, 1013, 900, 800})));
 
   // Example of an optional log entry, i.e., one that is not present in all
   // operands:
-  const auto generic_log = run.get(Data::Table{}, "generic_log")[0];
+  const auto generic_log = run.get(Data::Table, "generic_log")[0];
   EXPECT_EQ(generic_log.dimensions().count(), 1);
   EXPECT_EQ(generic_log.dimensions().label(0), Dim::Row);
   EXPECT_EQ(generic_log.dimensions().size(0), 2);
-  const auto generic_log_run1 = generic_log.get(Data::Table{}, "root")[0];
+  const auto generic_log_run1 = generic_log.get(Data::Table, "root")[0];
   // No entries from run 1.
   EXPECT_EQ(generic_log_run1.size(), 0);
-  const auto generic_log_run2 = generic_log.get(Data::Table{}, "root")[1];
+  const auto generic_log_run2 = generic_log.get(Data::Table, "root")[1];
   // 1 entry from run 2.
   EXPECT_EQ(generic_log_run2.size(), 1);
   EXPECT_EQ(generic_log_run2[0].name(), "user comment");
@@ -113,11 +110,11 @@ TEST(Run, meta_data_propagation) {
 
 TEST(Run, meta_data_fail_coord_mismatch) {
   Dataset d1;
-  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
-  run2.get(Coord::Polarization{})[0] = "Spin-Down";
+  auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
+  run2.get(Coord::Polarization)[0] = "Spin-Down";
   EXPECT_THROW_MSG(
       d1 += d2, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
@@ -125,11 +122,11 @@ TEST(Run, meta_data_fail_coord_mismatch) {
 
 TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
   Dataset d1;
-  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
-  run2.get(Coord::FuzzyTemperature{})[0] = ValueWithDelta<double>(4.0, 0.1);
+  auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
+  run2.get(Coord::FuzzyTemperature)[0] = ValueWithDelta<double>(4.0, 0.1);
   EXPECT_THROW_MSG(
       d1 += d2, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
@@ -137,11 +134,11 @@ TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
 
 TEST(Run, meta_data_fail_missing) {
   Dataset d1;
-  d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
+  d1.insert(Attr::ExperimentLog, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
-  run2.get(Data::Table{}, "comment")[0].erase(Data::String{});
+  auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
+  run2.get(Data::Table, "comment")[0].erase(Data::String);
   EXPECT_THROW_MSG(d1 += d2, std::runtime_error,
                    "Cannot add Variable: Nested Dataset dimension must be 1.");
 }

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -40,12 +40,13 @@ TEST(Run, meta_data_propagation) {
   EXPECT_NO_THROW(d1 += d1);
 
   auto run2(run1);
-  run2.get<Data::Value>("total_counts")[0] = 1111;
-  run2.get<Coord::FuzzyTemperature>()[0] = ValueWithDelta<double>(4.15, 0.1);
-  run2.get<Data::Table>("comment")[0].get<Data::String>()[0] = "second run";
-  run2.get<Data::Table>("generic_log")[0].get<Data::Table>("root")[0].insert(
-      Data::String{}, "user comment", {},
-      {"Spider walked through beam, verify data before publishing."});
+  run2.get(Data::Value{}, "total_counts")[0] = 1111;
+  run2.get(Coord::FuzzyTemperature{})[0] = ValueWithDelta<double>(4.15, 0.1);
+  run2.get(Data::Table{}, "comment")[0].get(Data::String{})[0] = "second run";
+  run2.get(Data::Table{}, "generic_log")[0]
+      .get(Data::Table{}, "root")[0]
+      .insert(Data::String{}, "user comment", {},
+              {"Spider walked through beam, verify data before publishing."});
 
   Dataset d2;
   d2.insert(Attr::ExperimentLog{}, "sample_log", {}, {run2});
@@ -60,49 +61,50 @@ TEST(Run, meta_data_propagation) {
   // are in different places in the internal dataset structure. For more
   // convenient access we should provide a view class that can be instantiated
   // on the fly.
-  const auto &run = d1.get<Attr::ExperimentLog>("sample_log")[0];
+  const auto &run = d1.get(Attr::ExperimentLog{}, "sample_log")[0];
 
   // Example of a log entry that is accumulated:
-  EXPECT_EQ(run.get<Data::Value>("total_counts").size(), 1);
-  EXPECT_EQ(run.get<Data::Value>("total_counts")[0], 2111);
+  EXPECT_EQ(run.get(Data::Value{}, "total_counts").size(), 1);
+  EXPECT_EQ(run.get(Data::Value{}, "total_counts")[0], 2111);
 
   // Example of a log entry that is verified:
-  EXPECT_EQ(run.get<Coord::Polarization>().size(), 1);
-  EXPECT_EQ(run.get<Coord::Polarization>()[0], "Spin-Up");
+  EXPECT_EQ(run.get(Coord::Polarization{}).size(), 1);
+  EXPECT_EQ(run.get(Coord::Polarization{})[0], "Spin-Up");
 
   // Example of a log entry that is verified with fuzzy matching:
-  EXPECT_EQ(run.get<Coord::FuzzyTemperature>().size(), 1);
+  EXPECT_EQ(run.get(Coord::FuzzyTemperature{}).size(), 1);
   // Note: No averaging happening here, it is simply checked to be in range.
-  EXPECT_EQ(run.get<Coord::FuzzyTemperature>()[0],
+  EXPECT_EQ(run.get(Coord::FuzzyTemperature{})[0],
             ValueWithDelta<double>(4.2, 0.1));
 
   // Example of a log entry that is concatenated:
-  const auto comments = run.get<Data::Table>("comment")[0].get<Data::String>();
+  const auto comments =
+      run.get(Data::Table{}, "comment")[0].get(Data::String{});
   EXPECT_EQ(comments.size(), 2);
   EXPECT_EQ(comments[0], "first run");
   EXPECT_EQ(comments[1], "second run");
 
   // Example of a "time series" log entry that is concatenated:
-  const auto pressure_log = run.get<Data::Table>("pressure_log")[0];
+  const auto pressure_log = run.get(Data::Table{}, "pressure_log")[0];
   EXPECT_EQ(pressure_log.dimensions().count(), 1);
   EXPECT_EQ(pressure_log.dimensions().label(0), Dim::Time);
   EXPECT_EQ(pressure_log.dimensions().size(0), 6);
   // No hidden magic here, it is simply concatenated, can do smarter processing
   // by hand afterwards.
   EXPECT_EQ(
-      pressure_log.get<Data::Value>("pressure1"),
+      pressure_log.get(Data::Value{}, "pressure1"),
       gsl::make_span(std::vector<double>({1013, 900, 800, 1013, 900, 800})));
 
   // Example of an optional log entry, i.e., one that is not present in all
   // operands:
-  const auto generic_log = run.get<Data::Table>("generic_log")[0];
+  const auto generic_log = run.get(Data::Table{}, "generic_log")[0];
   EXPECT_EQ(generic_log.dimensions().count(), 1);
   EXPECT_EQ(generic_log.dimensions().label(0), Dim::Row);
   EXPECT_EQ(generic_log.dimensions().size(0), 2);
-  const auto generic_log_run1 = generic_log.get<Data::Table>("root")[0];
+  const auto generic_log_run1 = generic_log.get(Data::Table{}, "root")[0];
   // No entries from run 1.
   EXPECT_EQ(generic_log_run1.size(), 0);
-  const auto generic_log_run2 = generic_log.get<Data::Table>("root")[1];
+  const auto generic_log_run2 = generic_log.get(Data::Table{}, "root")[1];
   // 1 entry from run 2.
   EXPECT_EQ(generic_log_run2.size(), 1);
   EXPECT_EQ(generic_log_run2[0].name(), "user comment");
@@ -114,8 +116,8 @@ TEST(Run, meta_data_fail_coord_mismatch) {
   d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];
-  run2.get<Coord::Polarization>()[0] = "Spin-Down";
+  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
+  run2.get(Coord::Polarization{})[0] = "Spin-Down";
   EXPECT_THROW_MSG(
       d1 += d2, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
@@ -126,8 +128,8 @@ TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
   d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];
-  run2.get<Coord::FuzzyTemperature>()[0] = ValueWithDelta<double>(4.0, 0.1);
+  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
+  run2.get(Coord::FuzzyTemperature{})[0] = ValueWithDelta<double>(4.0, 0.1);
   EXPECT_THROW_MSG(
       d1 += d2, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
@@ -138,8 +140,8 @@ TEST(Run, meta_data_fail_missing) {
   d1.insert(Attr::ExperimentLog{}, "sample_log", {}, {makeRun()});
   Dataset d2(d1);
 
-  auto &run2 = d2.get<Attr::ExperimentLog>("sample_log")[0];
-  run2.get<Data::Table>("comment")[0].erase(Data::String{});
+  auto &run2 = d2.get(Attr::ExperimentLog{}, "sample_log")[0];
+  run2.get(Data::Table{}, "comment")[0].erase(Data::String{});
   EXPECT_THROW_MSG(d1 += d2, std::runtime_error,
                    "Cannot add Variable: Nested Dataset dimension must be 1.");
 }

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -14,13 +14,13 @@
 std::vector<std::string> asStrings(const Variable &variable) {
   std::vector<std::string> strings;
   if (variable.tag() == Coord::RowLabel{})
-    for (const auto &value : variable.get<Coord::RowLabel>())
+    for (const auto &value : variable.get(Coord::RowLabel{}))
       strings.emplace_back(value);
   if (variable.tag() == Data::Value{})
-    for (const auto &value : variable.get<Data::Value>())
+    for (const auto &value : variable.get(Data::Value{}))
       strings.emplace_back(std::to_string(value));
   else if (variable.tag() == Data::String{})
-    for (const auto &value : variable.get<Data::String>())
+    for (const auto &value : variable.get(Data::String{}))
       strings.emplace_back(value);
   return strings;
 }

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -48,14 +48,14 @@ TEST(TableWorkspace, basics) {
   // Standard shape operations provide basic things required for tables:
   auto mergedTable = concatenate(table, table, Dim::Row);
   Dataset row = table(Dim::Row, 1, 2);
-  EXPECT_EQ(row.get<Coord::RowLabel>()[0], "b");
+  EXPECT_EQ(row.get(Coord::RowLabel{})[0], "b");
 
   // Slice a range to obtain a new table with a subset of rows.
   Dataset rows = mergedTable(Dim::Row, 1, 4);
-  ASSERT_EQ(rows.get<Coord::RowLabel>().size(), 3);
-  EXPECT_EQ(rows.get<Coord::RowLabel>()[0], "b");
-  EXPECT_EQ(rows.get<Coord::RowLabel>()[1], "c");
-  EXPECT_EQ(rows.get<Coord::RowLabel>()[2], "a");
+  ASSERT_EQ(rows.get(Coord::RowLabel{}).size(), 3);
+  EXPECT_EQ(rows.get(Coord::RowLabel{})[0], "b");
+  EXPECT_EQ(rows.get(Coord::RowLabel{})[1], "c");
+  EXPECT_EQ(rows.get(Coord::RowLabel{})[2], "a");
 
   // Can sort by arbitrary column.
   auto sortedTable = sort(table, Data::Value{});

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -13,30 +13,30 @@
 // of basic routines.
 std::vector<std::string> asStrings(const Variable &variable) {
   std::vector<std::string> strings;
-  if (variable.tag() == Coord::RowLabel{})
-    for (const auto &value : variable.get(Coord::RowLabel{}))
+  if (variable.tag() == Coord::RowLabel)
+    for (const auto &value : variable.get(Coord::RowLabel))
       strings.emplace_back(value);
-  if (variable.tag() == Data::Value{})
-    for (const auto &value : variable.get(Data::Value{}))
+  if (variable.tag() == Data::Value)
+    for (const auto &value : variable.get(Data::Value))
       strings.emplace_back(std::to_string(value));
-  else if (variable.tag() == Data::String{})
-    for (const auto &value : variable.get(Data::String{}))
+  else if (variable.tag() == Data::String)
+    for (const auto &value : variable.get(Data::String))
       strings.emplace_back(value);
   return strings;
 }
 
 TEST(TableWorkspace, basics) {
   Dataset table;
-  table.insert(Coord::RowLabel{}, {Dim::Row, 3},
+  table.insert(Coord::RowLabel, {Dim::Row, 3},
                Vector<std::string>{"a", "b", "c"});
-  table.insert(Data::Value{}, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
-  table.insert(Data::String{}, "", {Dim::Row, 3}, 3);
+  table.insert(Data::Value, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
+  table.insert(Data::String, "", {Dim::Row, 3}, 3);
 
   // Modify table with know columns.
-  auto view = zipMD(table, MDRead(Data::Value{}), MDWrite(Data::String{}));
+  auto view = zipMD(table, MDRead(Data::Value), MDWrite(Data::String));
   for (auto &item : view)
     if (item.value() < 0.0)
-      item.get<Data::String>() = "why is this negative?";
+      item.get(Data::String) = "why is this negative?";
 
   // Get string representation of arbitrary table, e.g., for visualization.
   EXPECT_EQ(asStrings(table[0]), std::vector<std::string>({"a", "b", "c"}));
@@ -48,17 +48,17 @@ TEST(TableWorkspace, basics) {
   // Standard shape operations provide basic things required for tables:
   auto mergedTable = concatenate(table, table, Dim::Row);
   Dataset row = table(Dim::Row, 1, 2);
-  EXPECT_EQ(row.get(Coord::RowLabel{})[0], "b");
+  EXPECT_EQ(row.get(Coord::RowLabel)[0], "b");
 
   // Slice a range to obtain a new table with a subset of rows.
   Dataset rows = mergedTable(Dim::Row, 1, 4);
-  ASSERT_EQ(rows.get(Coord::RowLabel{}).size(), 3);
-  EXPECT_EQ(rows.get(Coord::RowLabel{})[0], "b");
-  EXPECT_EQ(rows.get(Coord::RowLabel{})[1], "c");
-  EXPECT_EQ(rows.get(Coord::RowLabel{})[2], "a");
+  ASSERT_EQ(rows.get(Coord::RowLabel).size(), 3);
+  EXPECT_EQ(rows.get(Coord::RowLabel)[0], "b");
+  EXPECT_EQ(rows.get(Coord::RowLabel)[1], "c");
+  EXPECT_EQ(rows.get(Coord::RowLabel)[2], "a");
 
   // Can sort by arbitrary column.
-  auto sortedTable = sort(table, Data::Value{});
+  auto sortedTable = sort(table, Data::Value);
   EXPECT_EQ(asStrings(sortedTable[0]),
             std::vector<std::string>({"b", "a", "c"}));
   EXPECT_EQ(asStrings(sortedTable[1]),

--- a/test/Workspace2D_test.cpp
+++ b/test/Workspace2D_test.cpp
@@ -14,31 +14,30 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
   Dataset d;
 
   // Scalar metadata using existing Mantid classes:
-  // d.insert(Coord::Sample{}, {}, API::Sample{});
-  // d.insert(Coord::Run{}, {}, API::Run{});
+  // d.insert(Coord::Sample, {}, API::Sample{});
+  // d.insert(Coord::Run, {}, API::Run{});
 
   // Instrument
   Dataset dets;
   // Scalar part of instrument, e.g., something like this:
-  // d.insert(Coord::Instrument{}, {}, Beamline::ComponentInfo{});
-  dets.insert(Coord::DetectorId{}, {Dim::Detector, 4},
-              {1001, 1002, 1003, 1004});
-  dets.insert(Coord::Position{}, {Dim::Detector, 4});
-  d.insert(Coord::DetectorInfo{}, {}, {dets});
+  // d.insert(Coord::Instrument, {}, Beamline::ComponentInfo{});
+  dets.insert(Coord::DetectorId, {Dim::Detector, 4}, {1001, 1002, 1003, 1004});
+  dets.insert(Coord::Position, {Dim::Detector, 4});
+  d.insert(Coord::DetectorInfo, {}, {dets});
 
   // Spectrum to detector mapping and spectrum numbers.
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {
       {0, 2}, {1}, {}};
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 3}, grouping);
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 3}, {1, 2, 3});
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, 3}, grouping);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, 3}, {1, 2, 3});
 
   // "X" axis (shared for all spectra).
-  d.insert(Coord::Tof{}, {Dim::Tof, 1000});
+  d.insert(Coord::Tof, {Dim::Tof, 1000});
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
   // Y
-  d.insert(Data::Value{}, "sample", dims);
+  d.insert(Data::Value, "sample", dims);
   // E
-  d.insert(Data::Variance{}, "sample", dims);
+  d.insert(Data::Variance, "sample", dims);
 
   // Monitors
   // Temporarily disabled until we fixed Dataset::m_dimensions to not use
@@ -46,17 +45,17 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
   // TODO Use variable containing datasets as in the C++ example in the design
   // document.
   // dims = Dimensions({{Dim::MonitorTof, 222}, {Dim::Monitor, 2}});
-  // d.insert(Coord::MonitorTof{}, {Dim::MonitorTof, 222}, 222);
-  // d.insert(Data::Value{}, "monitor", dims, dims.volume());
-  // d.insert(Data::Variance{}, "monitor", dims, dims.volume());
+  // d.insert(Coord::MonitorTof, {Dim::MonitorTof, 222}, 222);
+  // d.insert(Data::Value, "monitor", dims, dims.volume());
+  // d.insert(Data::Variance, "monitor", dims, dims.volume());
 
   auto spinUp(d);
   auto spinDown(d);
 
   // Aka WorkspaceSingleValue
   Dataset offset;
-  offset.insert(Data::Value{}, "sample", {}, {1.0});
-  offset.insert(Data::Variance{}, "sample", {}, {0.1});
+  offset.insert(Data::Value, "sample", {}, {1.0});
+  offset.insert(Data::Variance, "sample", {}, {0.1});
   // Note the use of name "sample" such that offset affects sample, not
   // other `Data` variables such as monitors.
   spinDown += offset;
@@ -64,22 +63,22 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
   // Combine data for spin-up and spin-down in same dataset, polarization is an
   // extra dimension.
   auto combined = concatenate(spinUp, spinDown, Dim::Polarization);
-  combined.insert(Coord::Polarization{}, {Dim::Polarization, 2},
+  combined.insert(Coord::Polarization, {Dim::Polarization, 2},
                   Vector<std::string>{"spin-up", "spin-down"});
 
   // Do a temperature scan, adding a new temperature dimension to the dataset.
-  combined.insert(Coord::Temperature{}, {}, {300.0});
-  combined.get(Data::Value{}, "sample")[0] = exp(-0.001 * 300.0);
+  combined.insert(Coord::Temperature, {}, {300.0});
+  combined.get(Data::Value, "sample")[0] = exp(-0.001 * 300.0);
   auto dataPoint(combined);
   for (const auto temperature : {273.0, 200.0, 100.0, 10.0, 4.2}) {
-    dataPoint.get(Coord::Temperature{})[0] = temperature;
-    dataPoint.get(Data::Value{}, "sample")[0] = exp(-0.001 * temperature);
+    dataPoint.get(Coord::Temperature)[0] = temperature;
+    dataPoint.get(Data::Value, "sample")[0] = exp(-0.001 * temperature);
     combined = concatenate(combined, dataPoint, Dim::Temperature);
   }
 
   // Compute spin difference.
-  DatasetIndex<Coord::Polarization> spin(combined);
-  combined.erase(Coord::Polarization{});
+  DatasetIndex<decltype(Coord::Polarization)> spin(combined);
+  combined.erase(Coord::Polarization);
   Dataset delta = combined(Dim::Polarization, spin["spin-up"]) -
                   combined(Dim::Polarization, spin["spin-down"]);
 
@@ -87,67 +86,65 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
   delta = delta(Dim::Tof, 0);
 
   auto nested =
-      MDNested(MDRead(Coord::Temperature{}), MDRead(Data::Value{}, "sample"),
-               MDRead(Data::Variance{}, "sample"));
-  using PointData = decltype(nested)::type;
+      MDNested(MDRead(Coord::Temperature), MDRead(Data::Value, "sample"),
+               MDRead(Data::Variance, "sample"));
+  auto PointData = decltype(nested)::type(delta, "sample");
   auto view =
-      zipMD(delta, {Dim::Temperature}, nested, MDRead(Coord::SpectrumNumber{}));
+      zipMD(delta, {Dim::Temperature}, nested, MDRead(Coord::SpectrumNumber));
 
   auto tempDependence =
-      std::find_if(view.begin(), view.end(),
-                   [](const auto &item) {
-                     return item.template get<Coord::SpectrumNumber>() == 1;
-                   })
-          ->get<PointData>();
+      std::find_if(
+          view.begin(), view.end(),
+          [](const auto &item) { return item.get(Coord::SpectrumNumber) == 1; })
+          ->get(PointData);
   static_cast<void>(tempDependence);
 
   // Do something with the resulting point data, e.g., plot:
   // for (const auto &point : tempDependence)
-  //   plotPoint(point.get<Coord::Temperature>(), point.value(),
-  //             point.get<Data::Variance>());
+  //   plotPoint(point.get(Coord::Temperature), point.value(),
+  //             point.get(Data::Variance));
 }
 
 TEST(Workspace2D, multiple_data) {
   Dataset d;
 
-  d.insert(Coord::Tof{}, {Dim::Tof, 1000}, 1000);
+  d.insert(Coord::Tof, {Dim::Tof, 1000}, 1000);
 
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
 
   // Sample
-  d.insert(Data::Value{}, "sample", dims, dims.volume());
-  d.insert(Data::Variance{}, "sample", dims, dims.volume());
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
 
   // Background
-  d.insert(Data::Value{}, "background", dims, dims.volume());
-  d.insert(Data::Variance{}, "background", dims, dims.volume());
+  d.insert(Data::Value, "background", dims, dims.volume());
+  d.insert(Data::Variance, "background", dims, dims.volume());
 
   // Monitors
   // TODO Use Coord::Monitor instead of the old idea using Dim::MonitorTof.
   // dims = Dimensions({{Dim::MonitorTof, 222}, {Dim::Monitor, 2}});
-  // d.insert(Coord::MonitorTof{}, {Dim::MonitorTof, 222}, 222);
-  // d.insert(Data::Value{}, "monitor", dims, dims.volume());
-  // d.insert(Data::Variance{}, "monitor", dims, dims.volume());
+  // d.insert(Coord::MonitorTof, {Dim::MonitorTof, 222}, 222);
+  // d.insert(Data::Value, "monitor", dims, dims.volume());
+  // d.insert(Data::Variance, "monitor", dims, dims.volume());
 
   d.merge(d.extract("sample") - d.extract("background"));
   // Note: If we want to also keep "background" we can use:
   // d["sample"] -= d["background"];
 
-  EXPECT_NO_THROW(d.get(Data::Value{}, "sample"));
-  EXPECT_NO_THROW(d.get(Data::Variance{}, "sample"));
-  // EXPECT_NO_THROW(d.get(Data::Value{},"monitor"));
-  EXPECT_ANY_THROW(d.get(Data::Value{}, "background"));
+  EXPECT_NO_THROW(d.get(Data::Value, "sample"));
+  EXPECT_NO_THROW(d.get(Data::Variance, "sample"));
+  // EXPECT_NO_THROW(d.get(Data::Value,"monitor"));
+  EXPECT_ANY_THROW(d.get(Data::Value, "background"));
 }
 
 TEST(Workspace2D, scanning) {
   Dataset d;
 
   // Scalar part of instrument, e.g.:
-  // d.insert(Coord::Instrument{}, {}, Beamline::ComponentInfo{});
+  // d.insert(Coord::Instrument, {}, Beamline::ComponentInfo{});
   Dataset dets;
-  dets.insert(Coord::DetectorId{}, {Dim::Detector, 4},
-              {1001, 1002, 1003, 1004});
-  dets.insert(Coord::Position{}, {Dim::Detector, 4},
+  dets.insert(Coord::DetectorId, {Dim::Detector, 4}, {1001, 1002, 1003, 1004});
+  dets.insert(Coord::Position, {Dim::Detector, 4},
               {Eigen::Vector3d{1.0, 0.0, 0.0}, Eigen::Vector3d{2.0, 0.0, 0.0},
                Eigen::Vector3d{3.0, 0.0, 0.0}, Eigen::Vector3d{4.0, 0.0, 0.0}});
 
@@ -167,14 +164,14 @@ TEST(Workspace2D, scanning) {
   //   }
   // };
   auto moved(dets);
-  for (auto &pos : moved.get(Coord::Position{}))
+  for (auto &pos : moved.get(Coord::Position))
     pos += Eigen::Vector3d{0.5, 0.0, 0.0};
 
   auto scanning = concatenate(dets, moved, Dim::DetectorScan);
-  scanning.insert(Coord::TimeInterval{}, {Dim::DetectorScan, 2},
+  scanning.insert(Coord::TimeInterval, {Dim::DetectorScan, 2},
                   {std::make_pair(0l, 10l), std::make_pair(10l, 20l)});
 
-  d.insert(Coord::DetectorInfo{}, {}, {scanning});
+  d.insert(Coord::DetectorInfo, {}, {scanning});
 
   // Spectrum to detector mapping and spectrum numbers. Currently this mapping
   // is purely positional. We may consider changing this to an two-part
@@ -186,15 +183,15 @@ TEST(Workspace2D, scanning) {
   // is present.
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {
       {0}, {2}, {4}};
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 3}, grouping);
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 3}, {1, 2, 3});
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, 3}, grouping);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, 3}, {1, 2, 3});
 
-  auto view = zipMD(d, MDRead(Coord::Position{}));
+  auto view = zipMD(d, MDRead(Coord::Position));
   ASSERT_EQ(view.size(), 3);
   auto it = view.begin();
-  EXPECT_EQ(it++->get<Coord::Position>()[0], 1.0);
-  EXPECT_EQ(it++->get<Coord::Position>()[0], 3.0);
-  EXPECT_EQ(it++->get<Coord::Position>()[0], 1.5);
+  EXPECT_EQ(it++->get(Coord::Position)[0], 1.0);
+  EXPECT_EQ(it++->get(Coord::Position)[0], 3.0);
+  EXPECT_EQ(it++->get(Coord::Position)[0], 1.5);
 }
 
 TEST(Workspace2D, masking) {
@@ -202,19 +199,19 @@ TEST(Workspace2D, masking) {
 
   Dataset d;
 
-  d.insert(Coord::Tof{}, {Dim::Tof, 1000}, 1000);
+  d.insert(Coord::Tof, {Dim::Tof, 1000}, 1000);
   Dimensions dims({{Dim::Tof, 1000}, {Dim::Spectrum, 3}});
   // Sample
-  d.insert(Data::Value{}, "sample", dims, dims.volume());
-  d.insert(Data::Variance{}, "sample", dims, dims.volume());
+  d.insert(Data::Value, "sample", dims, dims.volume());
+  d.insert(Data::Variance, "sample", dims, dims.volume());
   // Background
-  d.insert(Data::Value{}, "background", dims, dims.volume());
-  d.insert(Data::Variance{}, "background", dims, dims.volume());
+  d.insert(Data::Value, "background", dims, dims.volume());
+  d.insert(Data::Variance, "background", dims, dims.volume());
 
   // Spectra mask.
   // Can be in its own Dataset to support loading, saving, and manipulation.
   Dataset mask;
-  mask.insert(Coord::Mask{}, {Dim::Spectrum, 3}, Vector<char>{0, 0, 1});
+  mask.insert(Coord::Mask, {Dim::Spectrum, 3}, Vector<char>{0, 0, 1});
 
   // Add mask to Dataset, not touching data.
   auto d_masked(d);
@@ -226,7 +223,7 @@ TEST(Workspace2D, masking) {
   // Adding non-masked to masked works, is this sensible behavior?
   EXPECT_NO_THROW(d_masked += d);
 
-  mask.get(Coord::Mask{})[0] = 1;
+  mask.get(Coord::Mask)[0] = 1;
   auto d_masked2(d);
   d_masked2.merge(mask);
 
@@ -236,26 +233,25 @@ TEST(Workspace2D, masking) {
   EXPECT_ANY_THROW(d_masked2 += d_masked);
 
   // Remove mask.
-  d_masked.erase(Coord::Mask{});
+  d_masked.erase(Coord::Mask);
 
   // Skip processing spectrum if it is masked.
-  EXPECT_FALSE(d_masked2(Coord::Mask{}).dimensions().contains(Dim::Tof));
+  EXPECT_FALSE(d_masked2(Coord::Mask).dimensions().contains(Dim::Tof));
   auto spectra =
-      zipMD(d_masked2, {Dim::Tof}, MDNested(MDWrite(Data::Value{}, "sample")),
-            MDRead(Coord::Mask{}));
+      zipMD(d_masked2, {Dim::Tof}, MDNested(MDWrite(Data::Value, "sample")),
+            MDRead(Coord::Mask));
   for (auto &item : spectra)
-    if (!item.get<Coord::Mask>())
-      for (auto &point :
-           item.get<decltype(MDNested(MDWrite(Data::Value{})))::type>())
+    if (!item.get(Coord::Mask))
+      for (auto &point : item.get(decltype(
+               MDNested(MDWrite(Data::Value)))::type(d_masked2, "sample")))
         point.value() += 1.0;
 
   // Apply mask.
-  auto view =
-      zipMD(d_masked2, MDWrite(Data::Value{}, "background"),
-            MDWrite(Data::Variance{}, "background"), MDRead(Coord::Mask{}));
+  auto view = zipMD(d_masked2, MDWrite(Data::Value, "background"),
+                    MDWrite(Data::Variance, "background"), MDRead(Coord::Mask));
   for (auto &item : view) {
-    item.value() *= item.get<Coord::Mask>();
-    item.get<Data::Variance>() *= item.get<Coord::Mask>();
+    item.value() *= item.get(Coord::Mask);
+    item.get(Data::Variance) *= item.get(Coord::Mask);
   }
   // Could by simplified if we implement binary operations with mixed types
   // (such as double * int):
@@ -264,11 +260,11 @@ TEST(Workspace2D, masking) {
 
   // Bin mask.
   mask = Dataset();
-  mask.insert(Coord::Mask{}, {Dim::Tof, 1000}, 1000);
-  mask.get(Coord::Mask{})[0] = 1;
+  mask.insert(Coord::Mask, {Dim::Tof, 1000}, 1000);
+  mask.get(Coord::Mask)[0] = 1;
   // mask has no Dim::Spectrum so this masks the first bin of all spectra.
   d_masked.merge(mask);
   // Different bin masking for all spectra.
   mask = Dataset();
-  mask.insert(Coord::Mask{}, dims, dims.volume());
+  mask.insert(Coord::Mask, dims, dims.volume());
 }

--- a/test/Workspace2D_test.cpp
+++ b/test/Workspace2D_test.cpp
@@ -69,11 +69,11 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
 
   // Do a temperature scan, adding a new temperature dimension to the dataset.
   combined.insert(Coord::Temperature{}, {}, {300.0});
-  combined.get<Data::Value>("sample")[0] = exp(-0.001 * 300.0);
+  combined.get(Data::Value{}, "sample")[0] = exp(-0.001 * 300.0);
   auto dataPoint(combined);
   for (const auto temperature : {273.0, 200.0, 100.0, 10.0, 4.2}) {
-    dataPoint.get<Coord::Temperature>()[0] = temperature;
-    dataPoint.get<Data::Value>("sample")[0] = exp(-0.001 * temperature);
+    dataPoint.get(Coord::Temperature{})[0] = temperature;
+    dataPoint.get(Data::Value{}, "sample")[0] = exp(-0.001 * temperature);
     combined = concatenate(combined, dataPoint, Dim::Temperature);
   }
 
@@ -133,10 +133,10 @@ TEST(Workspace2D, multiple_data) {
   // Note: If we want to also keep "background" we can use:
   // d["sample"] -= d["background"];
 
-  EXPECT_NO_THROW(d.get<Data::Value>("sample"));
-  EXPECT_NO_THROW(d.get<Data::Variance>("sample"));
-  // EXPECT_NO_THROW(d.get<Data::Value>("monitor"));
-  EXPECT_ANY_THROW(d.get<Data::Value>("background"));
+  EXPECT_NO_THROW(d.get(Data::Value{}, "sample"));
+  EXPECT_NO_THROW(d.get(Data::Variance{}, "sample"));
+  // EXPECT_NO_THROW(d.get(Data::Value{},"monitor"));
+  EXPECT_ANY_THROW(d.get(Data::Value{}, "background"));
 }
 
 TEST(Workspace2D, scanning) {
@@ -167,7 +167,7 @@ TEST(Workspace2D, scanning) {
   //   }
   // };
   auto moved(dets);
-  for (auto &pos : moved.get<Coord::Position>())
+  for (auto &pos : moved.get(Coord::Position{}))
     pos += Eigen::Vector3d{0.5, 0.0, 0.0};
 
   auto scanning = concatenate(dets, moved, Dim::DetectorScan);
@@ -226,7 +226,7 @@ TEST(Workspace2D, masking) {
   // Adding non-masked to masked works, is this sensible behavior?
   EXPECT_NO_THROW(d_masked += d);
 
-  mask.get<Coord::Mask>()[0] = 1;
+  mask.get(Coord::Mask{})[0] = 1;
   auto d_masked2(d);
   d_masked2.merge(mask);
 
@@ -265,7 +265,7 @@ TEST(Workspace2D, masking) {
   // Bin mask.
   mask = Dataset();
   mask.insert(Coord::Mask{}, {Dim::Tof, 1000}, 1000);
-  mask.get<Coord::Mask>()[0] = 1;
+  mask.get(Coord::Mask{})[0] = 1;
   // mask has no Dim::Spectrum so this masks the first bin of all spectra.
   d_masked.merge(mask);
   // Different bin masking for all spectra.

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -230,9 +230,9 @@ TEST(Dataset, const_get) {
   d.insert(Data::Value{}, "", Dimensions{}, {1.1});
   d.insert(Data::Int{}, "", Dimensions{}, {2});
   const auto &const_d(d);
-  auto view = const_d.get<Data::Value>();
+  auto view = const_d.get(Data::Value{});
   // No non-const access to variable if Dataset is const, will not compile:
-  // auto &view = const_d.get<Data::Value>();
+  // auto &view = const_d.get(Data::Value{});
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is deduced to be const, so assignment will not compile:
@@ -243,7 +243,7 @@ TEST(Dataset, get) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions{}, {1.1});
   d.insert(Data::Int{}, "", Dimensions{}, {2});
-  auto view = d.get<Data::Value>();
+  auto view = d.get(Data::Value{});
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   view[0] = 2.2;
@@ -254,7 +254,7 @@ TEST(Dataset, get_const) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions{}, {1.1});
   d.insert(Data::Int{}, "", Dimensions{}, {2});
-  auto view = d.get<Data::Value>();
+  auto view = d.get(Data::Value{});
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is now deduced to be const, so assignment will not compile:
@@ -265,10 +265,10 @@ TEST(Dataset, get_fail) {
   Dataset d;
   d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
   d.insert(Data::Value{}, "name2", Dimensions{}, {1.1});
-  EXPECT_THROW_MSG(d.get<Data::Value>(), std::runtime_error,
+  EXPECT_THROW_MSG(d.get(Data::Value{}), std::runtime_error,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Value and name ``.");
-  EXPECT_THROW_MSG(d.get<Data::Int>(), dataset::except::VariableNotFoundError,
+  EXPECT_THROW_MSG(d.get(Data::Int{}), dataset::except::VariableNotFoundError,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Int and name ``.");
 }
@@ -277,10 +277,10 @@ TEST(Dataset, get_named) {
   Dataset d;
   d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
   d.insert(Data::Value{}, "name2", Dimensions{}, {2.2});
-  auto var1 = d.get<Data::Value>("name1");
+  auto var1 = d.get(Data::Value{}, "name1");
   ASSERT_EQ(var1.size(), 1);
   EXPECT_EQ(var1[0], 1.1);
-  auto var2 = d.get<Data::Value>("name2");
+  auto var2 = d.get(Data::Value{}, "name2");
   ASSERT_EQ(var2.size(), 1);
   EXPECT_EQ(var2[0], 2.2);
 }
@@ -290,8 +290,8 @@ TEST(Dataset, operator_plus_equal) {
   a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
   a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   a += a;
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 4.4);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 4.4);
 }
 
 TEST(Dataset, operator_plus_equal_broadcast) {
@@ -305,13 +305,13 @@ TEST(Dataset, operator_plus_equal_broadcast) {
   b.insert(Data::Value{}, "", Dimensions({{Dim::Z, 3}}), {0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<Data::Value>()[1], 2.1);
-  EXPECT_EQ(a.get<Data::Value>()[2], 3.2);
-  EXPECT_EQ(a.get<Data::Value>()[3], 4.2);
-  EXPECT_EQ(a.get<Data::Value>()[4], 5.3);
-  EXPECT_EQ(a.get<Data::Value>()[5], 6.3);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value{})[1], 2.1);
+  EXPECT_EQ(a.get(Data::Value{})[2], 3.2);
+  EXPECT_EQ(a.get(Data::Value{})[3], 4.2);
+  EXPECT_EQ(a.get(Data::Value{})[4], 5.3);
+  EXPECT_EQ(a.get(Data::Value{})[5], 6.3);
 }
 
 TEST(Dataset, operator_plus_equal_transpose) {
@@ -326,13 +326,13 @@ TEST(Dataset, operator_plus_equal_transpose) {
            {0.1, 0.2, 0.3, 0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 1.1);
-  EXPECT_EQ(a.get<Data::Value>()[1], 2.1);
-  EXPECT_EQ(a.get<Data::Value>()[2], 3.2);
-  EXPECT_EQ(a.get<Data::Value>()[3], 4.2);
-  EXPECT_EQ(a.get<Data::Value>()[4], 5.3);
-  EXPECT_EQ(a.get<Data::Value>()[5], 6.3);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value{})[1], 2.1);
+  EXPECT_EQ(a.get(Data::Value{})[2], 3.2);
+  EXPECT_EQ(a.get(Data::Value{})[3], 4.2);
+  EXPECT_EQ(a.get(Data::Value{})[4], 5.3);
+  EXPECT_EQ(a.get(Data::Value{})[5], 6.3);
 }
 
 TEST(Dataset, operator_plus_equal_different_content) {
@@ -357,11 +357,11 @@ TEST(Dataset, operator_plus_equal_with_attributes) {
   logs.insert(Data::String{}, "comments", {}, {std::string("test")});
   a.insert(Attr::ExperimentLog{}, "", {}, {logs});
   a += a;
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 4.4);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 4.4);
   // For now there is no special merging behavior, just keep attributes of first
   // operand.
-  EXPECT_EQ(a.get<Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(a.get(Attr::ExperimentLog{})[0], logs);
 }
 
 TEST(Dataset, operator_times_equal) {
@@ -369,8 +369,8 @@ TEST(Dataset, operator_times_equal) {
   a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
   a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
   a *= a;
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 9.0);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 9.0);
 }
 
 TEST(Dataset, operator_times_equal_with_attributes) {
@@ -381,9 +381,9 @@ TEST(Dataset, operator_times_equal_with_attributes) {
   logs.insert(Data::String{}, "comments", {}, {std::string("test")});
   a.insert(Attr::ExperimentLog{}, "", {}, {logs});
   a *= a;
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 9.0);
-  EXPECT_EQ(a.get<Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 9.0);
+  EXPECT_EQ(a.get(Attr::ExperimentLog{})[0], logs);
 }
 
 TEST(Dataset, operator_times_equal_with_uncertainty) {
@@ -396,9 +396,9 @@ TEST(Dataset, operator_times_equal_with_uncertainty) {
   b.insert(Data::Value{}, "", {Dim::X, 1}, {4.0});
   b.insert(Data::Variance{}, "", {Dim::X, 1}, {3.0});
   a *= b;
-  EXPECT_EQ(a.get<Coord::X>()[0], 0.1);
-  EXPECT_EQ(a.get<Data::Value>()[0], 12.0);
-  EXPECT_EQ(a.get<Data::Variance>()[0], 2.0 * 16.0 + 3.0 * 9.0);
+  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value{})[0], 12.0);
+  EXPECT_EQ(a.get(Data::Variance{})[0], 2.0 * 16.0 + 3.0 * 9.0);
 }
 
 TEST(Dataset, operator_times_equal_uncertainty_failures) {
@@ -447,7 +447,7 @@ TEST(Dataset, operator_times_equal_with_units) {
   a *= a;
   EXPECT_EQ(a(Data::Value{}).unit(), Unit::Id::Area);
   EXPECT_EQ(a(Data::Variance{}).unit(), Unit::Id::AreaVariance);
-  EXPECT_EQ(a.get<Data::Variance>()[0], 36.0);
+  EXPECT_EQ(a.get(Data::Variance{})[0], 36.0);
 }
 
 TEST(Dataset, operator_times_equal_histogram_data) {
@@ -483,13 +483,13 @@ TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
   const auto a2(a);
   const auto b(a);
 
-  const auto *addr = &a.get<Data::Value>()[0];
+  const auto *addr = &a.get(Data::Value{})[0];
   auto sum = std::move(a) + b;
-  EXPECT_EQ(&sum.get<Data::Value>()[0], addr);
+  EXPECT_EQ(&sum.get(Data::Value{})[0], addr);
 
-  const auto *addr2 = &a2.get<Data::Value>()[0];
+  const auto *addr2 = &a2.get(Data::Value{})[0];
   auto sum2 = a2 + b;
-  EXPECT_NE(&sum2.get<Data::Value>()[0], addr2);
+  EXPECT_NE(&sum2.get(Data::Value{})[0], addr2);
 }
 
 TEST(Dataset, slice) {
@@ -500,28 +500,28 @@ TEST(Dataset, slice) {
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i);
     ASSERT_EQ(sliceX.size(), 1);
-    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get(Data::Value{}).size(), 3);
+    EXPECT_EQ(sliceX.get(Data::Value{})[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value{})[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value{})[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i, i + 1);
     ASSERT_EQ(sliceX.size(), 2);
-    ASSERT_EQ(sliceX.get<Coord::X>().size(), 1);
-    EXPECT_EQ(sliceX.get<Coord::X>()[0], 0.1 * i);
-    ASSERT_EQ(sliceX.get<Data::Value>().size(), 3);
-    EXPECT_EQ(sliceX.get<Data::Value>()[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get<Data::Value>()[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get<Data::Value>()[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get(Coord::X{}).size(), 1);
+    EXPECT_EQ(sliceX.get(Coord::X{})[0], 0.1 * i);
+    ASSERT_EQ(sliceX.get(Data::Value{}).size(), 3);
+    EXPECT_EQ(sliceX.get(Data::Value{})[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value{})[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value{})[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1, 2}) {
     Dataset sliceY = d(Dim::Y, i);
     ASSERT_EQ(sliceY.size(), 2);
-    ASSERT_EQ(sliceY.get<Coord::X>(), d.get<Coord::X>());
-    ASSERT_EQ(sliceY.get<Data::Value>().size(), 2);
-    EXPECT_EQ(sliceY.get<Data::Value>()[0], 0.0 + 2 * i);
-    EXPECT_EQ(sliceY.get<Data::Value>()[1], 1.0 + 2 * i);
+    ASSERT_EQ(sliceY.get(Coord::X{}), d.get(Coord::X{}));
+    ASSERT_EQ(sliceY.get(Data::Value{}).size(), 2);
+    EXPECT_EQ(sliceY.get(Data::Value{})[0], 0.0 + 2 * i);
+    EXPECT_EQ(sliceY.get(Data::Value{})[1], 1.0 + 2 * i);
   }
   EXPECT_THROW_MSG(
       d(Dim::Z, 0), std::runtime_error,
@@ -547,23 +547,23 @@ TEST(Dataset, concatenate) {
   a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<Data::Value>().size(), 2);
+  EXPECT_EQ(x.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(x.get(Data::Value{}).size(), 2);
   auto x2(x);
-  x2.get<Data::Value>()[0] = 100.0;
+  x2.get(Data::Value{})[0] = 100.0;
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value{}).size(), 4);
 
   xy = concatenate(xy, x, Dim::Y);
-  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<Data::Value>().size(), 6);
+  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value{}).size(), 6);
 
   xy = concatenate(xy, xy, Dim::Y);
-  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<Data::Value>().size(), 12);
+  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value{}).size(), 12);
 }
 
 TEST(Dataset, concatenate_with_bin_edges) {
@@ -596,8 +596,8 @@ TEST(Dataset, concatenate_with_bin_edges) {
   EXPECT_NO_THROW(merged = concatenate(ds, ds2, Dim::X));
   EXPECT_EQ(merged.dimensions().count(), 1);
   EXPECT_TRUE(merged.dimensions().contains(Dim::X));
-  EXPECT_TRUE(equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3}));
-  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 3.3}));
+  EXPECT_TRUE(equals(merged.get(Coord::X{}), {0.1, 0.2, 0.3}));
+  EXPECT_TRUE(equals(merged.get(Data::Value{}), {2.2, 3.3}));
 }
 
 TEST(Dataset, concatenate_with_varying_bin_edges) {
@@ -618,8 +618,8 @@ TEST(Dataset, concatenate_with_varying_bin_edges) {
   EXPECT_EQ(merged.dimensions()[Dim::X], 2);
   EXPECT_EQ(merged.dimensions()[Dim::Y], 2);
   EXPECT_TRUE(
-      equals(merged.get<Coord::X>(), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
-  EXPECT_TRUE(equals(merged.get<Data::Value>(), {2.2, 4.4, 3.3, 5.5}));
+      equals(merged.get(Coord::X{}), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
+  EXPECT_TRUE(equals(merged.get(Data::Value{}), {2.2, 4.4, 3.3, 5.5}));
 }
 
 TEST(Dataset, concatenate_with_attributes) {
@@ -632,29 +632,29 @@ TEST(Dataset, concatenate_with_attributes) {
 
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get<Coord::X>().size(), 2);
-  EXPECT_EQ(x.get<Data::Value>().size(), 2);
-  EXPECT_EQ(x.get<Attr::ExperimentLog>().size(), 1);
-  EXPECT_EQ(x.get<Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(x.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(x.get(Data::Value{}).size(), 2);
+  EXPECT_EQ(x.get(Attr::ExperimentLog{}).size(), 1);
+  EXPECT_EQ(x.get(Attr::ExperimentLog{})[0], logs);
 
   auto x2(x);
-  x2.get<Data::Value>()[0] = 100.0;
-  x2.get<Attr::ExperimentLog>()[0].get<Data::String>("comments")[0] =
+  x2.get(Data::Value{})[0] = 100.0;
+  x2.get(Attr::ExperimentLog{})[0].get(Data::String{}, "comments")[0] =
       "different";
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get<Coord::X>().size(), 2);
-  EXPECT_EQ(xy.get<Data::Value>().size(), 4);
+  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value{}).size(), 4);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
-  EXPECT_EQ(xy.get<Attr::ExperimentLog>().size(), 2);
-  EXPECT_EQ(xy.get<Attr::ExperimentLog>()[0], logs);
+  EXPECT_EQ(xy.get(Attr::ExperimentLog{}).size(), 2);
+  EXPECT_EQ(xy.get(Attr::ExperimentLog{})[0], logs);
 
   EXPECT_NO_THROW(concatenate(xy, xy, Dim::X));
 
   auto xy2(xy);
-  xy2.get<Attr::ExperimentLog>()[0].get<Data::String>("comments")[0] = "";
+  xy2.get(Attr::ExperimentLog{})[0].get(Data::String{}, "comments")[0] = "";
   // Concatenating in existing dimension fail currently. Would need to implement
   // merging functionality for attributes?
   EXPECT_ANY_THROW(concatenate(xy, xy2, Dim::X));
@@ -715,8 +715,8 @@ TEST(Dataset, rebin) {
 
   d.insert(Data::Value{}, "", {Dim::X, 2}, {10.0, 20.0});
   auto rebinned = rebin(d, coordNew);
-  EXPECT_EQ(rebinned.get<Data::Value>().size(), 1);
-  EXPECT_EQ(rebinned.get<Data::Value>()[0], 30.0);
+  EXPECT_EQ(rebinned.get(Data::Value{}).size(), 1);
+  EXPECT_EQ(rebinned.get(Data::Value{})[0], 30.0);
 }
 
 Dataset makeEvents() {
@@ -762,8 +762,8 @@ TEST(Dataset, histogram) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 1, 4}));
-  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 1, 4}));
 }
 
 TEST(Dataset, histogram_2D_coord) {
@@ -776,8 +776,8 @@ TEST(Dataset, histogram_2D_coord) {
   EXPECT_EQ(hist(Coord::Tof{}), coord);
   ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
   ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, histogram_2D_transpose_coord) {
@@ -794,8 +794,8 @@ TEST(Dataset, histogram_2D_transpose_coord) {
   // dimension will almost be the innermost one.
   ASSERT_EQ(hist(Data::Value{}, "sample1").dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Tof, 2}}));
-  EXPECT_TRUE(equals(hist.get<Data::Value>("sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get<Data::Variance>("sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, sort) {
@@ -806,21 +806,21 @@ TEST(Dataset, sort) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get(Coord::X{}).size(), 4);
+  EXPECT_EQ(sorted.get(Coord::X{})[0], 0.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[1], 1.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[2], 3.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[3], 5.0);
 
-  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get(Coord::Y{}).size(), 2);
+  EXPECT_EQ(sorted.get(Coord::Y{})[0], 1.0);
+  EXPECT_EQ(sorted.get(Coord::Y{})[1], 0.9);
 
-  ASSERT_EQ(sorted.get<Data::Value>().size(), 4);
-  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
+  ASSERT_EQ(sorted.get(Data::Value{}).size(), 4);
+  EXPECT_EQ(sorted.get(Data::Value{})[0], 4.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[1], 2.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[2], 3.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[3], 1.0);
 }
 
 TEST(Dataset, sort_2D) {
@@ -832,25 +832,25 @@ TEST(Dataset, sort_2D) {
 
   auto sorted = sort(d, Coord::X{});
 
-  ASSERT_EQ(sorted.get<Coord::X>().size(), 4);
-  EXPECT_EQ(sorted.get<Coord::X>()[0], 0.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[1], 1.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[2], 3.0);
-  EXPECT_EQ(sorted.get<Coord::X>()[3], 5.0);
+  ASSERT_EQ(sorted.get(Coord::X{}).size(), 4);
+  EXPECT_EQ(sorted.get(Coord::X{})[0], 0.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[1], 1.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[2], 3.0);
+  EXPECT_EQ(sorted.get(Coord::X{})[3], 5.0);
 
-  ASSERT_EQ(sorted.get<Coord::Y>().size(), 2);
-  EXPECT_EQ(sorted.get<Coord::Y>()[0], 1.0);
-  EXPECT_EQ(sorted.get<Coord::Y>()[1], 0.9);
+  ASSERT_EQ(sorted.get(Coord::Y{}).size(), 2);
+  EXPECT_EQ(sorted.get(Coord::Y{})[0], 1.0);
+  EXPECT_EQ(sorted.get(Coord::Y{})[1], 0.9);
 
-  ASSERT_EQ(sorted.get<Data::Value>().size(), 8);
-  EXPECT_EQ(sorted.get<Data::Value>()[0], 4.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[1], 2.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[2], 3.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[3], 1.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[4], 8.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[5], 6.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[6], 7.0);
-  EXPECT_EQ(sorted.get<Data::Value>()[7], 5.0);
+  ASSERT_EQ(sorted.get(Data::Value{}).size(), 8);
+  EXPECT_EQ(sorted.get(Data::Value{})[0], 4.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[1], 2.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[2], 3.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[3], 1.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[4], 8.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[5], 6.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[6], 7.0);
+  EXPECT_EQ(sorted.get(Data::Value{})[7], 5.0);
 }
 
 TEST(Dataset, filter) {
@@ -863,19 +863,19 @@ TEST(Dataset, filter) {
 
   auto filtered = filter(d, select);
 
-  ASSERT_EQ(filtered.get<Coord::X>().size(), 2);
-  EXPECT_EQ(filtered.get<Coord::X>()[0], 1.0);
-  EXPECT_EQ(filtered.get<Coord::X>()[1], 0.0);
+  ASSERT_EQ(filtered.get(Coord::X{}).size(), 2);
+  EXPECT_EQ(filtered.get(Coord::X{})[0], 1.0);
+  EXPECT_EQ(filtered.get(Coord::X{})[1], 0.0);
 
-  ASSERT_EQ(filtered.get<Coord::Y>().size(), 2);
-  EXPECT_EQ(filtered.get<Coord::Y>()[0], 1.0);
-  EXPECT_EQ(filtered.get<Coord::Y>()[1], 0.9);
+  ASSERT_EQ(filtered.get(Coord::Y{}).size(), 2);
+  EXPECT_EQ(filtered.get(Coord::Y{})[0], 1.0);
+  EXPECT_EQ(filtered.get(Coord::Y{})[1], 0.9);
 
-  ASSERT_EQ(filtered.get<Data::Value>().size(), 4);
-  EXPECT_EQ(filtered.get<Data::Value>()[0], 2.0);
-  EXPECT_EQ(filtered.get<Data::Value>()[1], 4.0);
-  EXPECT_EQ(filtered.get<Data::Value>()[2], 6.0);
-  EXPECT_EQ(filtered.get<Data::Value>()[3], 8.0);
+  ASSERT_EQ(filtered.get(Data::Value{}).size(), 4);
+  EXPECT_EQ(filtered.get(Data::Value{})[0], 2.0);
+  EXPECT_EQ(filtered.get(Data::Value{})[1], 4.0);
+  EXPECT_EQ(filtered.get(Data::Value{})[2], 6.0);
+  EXPECT_EQ(filtered.get(Data::Value{})[3], 8.0);
 }
 
 TEST(Dataset, integrate) {
@@ -889,7 +889,7 @@ TEST(Dataset, integrate) {
   EXPECT_FALSE(integral.contains(Coord::X{}));
   // Note: The current implementation assumes that Data::Value is counts,
   // handling of other data is not implemented yet.
-  EXPECT_TRUE(equals(integral.get<Data::Value>(), {30.0}));
+  EXPECT_TRUE(equals(integral.get(Data::Value{}), {30.0}));
 }
 
 TEST(DatasetSlice, basics) {
@@ -933,19 +933,19 @@ TEST(DatasetSlice, minus_equals) {
 
   EXPECT_NO_THROW(d -= d["a"]);
 
-  EXPECT_EQ(d.get<Data::Value>("a")[0], 0.0);
-  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<Data::Variance>("a")[0], 2.0);
-  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Value{}, "a")[0], 0.0);
+  EXPECT_EQ(d.get(Data::Value{}, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Variance{}, "a")[0], 2.0);
+  EXPECT_EQ(d.get(Data::Variance{}, "b")[0], 1.0);
 
   ASSERT_NO_THROW(d["a"] -= d["b"]);
 
   ASSERT_EQ(d.size(), 6);
   // Note: Variable not renamed when operating with slices.
-  EXPECT_EQ(d.get<Data::Value>("a")[0], -1.0);
-  EXPECT_EQ(d.get<Data::Value>("b")[0], 1.0);
-  EXPECT_EQ(d.get<Data::Variance>("a")[0], 3.0);
-  EXPECT_EQ(d.get<Data::Variance>("b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Value{}, "a")[0], -1.0);
+  EXPECT_EQ(d.get(Data::Value{}, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Variance{}, "a")[0], 3.0);
+  EXPECT_EQ(d.get(Data::Variance{}, "b")[0], 1.0);
 }
 
 TEST(DatasetSlice, slice_spatial) {
@@ -996,12 +996,12 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4}));
-  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {1, 2, 3, 4}));
+  EXPECT_TRUE(equals(d.get(Coord::Y{}), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1044,12 +1044,12 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {1, 2, 3, 4, 5}));
-  EXPECT_TRUE(equals(d.get<Coord::Y>(), {1, 2}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {1, 2, 3, 4, 5}));
+  EXPECT_TRUE(equals(d.get(Coord::Y{}), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   auto view_a_x01 = d["a"](Dim::X, 0, 1);
   auto view_a_x12 = d["a"](Dim::X, 1, 2);
@@ -1106,25 +1106,25 @@ TEST(Dataset, binary_assign_with_scalar) {
   d.insert(Data::Variance{}, "d2", {}, {6});
 
   d += 1;
-  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {2, 3}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {2, 3}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {6}));
 
   d -= 2;
-  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 1}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {0, 1}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {6}));
 
   d *= 2;
-  EXPECT_TRUE(equals(d.get<Data::Value>("d1"), {0, 2}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("d2"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {0, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d1"), {16, 20}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("d2"), {24}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {16, 20}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {24}));
 }
 
 TEST(DatasetSlice, binary_assign_with_scalar) {
@@ -1138,29 +1138,29 @@ TEST(DatasetSlice, binary_assign_with_scalar) {
   auto slice = d(Dim::X, 1);
 
   slice += 1;
-  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 3}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 3}));
   // TODO This behavior should be reconsidered and probably change: A slice
   // should not include variables that do not have the dimension, otherwise,
   // e.g., looping over slices will apply an operation to that variable more
   // than once.
-  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {6}));
 
   slice -= 2;
-  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 1}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {6}));
 
   slice *= 2;
-  EXPECT_TRUE(equals(d.get<Data::Value>("a"), {1, 2}));
-  EXPECT_TRUE(equals(d.get<Data::Value>("b"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get<Data::Variance>("a"), {4, 20}));
-  EXPECT_TRUE(equals(d.get<Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 20}));
+  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {24}));
 }
 
 TEST(Dataset, binary_with_scalar) {
@@ -1172,37 +1172,37 @@ TEST(Dataset, binary_with_scalar) {
   d.insert(Data::Variance{}, "b", {}, {6});
 
   auto sum = d + 1;
-  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {2, 3}));
-  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {2, 3}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
   sum = 2 + d;
-  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3, 4}));
-  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {3, 4}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
 
   auto diff = d - 1;
-  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0, 1}));
-  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {0, 1}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {2}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
   diff = 2 - d;
-  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1, 0}));
-  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {1, 0}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {-1}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
 
   auto prod = d * 2;
-  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {2, 4}));
-  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {16, 20}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {2, 4}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {16, 20}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {24}));
   prod = 3 * d;
-  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {3, 6}));
-  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {36, 45}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {3, 6}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {9}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {36, 45}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {54}));
 }
 
 TEST(DatasetSlice, binary_with_scalar) {
@@ -1219,37 +1219,37 @@ TEST(DatasetSlice, binary_with_scalar) {
   // DatasetSlice to Dataset, so this test is actually testing that conversion,
   // not the binary operation iteself.
   auto sum = slice + 1;
-  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {3}));
-  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {4}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {3}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
   sum = 2 + slice;
-  EXPECT_TRUE(equals(sum.get<Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(sum.get<Data::Value>("b"), {5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(sum.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
 
   auto diff = slice - 1;
-  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {1}));
-  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {2}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {1}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {2}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
   diff = 2 - slice;
-  EXPECT_TRUE(equals(diff.get<Data::Value>("a"), {0}));
-  EXPECT_TRUE(equals(diff.get<Data::Value>("b"), {-1}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("a"), {5}));
-  EXPECT_TRUE(equals(diff.get<Data::Variance>("b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {0}));
+  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {-1}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
 
   auto prod = slice * 2;
-  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {4}));
-  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {6}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {20}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {24}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {4}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {20}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {24}));
   prod = 3 * slice;
-  EXPECT_TRUE(equals(prod.get<Data::Value>("a"), {6}));
-  EXPECT_TRUE(equals(prod.get<Data::Value>("b"), {9}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("a"), {45}));
-  EXPECT_TRUE(equals(prod.get<Data::Variance>("b"), {54}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {9}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {45}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {54}));
 }
 
 Dataset makeTofDataForUnitConversion() {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -1057,8 +1057,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 1 so we get 2 edges.
   ASSERT_EQ(view_a_x01.dimensions()[Dim::X], 1);
   ASSERT_EQ(view_a_x01[0].dimensions()[Dim::X], 2);
-  EXPECT_TRUE(equals(view_a_x01[0].get<Coord::X>(), {1, 2}));
-  EXPECT_TRUE(equals(view_a_x12[0].get<Coord::X>(), {2, 3}));
+  EXPECT_TRUE(equals(view_a_x01[0].get(Coord::X{}), {1, 2}));
+  EXPECT_TRUE(equals(view_a_x12[0].get(Coord::X{}), {2, 3}));
 
   auto view_a_x02 = d["a"](Dim::X, 0, 2);
   auto view_a_x13 = d["a"](Dim::X, 1, 3);
@@ -1066,8 +1066,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // View extent is 2 so we get 3 edges.
   ASSERT_EQ(view_a_x02.dimensions()[Dim::X], 2);
   ASSERT_EQ(view_a_x02[0].dimensions()[Dim::X], 3);
-  EXPECT_TRUE(equals(view_a_x02[0].get<Coord::X>(), {1, 2, 3}));
-  EXPECT_TRUE(equals(view_a_x13[0].get<Coord::X>(), {2, 3, 4}));
+  EXPECT_TRUE(equals(view_a_x02[0].get(Coord::X{}), {1, 2, 3}));
+  EXPECT_TRUE(equals(view_a_x13[0].get(Coord::X{}), {2, 3, 4}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1288,11 +1288,11 @@ TEST(Dataset, convert) {
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 4}}));
   // TODO Check unit.
 
-  const auto values = coord.get<Coord::Energy>();
+  const auto values = coord.get(Coord::Energy{});
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 437 * sqrt ( E[meV] )
   Variable tof_in_seconds = tof(Coord::Tof{}) * 1e-6;
-  const auto tofs = tof_in_seconds.get<Coord::Tof>();
+  const auto tofs = tof_in_seconds.get(Coord::Tof{});
   // Spectrum 0 is 11 m from source
   EXPECT_NEAR(values[0], pow((11.0 / tofs[0]) / 437.0, 2), values[0] * 0.01);
   EXPECT_NEAR(values[1], pow((11.0 / tofs[1]) / 437.0, 2), values[1] * 0.01);
@@ -1309,7 +1309,7 @@ TEST(Dataset, convert) {
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
-  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1372,16 +1372,16 @@ TEST(Dataset, convert_direct_inelastic) {
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
   EXPECT_FALSE(
-      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+      equals(coord.get(Coord::DeltaE{}), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position see same deltaE.
-  EXPECT_EQ(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
+  EXPECT_EQ(coord(Dim::Spectrum, 0).get(Coord::DeltaE{})[0],
+            coord(Dim::Spectrum, 1).get(Coord::DeltaE{})[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
@@ -1424,17 +1424,17 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
   EXPECT_FALSE(
-      equals(coord.get<Coord::DeltaE>(), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+      equals(coord.get(Coord::DeltaE{}), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position, but now their Ei differs, so deltaE is also
   // different (compare to test for single Ei above).
-  EXPECT_NE(coord(Dim::Spectrum, 0).get<Coord::DeltaE>()[0],
-            coord(Dim::Spectrum, 1).get<Coord::DeltaE>()[0]);
+  EXPECT_NE(coord(Dim::Spectrum, 0).get(Coord::DeltaE{})[0],
+            coord(Dim::Spectrum, 1).get(Coord::DeltaE{})[0]);
 
   ASSERT_TRUE(energy.contains(Data::Value{}));
   const auto &data = energy(Data::Value{});
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(equals(data.get<Data::Value>(), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
   ASSERT_TRUE(energy.contains(Coord::Position{}));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -17,28 +17,26 @@ TEST(Dataset, construct) { ASSERT_NO_THROW(Dataset d); }
 
 TEST(Dataset, insert_coords) {
   Dataset d;
-  d.insert(Coord::Tof{}, Dimensions{}, {1.1});
-  d.insert(Coord::SpectrumNumber{}, Dimensions{}, {2});
-  EXPECT_THROW_MSG(d.insert(Coord::SpectrumNumber{}, Dimensions{}, {2}),
-                   std::runtime_error,
+  d.insert(Coord::Tof, {}, {1.1});
+  d.insert(Coord::SpectrumNumber, {}, {2});
+  EXPECT_THROW_MSG(d.insert(Coord::SpectrumNumber, {}, {2}), std::runtime_error,
                    "Attempt to insert duplicate coordinate.");
   ASSERT_EQ(d.size(), 2);
 }
 
 TEST(Dataset, insert_data) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
-  EXPECT_THROW_MSG(d.insert(Data::Int{}, "name2", Dimensions{}, {2}),
-                   std::runtime_error,
+  d.insert(Data::Value, "name1", {}, {1.1});
+  d.insert(Data::Int, "name2", {}, {2});
+  EXPECT_THROW_MSG(d.insert(Data::Int, "name2", {}, {2}), std::runtime_error,
                    "Attempt to insert data of same type with duplicate name.");
   ASSERT_EQ(d.size(), 2);
 }
 
 TEST(Dataset, insert_variables_with_dimensions) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 2), {1.1, 2.2});
-  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
+  d.insert(Data::Value, "name1", Dimensions(Dim::Tof, 2), {1.1, 2.2});
+  d.insert(Data::Int, "name2", {}, {2});
 }
 
 TEST(Dataset, insert_variables_different_order) {
@@ -53,55 +51,55 @@ TEST(Dataset, insert_variables_different_order) {
   yz.add(Dim::Z, 3);
 
   Dataset xyz;
-  xyz.insert(Data::Value{}, "name1", xy, 2);
-  EXPECT_NO_THROW(xyz.insert(Data::Value{}, "name2", yz, 6));
-  EXPECT_NO_THROW(xyz.insert(Data::Value{}, "name3", xz, 3));
+  xyz.insert(Data::Value, "name1", xy, 2);
+  EXPECT_NO_THROW(xyz.insert(Data::Value, "name2", yz, 6));
+  EXPECT_NO_THROW(xyz.insert(Data::Value, "name3", xz, 3));
 
   Dataset xzy;
-  xzy.insert(Data::Value{}, "name1", xz, 3);
-  EXPECT_NO_THROW(xzy.insert(Data::Value{}, "name2", xy, 2));
-  EXPECT_NO_THROW(xzy.insert(Data::Value{}, "name3", yz, 6));
+  xzy.insert(Data::Value, "name1", xz, 3);
+  EXPECT_NO_THROW(xzy.insert(Data::Value, "name2", xy, 2));
+  EXPECT_NO_THROW(xzy.insert(Data::Value, "name3", yz, 6));
 }
 
 TEST(Dataset, insert_edges) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", {Dim::Tof, 2});
+  d.insert(Data::Value, "name1", {Dim::Tof, 2});
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
-  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
 }
 
 TEST(Dataset, insert_edges_first) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
-  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
 }
 
 TEST(Dataset, insert_edges_first_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
-  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
   // Once we have edges and non-edges dimensions cannot change further.
   EXPECT_THROW_MSG(
-      d.insert(Data::Value{}, "name2", {Dim::Tof, 1}), std::runtime_error,
+      d.insert(Data::Value, "name2", {Dim::Tof, 1}), std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
-  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 4}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 4}), std::runtime_error,
                    "Attempt to insert duplicate coordinate.");
 }
 
 TEST(Dataset, insert_edges_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert(Data::Value{}, "name1", {Dim::Tof, 2}));
+  EXPECT_NO_THROW(d.insert(Data::Value, "name1", {Dim::Tof, 2}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
-  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 4}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 4}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
                    "dimension coordiante, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
-  EXPECT_THROW_MSG(d.insert(Coord::Tof{}, {Dim::Tof, 1}), std::runtime_error,
+  EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 1}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
                    "dimension coordiante, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
@@ -109,22 +107,22 @@ TEST(Dataset, insert_edges_fail) {
 
 TEST(Dataset, insert_edges_reverse_fail) {
   Dataset d;
-  EXPECT_NO_THROW(d.insert(Coord::Tof{}, {Dim::Tof, 3}));
+  EXPECT_NO_THROW(d.insert(Coord::Tof, {Dim::Tof, 3}));
   EXPECT_EQ(d.dimensions()[Dim::Tof], 3);
   EXPECT_THROW_MSG(
-      d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 1)),
+      d.insert(Data::Value, "name1", Dimensions(Dim::Tof, 1)),
       std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
   EXPECT_THROW_MSG(
-      d.insert(Data::Value{}, "name1", Dimensions(Dim::Tof, 4)),
+      d.insert(Data::Value, "name1", Dimensions(Dim::Tof, 4)),
       std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
 }
 
 TEST(Dataset, can_use_normal_insert_to_copy_edges) {
   Dataset d;
-  d.insert(Data::Value{}, "", {Dim::X, 2});
-  d.insert(Coord::X{}, {Dim::X, 3});
+  d.insert(Data::Value, "", {Dim::X, 2});
+  d.insert(Coord::X, {Dim::X, 3});
 
   Dataset copy;
   for (auto var : d)
@@ -133,19 +131,19 @@ TEST(Dataset, can_use_normal_insert_to_copy_edges) {
 
 TEST(Dataset, custom_type) {
   Dataset d;
-  d.insert<float>(Data::Value{}, "", {Dim::Tof, 2});
-  EXPECT_EQ(d(Data::Value{}, "").dtype(), dtype<float>);
+  d.insert<float>(Data::Value, "", {Dim::Tof, 2});
+  EXPECT_EQ(d(Data::Value, "").dtype(), dtype<float>);
   EXPECT_TRUE(
-      (std::is_same<decltype(d(Data::Value{}, "").span<float>())::element_type,
+      (std::is_same<decltype(d(Data::Value, "").span<float>())::element_type,
                     float>::value));
 }
 
 TEST(Dataset, mixed_type_operations_fails_currently) {
   // This *currently* fails, but we would eventually want to support this.
   Dataset d1;
-  d1.insert<float>(Data::Value{}, "", {});
+  d1.insert<float>(Data::Value, "", {});
   Dataset d2;
-  d2.insert<double>(Data::Value{}, "", {});
+  d2.insert<double>(Data::Value, "", {});
   EXPECT_NO_THROW(d1 += d1);
   EXPECT_NO_THROW(d2 += d2);
   EXPECT_ANY_THROW(d1 += d2);
@@ -153,25 +151,25 @@ TEST(Dataset, mixed_type_operations_fails_currently) {
 
 TEST(Dataset, get_variable_view) {
   Dataset d;
-  d.insert(Data::Value{}, "", {});
-  d.insert(Data::Value{}, "name", {});
-  d.insert(Coord::X{}, {});
+  d.insert(Data::Value, "", {});
+  d.insert(Data::Value, "name", {});
+  d.insert(Coord::X, {});
 
-  EXPECT_EQ(d(Coord::X{}).tag(), Coord::X{});
-  EXPECT_EQ(d(Data::Value{}, "").tag(), Data::Value{});
-  EXPECT_EQ(d(Data::Value{}, "").name(), "");
-  EXPECT_EQ(d(Data::Value{}, "name").tag(), Data::Value{});
-  EXPECT_EQ(d(Data::Value{}, "name").name(), "name");
-  EXPECT_THROW_MSG(d(Coord::Y{}), dataset::except::VariableNotFoundError,
+  EXPECT_EQ(d(Coord::X).tag(), Coord::X);
+  EXPECT_EQ(d(Data::Value, "").tag(), Data::Value);
+  EXPECT_EQ(d(Data::Value, "").name(), "");
+  EXPECT_EQ(d(Data::Value, "name").tag(), Data::Value);
+  EXPECT_EQ(d(Data::Value, "name").name(), "name");
+  EXPECT_THROW_MSG(d(Coord::Y), dataset::except::VariableNotFoundError,
                    "Dataset with 3 variables, could not find variable with tag "
                    "Coord::Y and name ``.");
 }
 
 TEST(Dataset, extract) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Variance{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
+  d.insert(Data::Value, "name1", {}, {1.1});
+  d.insert(Data::Variance, "name1", {}, {1.1});
+  d.insert(Data::Int, "name2", {}, {2});
   EXPECT_EQ(d.size(), 3);
   auto name1 = d.extract("name1");
   EXPECT_EQ(d.size(), 1);
@@ -183,9 +181,9 @@ TEST(Dataset, extract) {
 
 TEST(Dataset, merge) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Variance{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "name2", Dimensions{}, {2});
+  d.insert(Data::Value, "name1", {}, {1.1});
+  d.insert(Data::Variance, "name1", {}, {1.1});
+  d.insert(Data::Int, "name2", {}, {2});
 
   Dataset merged;
   merged.merge(d);
@@ -194,19 +192,19 @@ TEST(Dataset, merge) {
                    "Attempt to insert data of same type with duplicate name.");
 
   Dataset d2;
-  d2.insert(Data::Value{}, "name3", Dimensions{}, {1.1});
+  d2.insert(Data::Value, "name3", {}, {1.1});
   merged.merge(d2);
   EXPECT_EQ(merged.size(), 4);
 }
 
 TEST(Dataset, merge_matching_coordinates) {
   Dataset d1;
-  d1.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
-  d1.insert(Data::Value{}, "data1", {Dim::X, 2});
+  d1.insert(Coord::X, {Dim::X, 2}, {1.1, 2.2});
+  d1.insert(Data::Value, "data1", {Dim::X, 2});
 
   Dataset d2;
-  d2.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
-  d2.insert(Data::Value{}, "data2", {Dim::X, 2});
+  d2.insert(Coord::X, {Dim::X, 2}, {1.1, 2.2});
+  d2.insert(Data::Value, "data2", {Dim::X, 2});
 
   ASSERT_NO_THROW(d1.merge(d2));
   EXPECT_EQ(d1.size(), 3);
@@ -214,12 +212,12 @@ TEST(Dataset, merge_matching_coordinates) {
 
 TEST(Dataset, merge_coord_mismatch_fail) {
   Dataset d1;
-  d1.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.2});
-  d1.insert(Data::Value{}, "data1", {Dim::X, 2});
+  d1.insert(Coord::X, {Dim::X, 2}, {1.1, 2.2});
+  d1.insert(Data::Value, "data1", {Dim::X, 2});
 
   Dataset d2;
-  d2.insert(Coord::X{}, {Dim::X, 2}, {1.1, 2.3});
-  d2.insert(Data::Value{}, "data2", {Dim::X, 2});
+  d2.insert(Coord::X, {Dim::X, 2}, {1.1, 2.3});
+  d2.insert(Data::Value, "data2", {Dim::X, 2});
 
   EXPECT_THROW_MSG(d1.merge(d2), std::runtime_error,
                    "Cannot merge: Coordinates do not match.");
@@ -227,12 +225,12 @@ TEST(Dataset, merge_coord_mismatch_fail) {
 
 TEST(Dataset, const_get) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "", Dimensions{}, {2});
+  d.insert(Data::Value, "", {}, {1.1});
+  d.insert(Data::Int, "", {}, {2});
   const auto &const_d(d);
-  auto view = const_d.get(Data::Value{});
+  auto view = const_d.get(Data::Value);
   // No non-const access to variable if Dataset is const, will not compile:
-  // auto &view = const_d.get(Data::Value{});
+  // auto &view = const_d.get(Data::Value);
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is deduced to be const, so assignment will not compile:
@@ -241,9 +239,9 @@ TEST(Dataset, const_get) {
 
 TEST(Dataset, get) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "", Dimensions{}, {2});
-  auto view = d.get(Data::Value{});
+  d.insert(Data::Value, "", {}, {1.1});
+  d.insert(Data::Int, "", {}, {2});
+  auto view = d.get(Data::Value);
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   view[0] = 2.2;
@@ -252,9 +250,9 @@ TEST(Dataset, get) {
 
 TEST(Dataset, get_const) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "", Dimensions{}, {2});
-  auto view = d.get(Data::Value{});
+  d.insert(Data::Value, "", {}, {1.1});
+  d.insert(Data::Int, "", {}, {2});
+  auto view = d.get(Data::Value);
   ASSERT_EQ(view.size(), 1);
   EXPECT_EQ(view[0], 1.1);
   // auto is now deduced to be const, so assignment will not compile:
@@ -263,86 +261,84 @@ TEST(Dataset, get_const) {
 
 TEST(Dataset, get_fail) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Value{}, "name2", Dimensions{}, {1.1});
-  EXPECT_THROW_MSG(d.get(Data::Value{}), std::runtime_error,
+  d.insert(Data::Value, "name1", {}, {1.1});
+  d.insert(Data::Value, "name2", {}, {1.1});
+  EXPECT_THROW_MSG(d.get(Data::Value), std::runtime_error,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Value and name ``.");
-  EXPECT_THROW_MSG(d.get(Data::Int{}), dataset::except::VariableNotFoundError,
+  EXPECT_THROW_MSG(d.get(Data::Int), dataset::except::VariableNotFoundError,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Int and name ``.");
 }
 
 TEST(Dataset, get_named) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  d.insert(Data::Value{}, "name2", Dimensions{}, {2.2});
-  auto var1 = d.get(Data::Value{}, "name1");
+  d.insert(Data::Value, "name1", {}, {1.1});
+  d.insert(Data::Value, "name2", {}, {2.2});
+  auto var1 = d.get(Data::Value, "name1");
   ASSERT_EQ(var1.size(), 1);
   EXPECT_EQ(var1[0], 1.1);
-  auto var2 = d.get(Data::Value{}, "name2");
+  auto var2 = d.get(Data::Value, "name2");
   ASSERT_EQ(var2.size(), 1);
   EXPECT_EQ(var2[0], 2.2);
 }
 
 TEST(Dataset, operator_plus_equal) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   a += a;
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 4.4);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 4.4);
 }
 
 TEST(Dataset, operator_plus_equal_broadcast) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "",
-           Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "", Dimensions({{Dim::Z, 3}}), {0.1, 0.2, 0.3});
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "", Dimensions({{Dim::Z, 3}}), {0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 2.1);
-  EXPECT_EQ(a.get(Data::Value{})[2], 3.2);
-  EXPECT_EQ(a.get(Data::Value{})[3], 4.2);
-  EXPECT_EQ(a.get(Data::Value{})[4], 5.3);
-  EXPECT_EQ(a.get(Data::Value{})[5], 6.3);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 2.1);
+  EXPECT_EQ(a.get(Data::Value)[2], 3.2);
+  EXPECT_EQ(a.get(Data::Value)[3], 4.2);
+  EXPECT_EQ(a.get(Data::Value)[4], 5.3);
+  EXPECT_EQ(a.get(Data::Value)[5], 6.3);
 }
 
 TEST(Dataset, operator_plus_equal_transpose) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "",
-           Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}),
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "", Dimensions({{Dim::Y, 2}, {Dim::Z, 3}}),
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "", Dimensions({{Dim::Y, 2}, {Dim::Z, 3}}),
            {0.1, 0.2, 0.3, 0.1, 0.2, 0.3});
 
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 2.1);
-  EXPECT_EQ(a.get(Data::Value{})[2], 3.2);
-  EXPECT_EQ(a.get(Data::Value{})[3], 4.2);
-  EXPECT_EQ(a.get(Data::Value{})[4], 5.3);
-  EXPECT_EQ(a.get(Data::Value{})[5], 6.3);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 2.1);
+  EXPECT_EQ(a.get(Data::Value)[2], 3.2);
+  EXPECT_EQ(a.get(Data::Value)[3], 4.2);
+  EXPECT_EQ(a.get(Data::Value)[4], 5.3);
+  EXPECT_EQ(a.get(Data::Value)[5], 6.3);
 }
 
 TEST(Dataset, operator_plus_equal_different_content) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "name1", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "name1", {Dim::X, 1}, {2.2});
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {2.2});
-  b.insert(Data::Value{}, "name2", {Dim::X, 1}, {3.3});
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "name1", {Dim::X, 1}, {2.2});
+  b.insert(Data::Value, "name2", {Dim::X, 1}, {3.3});
   EXPECT_THROW_MSG(a += b, std::runtime_error,
                    "Right-hand-side in binary operation contains variable that "
                    "is not present in left-hand-side.");
@@ -351,67 +347,67 @@ TEST(Dataset, operator_plus_equal_different_content) {
 
 TEST(Dataset, operator_plus_equal_with_attributes) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   Dataset logs;
-  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
-  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
+  logs.insert(Data::String, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog, "", {}, {logs});
   a += a;
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 4.4);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 4.4);
   // For now there is no special merging behavior, just keep attributes of first
   // operand.
-  EXPECT_EQ(a.get(Attr::ExperimentLog{})[0], logs);
+  EXPECT_EQ(a.get(Attr::ExperimentLog)[0], logs);
 }
 
 TEST(Dataset, operator_times_equal) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {3.0});
   a *= a;
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 9.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 9.0);
 }
 
 TEST(Dataset, operator_times_equal_with_attributes) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {3.0});
   Dataset logs;
-  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
-  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
+  logs.insert(Data::String, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog, "", {}, {logs});
   a *= a;
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 9.0);
-  EXPECT_EQ(a.get(Attr::ExperimentLog{})[0], logs);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 9.0);
+  EXPECT_EQ(a.get(Attr::ExperimentLog)[0], logs);
 }
 
 TEST(Dataset, operator_times_equal_with_uncertainty) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {3.0});
-  a.insert(Data::Variance{}, "", {Dim::X, 1}, {2.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {3.0});
+  a.insert(Data::Variance, "", {Dim::X, 1}, {2.0});
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "", {Dim::X, 1}, {4.0});
-  b.insert(Data::Variance{}, "", {Dim::X, 1}, {3.0});
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "", {Dim::X, 1}, {4.0});
+  b.insert(Data::Variance, "", {Dim::X, 1}, {3.0});
   a *= b;
-  EXPECT_EQ(a.get(Coord::X{})[0], 0.1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 12.0);
-  EXPECT_EQ(a.get(Data::Variance{})[0], 2.0 * 16.0 + 3.0 * 9.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 0.1);
+  EXPECT_EQ(a.get(Data::Value)[0], 12.0);
+  EXPECT_EQ(a.get(Data::Variance)[0], 2.0 * 16.0 + 3.0 * 9.0);
 }
 
 TEST(Dataset, operator_times_equal_uncertainty_failures) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "name1", {Dim::X, 1}, {3.0});
-  a.insert(Data::Variance{}, "name1", {Dim::X, 1}, {2.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "name1", {Dim::X, 1}, {3.0});
+  a.insert(Data::Variance, "name1", {Dim::X, 1}, {2.0});
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {4.0});
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "name1", {Dim::X, 1}, {4.0});
   Dataset c;
-  c.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  c.insert(Data::Variance{}, "name1", {Dim::X, 1}, {2.0});
+  c.insert(Coord::X, {Dim::X, 1}, {0.1});
+  c.insert(Data::Variance, "name1", {Dim::X, 1}, {2.0});
   EXPECT_THROW_MSG(a *= b, std::runtime_error,
                    "Either both or none of the operands must have a variance "
                    "for their values.");
@@ -437,35 +433,35 @@ TEST(Dataset, operator_times_equal_uncertainty_failures) {
 
 TEST(Dataset, operator_times_equal_with_units) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  Variable values(Data::Value{}, Dimensions({{Dim::X, 1}}), {3.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  Variable values(Data::Value, Dimensions({{Dim::X, 1}}), {3.0});
   values.setUnit(Unit::Id::Length);
-  Variable variances(Data::Variance{}, Dimensions({{Dim::X, 1}}), {2.0});
+  Variable variances(Data::Variance, Dimensions({{Dim::X, 1}}), {2.0});
   variances.setUnit(Unit::Id::Area);
   a.insert(values);
   a.insert(variances);
   a *= a;
-  EXPECT_EQ(a(Data::Value{}).unit(), Unit::Id::Area);
-  EXPECT_EQ(a(Data::Variance{}).unit(), Unit::Id::AreaVariance);
-  EXPECT_EQ(a.get(Data::Variance{})[0], 36.0);
+  EXPECT_EQ(a(Data::Value).unit(), Unit::Id::Area);
+  EXPECT_EQ(a(Data::Variance).unit(), Unit::Id::AreaVariance);
+  EXPECT_EQ(a.get(Data::Variance)[0], 36.0);
 }
 
 TEST(Dataset, operator_times_equal_histogram_data) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  Variable values(Data::Value{}, Dimensions({{Dim::X, 1}}), {3.0});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  Variable values(Data::Value, Dimensions({{Dim::X, 1}}), {3.0});
   values.setName("name1");
   values.setUnit(Unit::Id::Counts);
-  Variable variances(Data::Variance{}, Dimensions({{Dim::X, 1}}), {2.0});
+  Variable variances(Data::Variance, Dimensions({{Dim::X, 1}}), {2.0});
   variances.setName("name1");
   variances.setUnit(Unit::Id::CountsVariance);
   a.insert(values);
   a.insert(variances);
 
   Dataset b;
-  b.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  b.insert(Data::Value{}, "name1", {Dim::X, 1}, {4.0});
-  b.insert(Data::Variance{}, "name1", {Dim::X, 1}, {4.0});
+  b.insert(Coord::X, {Dim::X, 1}, {0.1});
+  b.insert(Data::Value, "name1", {Dim::X, 1}, {4.0});
+  b.insert(Data::Variance, "name1", {Dim::X, 1}, {4.0});
 
   // Counts (aka "histogram data") times counts not possible.
   EXPECT_THROW_MSG(a *= a, std::runtime_error, "Unsupported unit on LHS");
@@ -479,49 +475,49 @@ TEST(Dataset, operator_times_equal_histogram_data) {
 
 TEST(Dataset, operator_plus_with_temporary_avoids_copy) {
   Dataset a;
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  a.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   const auto a2(a);
   const auto b(a);
 
-  const auto *addr = &a.get(Data::Value{})[0];
+  const auto *addr = &a.get(Data::Value)[0];
   auto sum = std::move(a) + b;
-  EXPECT_EQ(&sum.get(Data::Value{})[0], addr);
+  EXPECT_EQ(&sum.get(Data::Value)[0], addr);
 
-  const auto *addr2 = &a2.get(Data::Value{})[0];
+  const auto *addr2 = &a2.get(Data::Value)[0];
   auto sum2 = a2 + b;
-  EXPECT_NE(&sum2.get(Data::Value{})[0], addr2);
+  EXPECT_NE(&sum2.get(Data::Value)[0], addr2);
 }
 
 TEST(Dataset, slice) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2}, {0.0, 0.1});
-  d.insert(Data::Value{}, "", {{Dim::Y, 3}, {Dim::X, 2}},
+  d.insert(Coord::X, {Dim::X, 2}, {0.0, 0.1});
+  d.insert(Data::Value, "", {{Dim::Y, 3}, {Dim::X, 2}},
            {0.0, 1.0, 2.0, 3.0, 4.0, 5.0});
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i);
     ASSERT_EQ(sliceX.size(), 1);
-    ASSERT_EQ(sliceX.get(Data::Value{}).size(), 3);
-    EXPECT_EQ(sliceX.get(Data::Value{})[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get(Data::Value{})[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get(Data::Value{})[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get(Data::Value).size(), 3);
+    EXPECT_EQ(sliceX.get(Data::Value)[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value)[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value)[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1}) {
     Dataset sliceX = d(Dim::X, i, i + 1);
     ASSERT_EQ(sliceX.size(), 2);
-    ASSERT_EQ(sliceX.get(Coord::X{}).size(), 1);
-    EXPECT_EQ(sliceX.get(Coord::X{})[0], 0.1 * i);
-    ASSERT_EQ(sliceX.get(Data::Value{}).size(), 3);
-    EXPECT_EQ(sliceX.get(Data::Value{})[0], 0.0 + i);
-    EXPECT_EQ(sliceX.get(Data::Value{})[1], 2.0 + i);
-    EXPECT_EQ(sliceX.get(Data::Value{})[2], 4.0 + i);
+    ASSERT_EQ(sliceX.get(Coord::X).size(), 1);
+    EXPECT_EQ(sliceX.get(Coord::X)[0], 0.1 * i);
+    ASSERT_EQ(sliceX.get(Data::Value).size(), 3);
+    EXPECT_EQ(sliceX.get(Data::Value)[0], 0.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value)[1], 2.0 + i);
+    EXPECT_EQ(sliceX.get(Data::Value)[2], 4.0 + i);
   }
   for (const gsl::index i : {0, 1, 2}) {
     Dataset sliceY = d(Dim::Y, i);
     ASSERT_EQ(sliceY.size(), 2);
-    ASSERT_EQ(sliceY.get(Coord::X{}), d.get(Coord::X{}));
-    ASSERT_EQ(sliceY.get(Data::Value{}).size(), 2);
-    EXPECT_EQ(sliceY.get(Data::Value{})[0], 0.0 + 2 * i);
-    EXPECT_EQ(sliceY.get(Data::Value{})[1], 1.0 + 2 * i);
+    ASSERT_EQ(sliceY.get(Coord::X), d.get(Coord::X));
+    ASSERT_EQ(sliceY.get(Data::Value).size(), 2);
+    EXPECT_EQ(sliceY.get(Data::Value)[0], 0.0 + 2 * i);
+    EXPECT_EQ(sliceY.get(Data::Value)[1], 1.0 + 2 * i);
   }
   EXPECT_THROW_MSG(
       d(Dim::Z, 0), std::runtime_error,
@@ -533,8 +529,8 @@ TEST(Dataset, slice) {
 
 TEST(Dataset, concatenate_constant_dimension_broken) {
   Dataset a;
-  a.insert(Data::Value{}, "name1", Dimensions{}, {1.1});
-  a.insert(Data::Value{}, "name2", Dimensions{}, {2.2});
+  a.insert(Data::Value, "name1", {}, {1.1});
+  a.insert(Data::Value, "name2", {}, {2.2});
   auto d = concatenate(a, a, Dim::X);
   // TODO Special case: No variable depends on X so the result does not contain
   // this dimension either. Change this behavior?!
@@ -543,43 +539,43 @@ TEST(Dataset, concatenate_constant_dimension_broken) {
 
 TEST(Dataset, concatenate) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(x.get(Data::Value{}).size(), 2);
+  EXPECT_EQ(x.get(Coord::X).size(), 2);
+  EXPECT_EQ(x.get(Data::Value).size(), 2);
   auto x2(x);
-  x2.get(Data::Value{})[0] = 100.0;
+  x2.get(Data::Value)[0] = 100.0;
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(xy.get(Data::Value{}).size(), 4);
+  EXPECT_EQ(xy.get(Coord::X).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value).size(), 4);
 
   xy = concatenate(xy, x, Dim::Y);
-  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(xy.get(Data::Value{}).size(), 6);
+  EXPECT_EQ(xy.get(Coord::X).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value).size(), 6);
 
   xy = concatenate(xy, xy, Dim::Y);
-  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(xy.get(Data::Value{}).size(), 12);
+  EXPECT_EQ(xy.get(Coord::X).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value).size(), 12);
 }
 
 TEST(Dataset, concatenate_with_bin_edges) {
   Dataset ds;
-  ds.insert(Coord::X{}, {Dim::X, 2}, {0.1, 0.2});
-  ds.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  ds.insert(Coord::X, {Dim::X, 2}, {0.1, 0.2});
+  ds.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   EXPECT_NO_THROW(concatenate(ds, ds, Dim::Y));
 
   Dataset not_edge;
-  not_edge.insert(Coord::X{}, {Dim::X, 1}, {0.3});
-  not_edge.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  not_edge.insert(Coord::X, {Dim::X, 1}, {0.3});
+  not_edge.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   EXPECT_THROW_MSG(
       concatenate(ds, not_edge, Dim::X), std::runtime_error,
       "Cannot concatenate: Second variable is not an edge variable.");
-  not_edge.erase(Coord::X{});
-  not_edge.insert(Coord::X{}, {}, {0.3});
+  not_edge.erase(Coord::X);
+  not_edge.insert(Coord::X, {}, {0.3});
   EXPECT_THROW_MSG(concatenate(ds, not_edge, Dim::X),
                    dataset::except::DimensionNotFoundError,
                    "Expected dimension to be in {}, got Dim::X.");
@@ -589,25 +585,25 @@ TEST(Dataset, concatenate_with_bin_edges) {
                    "does not match first bin edge of second edge variable.");
 
   Dataset ds2;
-  ds2.insert(Coord::X{}, {Dim::X, 2}, {0.2, 0.3});
-  ds2.insert(Data::Value{}, "", {Dim::X, 1}, {3.3});
+  ds2.insert(Coord::X, {Dim::X, 2}, {0.2, 0.3});
+  ds2.insert(Data::Value, "", {Dim::X, 1}, {3.3});
 
   Dataset merged;
   EXPECT_NO_THROW(merged = concatenate(ds, ds2, Dim::X));
   EXPECT_EQ(merged.dimensions().count(), 1);
   EXPECT_TRUE(merged.dimensions().contains(Dim::X));
-  EXPECT_TRUE(equals(merged.get(Coord::X{}), {0.1, 0.2, 0.3}));
-  EXPECT_TRUE(equals(merged.get(Data::Value{}), {2.2, 3.3}));
+  EXPECT_TRUE(equals(merged.get(Coord::X), {0.1, 0.2, 0.3}));
+  EXPECT_TRUE(equals(merged.get(Data::Value), {2.2, 3.3}));
 }
 
 TEST(Dataset, concatenate_with_varying_bin_edges) {
   Dataset ds;
-  ds.insert(Coord::X{}, {{Dim::Y, 2}, {Dim::X, 2}}, {0.1, 0.2, 0.11, 0.21});
-  ds.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 1}}, {2.2, 3.3});
+  ds.insert(Coord::X, {{Dim::Y, 2}, {Dim::X, 2}}, {0.1, 0.2, 0.11, 0.21});
+  ds.insert(Data::Value, "", {{Dim::Y, 2}, {Dim::X, 1}}, {2.2, 3.3});
 
   Dataset ds2;
-  ds2.insert(Coord::X{}, {{Dim::Y, 2}, {Dim::X, 2}}, {0.2, 0.3, 0.21, 0.31});
-  ds2.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 1}}, {4.4, 5.5});
+  ds2.insert(Coord::X, {{Dim::Y, 2}, {Dim::X, 2}}, {0.2, 0.3, 0.21, 0.31});
+  ds2.insert(Data::Value, "", {{Dim::Y, 2}, {Dim::X, 1}}, {4.4, 5.5});
 
   Dataset merged;
   merged = concatenate(ds, ds2, Dim::X);
@@ -617,44 +613,42 @@ TEST(Dataset, concatenate_with_varying_bin_edges) {
   ASSERT_TRUE(merged.dimensions().contains(Dim::Y));
   EXPECT_EQ(merged.dimensions()[Dim::X], 2);
   EXPECT_EQ(merged.dimensions()[Dim::Y], 2);
-  EXPECT_TRUE(
-      equals(merged.get(Coord::X{}), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
-  EXPECT_TRUE(equals(merged.get(Data::Value{}), {2.2, 4.4, 3.3, 5.5}));
+  EXPECT_TRUE(equals(merged.get(Coord::X), {0.1, 0.2, 0.3, 0.11, 0.21, 0.31}));
+  EXPECT_TRUE(equals(merged.get(Data::Value), {2.2, 4.4, 3.3, 5.5}));
 }
 
 TEST(Dataset, concatenate_with_attributes) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 1}, {0.1});
-  a.insert(Data::Value{}, "", {Dim::X, 1}, {2.2});
+  a.insert(Coord::X, {Dim::X, 1}, {0.1});
+  a.insert(Data::Value, "", {Dim::X, 1}, {2.2});
   Dataset logs;
-  logs.insert(Data::String{}, "comments", {}, {std::string("test")});
-  a.insert(Attr::ExperimentLog{}, "", {}, {logs});
+  logs.insert(Data::String, "comments", {}, {std::string("test")});
+  a.insert(Attr::ExperimentLog, "", {}, {logs});
 
   auto x = concatenate(a, a, Dim::X);
   EXPECT_TRUE(x.dimensions().contains(Dim::X));
-  EXPECT_EQ(x.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(x.get(Data::Value{}).size(), 2);
-  EXPECT_EQ(x.get(Attr::ExperimentLog{}).size(), 1);
-  EXPECT_EQ(x.get(Attr::ExperimentLog{})[0], logs);
+  EXPECT_EQ(x.get(Coord::X).size(), 2);
+  EXPECT_EQ(x.get(Data::Value).size(), 2);
+  EXPECT_EQ(x.get(Attr::ExperimentLog).size(), 1);
+  EXPECT_EQ(x.get(Attr::ExperimentLog)[0], logs);
 
   auto x2(x);
-  x2.get(Data::Value{})[0] = 100.0;
-  x2.get(Attr::ExperimentLog{})[0].get(Data::String{}, "comments")[0] =
-      "different";
+  x2.get(Data::Value)[0] = 100.0;
+  x2.get(Attr::ExperimentLog)[0].get(Data::String, "comments")[0] = "different";
   auto xy = concatenate(x, x2, Dim::Y);
   EXPECT_TRUE(xy.dimensions().contains(Dim::X));
   EXPECT_TRUE(xy.dimensions().contains(Dim::Y));
-  EXPECT_EQ(xy.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(xy.get(Data::Value{}).size(), 4);
+  EXPECT_EQ(xy.get(Coord::X).size(), 2);
+  EXPECT_EQ(xy.get(Data::Value).size(), 4);
   // Attributes get a dimension, no merging happens. This might be useful
   // behavior, e.g., when dealing with multiple runs in a single dataset?
-  EXPECT_EQ(xy.get(Attr::ExperimentLog{}).size(), 2);
-  EXPECT_EQ(xy.get(Attr::ExperimentLog{})[0], logs);
+  EXPECT_EQ(xy.get(Attr::ExperimentLog).size(), 2);
+  EXPECT_EQ(xy.get(Attr::ExperimentLog)[0], logs);
 
   EXPECT_NO_THROW(concatenate(xy, xy, Dim::X));
 
   auto xy2(xy);
-  xy2.get(Attr::ExperimentLog{})[0].get(Data::String{}, "comments")[0] = "";
+  xy2.get(Attr::ExperimentLog)[0].get(Data::String, "comments")[0] = "";
   // Concatenating in existing dimension fail currently. Would need to implement
   // merging functionality for attributes?
   EXPECT_ANY_THROW(concatenate(xy, xy2, Dim::X));
@@ -662,50 +656,50 @@ TEST(Dataset, concatenate_with_attributes) {
 
 TEST(Dataset, rebin_failures) {
   Dataset d;
-  Variable coord(Coord::X{}, {Dim::X, 3}, {1.0, 3.0, 5.0});
+  Variable coord(Coord::X, {Dim::X, 3}, {1.0, 3.0, 5.0});
   EXPECT_THROW_MSG(rebin(d, coord), dataset::except::VariableNotFoundError,
                    "Dataset with 0 variables, could not find variable with tag "
                    "Coord::X and name ``.");
-  Variable data(Data::Value{}, {Dim::X, 2}, {2.0, 4.0});
+  Variable data(Data::Value, {Dim::X, 2}, {2.0, 4.0});
   EXPECT_THROW_MSG(
       rebin(d, data), std::runtime_error,
       "The provided rebin coordinate is not a coordinate variable.");
-  Variable nonDimCoord(Coord::Position{}, {Dim::Detector, 2});
+  Variable nonDimCoord(Coord::Position, {Dim::Detector, 2});
   EXPECT_THROW_MSG(
       rebin(d, nonDimCoord), std::runtime_error,
       "The provided rebin coordinate is not a dimension coordinate.");
-  Variable missingDimCoord(Coord::X{}, {Dim::Y, 2}, {2.0, 4.0});
+  Variable missingDimCoord(Coord::X, {Dim::Y, 2}, {2.0, 4.0});
   EXPECT_THROW_MSG(rebin(d, missingDimCoord), std::runtime_error,
                    "The provided rebin coordinate lacks the dimension "
                    "corresponding to the coordinate.");
-  Variable nonContinuousCoord(Coord::SpectrumNumber{}, {Dim::Spectrum, 2},
+  Variable nonContinuousCoord(Coord::SpectrumNumber, {Dim::Spectrum, 2},
                               {2.0, 4.0});
   EXPECT_THROW_MSG(
       rebin(d, nonContinuousCoord), std::runtime_error,
       "The provided rebin coordinate is not a continuous coordinate.");
-  Variable oldMissingDimCoord(Coord::X{}, {Dim::Y, 3}, {1.0, 3.0, 5.0});
+  Variable oldMissingDimCoord(Coord::X, {Dim::Y, 3}, {1.0, 3.0, 5.0});
   d.insert(oldMissingDimCoord);
   EXPECT_THROW_MSG(rebin(d, coord), std::runtime_error,
                    "Existing coordinate to be rebined lacks the dimension "
                    "corresponding to the new coordinate.");
-  d.erase(Coord::X{});
+  d.erase(Coord::X);
   d.insert(coord);
   EXPECT_THROW_MSG(rebin(d, coord), std::runtime_error,
                    "Existing coordinate to be rebinned is not a bin edge "
                    "coordinate. Use `resample` instead of rebin or convert to "
                    "histogram data first.");
-  d.erase(Coord::X{});
+  d.erase(Coord::X);
   d.insert(coord);
-  d.insert(Data::Value{}, "badAuxDim", Dimensions({{Dim::X, 2}, {Dim::Y, 2}}));
-  Variable badAuxDim(Coord::X{}, Dimensions({{Dim::X, 3}, {Dim::Y, 3}}));
+  d.insert(Data::Value, "badAuxDim", Dimensions({{Dim::X, 2}, {Dim::Y, 2}}));
+  Variable badAuxDim(Coord::X, Dimensions({{Dim::X, 3}, {Dim::Y, 3}}));
   EXPECT_THROW_MSG(rebin(d, badAuxDim), std::runtime_error,
                    "Size mismatch in auxiliary dimension of new coordinate.");
 }
 
 TEST(Dataset, rebin) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 3.0, 5.0});
-  Variable coordNew(Coord::X{}, {Dim::X, 2}, {1.0, 5.0});
+  d.insert(Coord::X, {Dim::X, 3}, {1.0, 3.0, 5.0});
+  Variable coordNew(Coord::X, {Dim::X, 2}, {1.0, 5.0});
   // With only the coord in the dataset there is no way to tell it is an edge,
   // so this fails.
   EXPECT_THROW_MSG(rebin(d, coordNew), std::runtime_error,
@@ -713,19 +707,19 @@ TEST(Dataset, rebin) {
                    "coordinate. Use `resample` instead of rebin or convert to "
                    "histogram data first.");
 
-  d.insert(Data::Value{}, "", {Dim::X, 2}, {10.0, 20.0});
+  d.insert(Data::Value, "", {Dim::X, 2}, {10.0, 20.0});
   auto rebinned = rebin(d, coordNew);
-  EXPECT_EQ(rebinned.get(Data::Value{}).size(), 1);
-  EXPECT_EQ(rebinned.get(Data::Value{})[0], 30.0);
+  EXPECT_EQ(rebinned.get(Data::Value).size(), 1);
+  EXPECT_EQ(rebinned.get(Data::Value)[0], 30.0);
 }
 
 Dataset makeEvents() {
   Dataset e1;
-  e1.insert(Data::Tof{}, "", {Dim::Event, 5}, {1, 2, 3, 4, 5});
+  e1.insert(Data::Tof, "", {Dim::Event, 5}, {1, 2, 3, 4, 5});
   Dataset e2;
-  e2.insert(Data::Tof{}, "", {Dim::Event, 7}, {1, 2, 3, 4, 4, 5, 7});
+  e2.insert(Data::Tof, "", {Dim::Event, 7}, {1, 2, 3, 4, 4, 5, 7});
   Dataset d;
-  d.insert(Data::Events{}, "sample1", {Dim::Spectrum, 2}, {e1, e2});
+  d.insert(Data::Events, "sample1", {Dim::Spectrum, 2}, {e1, e2});
   return d;
 }
 
@@ -733,173 +727,173 @@ TEST(Dataset, histogram_failures) {
   auto d = makeEvents();
 
   Dataset dependsOnBinDim;
-  dependsOnBinDim.insert(d(Data::Events{}, "sample1").reshape({Dim::Tof, 2}));
-  Variable coord(Coord::Tof{}, {Dim::Tof, 3}, {1.0, 1.5, 4.5});
+  dependsOnBinDim.insert(d(Data::Events, "sample1").reshape({Dim::Tof, 2}));
+  Variable coord(Coord::Tof, {Dim::Tof, 3}, {1.0, 1.5, 4.5});
   EXPECT_THROW_MSG(histogram(dependsOnBinDim, coord), std::runtime_error,
                    "Data to histogram depends on histogram dimension.");
 
-  Variable coordWithExtraDim(Coord::Tof{}, {{Dim::X, 2}, {Dim::Tof, 3}},
+  Variable coordWithExtraDim(Coord::Tof, {{Dim::X, 2}, {Dim::Tof, 3}},
                              {1.0, 1.5, 4.5, 1.5, 4.5, 7.5});
   EXPECT_THROW(histogram(d, coordWithExtraDim),
                dataset::except::DimensionNotFoundError);
 
-  Variable coordWithLengthMismatch(Coord::Tof{},
+  Variable coordWithLengthMismatch(Coord::Tof,
                                    {{Dim::Spectrum, 3}, {Dim::Tof, 3}});
   EXPECT_THROW(histogram(d, coordWithLengthMismatch),
                dataset::except::DimensionLengthError);
 
-  Variable coordNotIncreasing(Coord::Tof{}, {Dim::Tof, 3}, {1.0, 1.5, 1.4});
+  Variable coordNotIncreasing(Coord::Tof, {Dim::Tof, 3}, {1.0, 1.5, 1.4});
   EXPECT_THROW_MSG(histogram(d, coordNotIncreasing), std::runtime_error,
                    "Coordinate used for binning is not increasing.");
 }
 
 TEST(Dataset, histogram) {
   auto d = makeEvents();
-  Variable coord(Coord::Tof{}, {Dim::Tof, 3}, {1.0, 1.5, 4.5});
+  Variable coord(Coord::Tof, {Dim::Tof, 3}, {1.0, 1.5, 4.5});
   auto hist = histogram(d, coord);
 
-  ASSERT_TRUE(hist.contains(Coord::Tof{}));
-  EXPECT_EQ(hist(Coord::Tof{}), coord);
-  ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
-  ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 1, 4}));
-  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 1, 4}));
+  ASSERT_TRUE(hist.contains(Coord::Tof));
+  EXPECT_EQ(hist(Coord::Tof), coord);
+  ASSERT_TRUE(hist.contains(Data::Value, "sample1"));
+  ASSERT_TRUE(hist.contains(Data::Variance, "sample1"));
+  EXPECT_TRUE(equals(hist.get(Data::Value, "sample1"), {1, 3, 1, 4}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance, "sample1"), {1, 3, 1, 4}));
 }
 
 TEST(Dataset, histogram_2D_coord) {
   auto d = makeEvents();
-  Variable coord(Coord::Tof{}, {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
+  Variable coord(Coord::Tof, {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
                  {1.0, 1.5, 4.5, 1.5, 4.5, 7.5});
   auto hist = histogram(d, coord);
 
-  ASSERT_TRUE(hist.contains(Coord::Tof{}));
-  EXPECT_EQ(hist(Coord::Tof{}), coord);
-  ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
-  ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
-  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 4, 2}));
+  ASSERT_TRUE(hist.contains(Coord::Tof));
+  EXPECT_EQ(hist(Coord::Tof), coord);
+  ASSERT_TRUE(hist.contains(Data::Value, "sample1"));
+  ASSERT_TRUE(hist.contains(Data::Variance, "sample1"));
+  EXPECT_TRUE(equals(hist.get(Data::Value, "sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance, "sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, histogram_2D_transpose_coord) {
   auto d = makeEvents();
-  Variable coord(Coord::Tof{}, {{Dim::Tof, 3}, {Dim::Spectrum, 2}},
+  Variable coord(Coord::Tof, {{Dim::Tof, 3}, {Dim::Spectrum, 2}},
                  {1.0, 1.5, 1.5, 4.5, 4.5, 7.5});
   auto hist = histogram(d, coord);
 
-  ASSERT_TRUE(hist.contains(Coord::Tof{}));
-  EXPECT_EQ(hist(Coord::Tof{}), coord);
-  ASSERT_TRUE(hist.contains(Data::Value{}, "sample1"));
-  ASSERT_TRUE(hist.contains(Data::Variance{}, "sample1"));
+  ASSERT_TRUE(hist.contains(Coord::Tof));
+  EXPECT_EQ(hist(Coord::Tof), coord);
+  ASSERT_TRUE(hist.contains(Data::Value, "sample1"));
+  ASSERT_TRUE(hist.contains(Data::Variance, "sample1"));
   // Dimensionality of output is determined by that of the input events, the bin
   // dimension will almost be the innermost one.
-  ASSERT_EQ(hist(Data::Value{}, "sample1").dimensions(),
+  ASSERT_EQ(hist(Data::Value, "sample1").dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Tof, 2}}));
-  EXPECT_TRUE(equals(hist.get(Data::Value{}, "sample1"), {1, 3, 4, 2}));
-  EXPECT_TRUE(equals(hist.get(Data::Variance{}, "sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Value, "sample1"), {1, 3, 4, 2}));
+  EXPECT_TRUE(equals(hist.get(Data::Variance, "sample1"), {1, 3, 4, 2}));
 }
 
 TEST(Dataset, sort) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
-  d.insert(Data::Value{}, "", {Dim::X, 4}, {1.0, 2.0, 3.0, 4.0});
+  d.insert(Coord::X, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value, "", {Dim::X, 4}, {1.0, 2.0, 3.0, 4.0});
 
-  auto sorted = sort(d, Coord::X{});
+  auto sorted = sort(d, Coord::X);
 
-  ASSERT_EQ(sorted.get(Coord::X{}).size(), 4);
-  EXPECT_EQ(sorted.get(Coord::X{})[0], 0.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[1], 1.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[2], 3.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[3], 5.0);
+  ASSERT_EQ(sorted.get(Coord::X).size(), 4);
+  EXPECT_EQ(sorted.get(Coord::X)[0], 0.0);
+  EXPECT_EQ(sorted.get(Coord::X)[1], 1.0);
+  EXPECT_EQ(sorted.get(Coord::X)[2], 3.0);
+  EXPECT_EQ(sorted.get(Coord::X)[3], 5.0);
 
-  ASSERT_EQ(sorted.get(Coord::Y{}).size(), 2);
-  EXPECT_EQ(sorted.get(Coord::Y{})[0], 1.0);
-  EXPECT_EQ(sorted.get(Coord::Y{})[1], 0.9);
+  ASSERT_EQ(sorted.get(Coord::Y).size(), 2);
+  EXPECT_EQ(sorted.get(Coord::Y)[0], 1.0);
+  EXPECT_EQ(sorted.get(Coord::Y)[1], 0.9);
 
-  ASSERT_EQ(sorted.get(Data::Value{}).size(), 4);
-  EXPECT_EQ(sorted.get(Data::Value{})[0], 4.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[1], 2.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[2], 3.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[3], 1.0);
+  ASSERT_EQ(sorted.get(Data::Value).size(), 4);
+  EXPECT_EQ(sorted.get(Data::Value)[0], 4.0);
+  EXPECT_EQ(sorted.get(Data::Value)[1], 2.0);
+  EXPECT_EQ(sorted.get(Data::Value)[2], 3.0);
+  EXPECT_EQ(sorted.get(Data::Value)[3], 1.0);
 }
 
 TEST(Dataset, sort_2D) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
-  d.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Coord::X, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value, "", {{Dim::Y, 2}, {Dim::X, 4}},
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
 
-  auto sorted = sort(d, Coord::X{});
+  auto sorted = sort(d, Coord::X);
 
-  ASSERT_EQ(sorted.get(Coord::X{}).size(), 4);
-  EXPECT_EQ(sorted.get(Coord::X{})[0], 0.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[1], 1.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[2], 3.0);
-  EXPECT_EQ(sorted.get(Coord::X{})[3], 5.0);
+  ASSERT_EQ(sorted.get(Coord::X).size(), 4);
+  EXPECT_EQ(sorted.get(Coord::X)[0], 0.0);
+  EXPECT_EQ(sorted.get(Coord::X)[1], 1.0);
+  EXPECT_EQ(sorted.get(Coord::X)[2], 3.0);
+  EXPECT_EQ(sorted.get(Coord::X)[3], 5.0);
 
-  ASSERT_EQ(sorted.get(Coord::Y{}).size(), 2);
-  EXPECT_EQ(sorted.get(Coord::Y{})[0], 1.0);
-  EXPECT_EQ(sorted.get(Coord::Y{})[1], 0.9);
+  ASSERT_EQ(sorted.get(Coord::Y).size(), 2);
+  EXPECT_EQ(sorted.get(Coord::Y)[0], 1.0);
+  EXPECT_EQ(sorted.get(Coord::Y)[1], 0.9);
 
-  ASSERT_EQ(sorted.get(Data::Value{}).size(), 8);
-  EXPECT_EQ(sorted.get(Data::Value{})[0], 4.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[1], 2.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[2], 3.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[3], 1.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[4], 8.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[5], 6.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[6], 7.0);
-  EXPECT_EQ(sorted.get(Data::Value{})[7], 5.0);
+  ASSERT_EQ(sorted.get(Data::Value).size(), 8);
+  EXPECT_EQ(sorted.get(Data::Value)[0], 4.0);
+  EXPECT_EQ(sorted.get(Data::Value)[1], 2.0);
+  EXPECT_EQ(sorted.get(Data::Value)[2], 3.0);
+  EXPECT_EQ(sorted.get(Data::Value)[3], 1.0);
+  EXPECT_EQ(sorted.get(Data::Value)[4], 8.0);
+  EXPECT_EQ(sorted.get(Data::Value)[5], 6.0);
+  EXPECT_EQ(sorted.get(Data::Value)[6], 7.0);
+  EXPECT_EQ(sorted.get(Data::Value)[7], 5.0);
 }
 
 TEST(Dataset, filter) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1.0, 0.9});
-  d.insert(Data::Value{}, "", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Coord::X, {Dim::X, 4}, {5.0, 1.0, 3.0, 0.0});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1.0, 0.9});
+  d.insert(Data::Value, "", {{Dim::Y, 2}, {Dim::X, 4}},
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
-  Variable select(Coord::Mask{}, {Dim::X, 4}, {false, true, false, true});
+  Variable select(Coord::Mask, {Dim::X, 4}, {false, true, false, true});
 
   auto filtered = filter(d, select);
 
-  ASSERT_EQ(filtered.get(Coord::X{}).size(), 2);
-  EXPECT_EQ(filtered.get(Coord::X{})[0], 1.0);
-  EXPECT_EQ(filtered.get(Coord::X{})[1], 0.0);
+  ASSERT_EQ(filtered.get(Coord::X).size(), 2);
+  EXPECT_EQ(filtered.get(Coord::X)[0], 1.0);
+  EXPECT_EQ(filtered.get(Coord::X)[1], 0.0);
 
-  ASSERT_EQ(filtered.get(Coord::Y{}).size(), 2);
-  EXPECT_EQ(filtered.get(Coord::Y{})[0], 1.0);
-  EXPECT_EQ(filtered.get(Coord::Y{})[1], 0.9);
+  ASSERT_EQ(filtered.get(Coord::Y).size(), 2);
+  EXPECT_EQ(filtered.get(Coord::Y)[0], 1.0);
+  EXPECT_EQ(filtered.get(Coord::Y)[1], 0.9);
 
-  ASSERT_EQ(filtered.get(Data::Value{}).size(), 4);
-  EXPECT_EQ(filtered.get(Data::Value{})[0], 2.0);
-  EXPECT_EQ(filtered.get(Data::Value{})[1], 4.0);
-  EXPECT_EQ(filtered.get(Data::Value{})[2], 6.0);
-  EXPECT_EQ(filtered.get(Data::Value{})[3], 8.0);
+  ASSERT_EQ(filtered.get(Data::Value).size(), 4);
+  EXPECT_EQ(filtered.get(Data::Value)[0], 2.0);
+  EXPECT_EQ(filtered.get(Data::Value)[1], 4.0);
+  EXPECT_EQ(filtered.get(Data::Value)[2], 6.0);
+  EXPECT_EQ(filtered.get(Data::Value)[3], 8.0);
 }
 
 TEST(Dataset, integrate) {
   Dataset ds;
-  ds.insert(Coord::X{}, {Dim::X, 3}, {0.1, 0.2, 0.4});
-  ds.insert(Data::Value{}, "", {Dim::X, 2}, {10.0, 20.0});
+  ds.insert(Coord::X, {Dim::X, 3}, {0.1, 0.2, 0.4});
+  ds.insert(Data::Value, "", {Dim::X, 2}, {10.0, 20.0});
 
   Dataset integral;
   EXPECT_NO_THROW(integral = integrate(ds, Dim::X));
   EXPECT_EQ(integral.dimensions().count(), 0);
-  EXPECT_FALSE(integral.contains(Coord::X{}));
+  EXPECT_FALSE(integral.contains(Coord::X));
   // Note: The current implementation assumes that Data::Value is counts,
   // handling of other data is not implemented yet.
-  EXPECT_TRUE(equals(integral.get(Data::Value{}), {30.0}));
+  EXPECT_TRUE(equals(integral.get(Data::Value), {30.0}));
 }
 
 TEST(DatasetSlice, basics) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4});
-  d.insert(Coord::Y{}, {Dim::Y, 2});
-  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}});
-  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Coord::X, {Dim::X, 4});
+  d.insert(Coord::Y, {Dim::Y, 2});
+  d.insert(Data::Value, "a", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Value, "b", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}});
+  d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}});
 
   ConstDatasetSlice viewA(d, "a");
   ConstDatasetSlice viewB(d, "b");
@@ -924,37 +918,37 @@ TEST(DatasetSlice, basics) {
 
 TEST(DatasetSlice, minus_equals) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4});
-  d.insert(Coord::Y{}, {Dim::Y, 2});
-  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
-  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Coord::X, {Dim::X, 4});
+  d.insert(Coord::Y, {Dim::Y, 2});
+  d.insert(Data::Value, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Value, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
+  d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
 
   EXPECT_NO_THROW(d -= d["a"]);
 
-  EXPECT_EQ(d.get(Data::Value{}, "a")[0], 0.0);
-  EXPECT_EQ(d.get(Data::Value{}, "b")[0], 1.0);
-  EXPECT_EQ(d.get(Data::Variance{}, "a")[0], 2.0);
-  EXPECT_EQ(d.get(Data::Variance{}, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Value, "a")[0], 0.0);
+  EXPECT_EQ(d.get(Data::Value, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Variance, "a")[0], 2.0);
+  EXPECT_EQ(d.get(Data::Variance, "b")[0], 1.0);
 
   ASSERT_NO_THROW(d["a"] -= d["b"]);
 
   ASSERT_EQ(d.size(), 6);
   // Note: Variable not renamed when operating with slices.
-  EXPECT_EQ(d.get(Data::Value{}, "a")[0], -1.0);
-  EXPECT_EQ(d.get(Data::Value{}, "b")[0], 1.0);
-  EXPECT_EQ(d.get(Data::Variance{}, "a")[0], 3.0);
-  EXPECT_EQ(d.get(Data::Variance{}, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Value, "a")[0], -1.0);
+  EXPECT_EQ(d.get(Data::Value, "b")[0], 1.0);
+  EXPECT_EQ(d.get(Data::Variance, "a")[0], 3.0);
+  EXPECT_EQ(d.get(Data::Variance, "b")[0], 1.0);
 }
 
 TEST(DatasetSlice, slice_spatial) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {1, 2, 3, 4});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Coord::X, {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_x13 = d(Dim::X, 1, 3);
@@ -967,15 +961,15 @@ TEST(DatasetSlice, slice_spatial) {
 
 TEST(DatasetSlice, subset_slice_spatial) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {1, 2, 3, 4});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Coord::X, {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Value, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_a_x0 = d["a"](Dim::X, 0);
@@ -996,12 +990,12 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {1, 2, 3, 4}));
-  EXPECT_TRUE(equals(d.get(Coord::Y{}), {1, 2}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {1, 2, 3, 4}));
+  EXPECT_TRUE(equals(d.get(Coord::Y), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1015,15 +1009,15 @@ TEST(DatasetSlice, subset_slice_spatial) {
 
 TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 5}, {1, 2, 3, 4, 5});
-  d.insert(Coord::Y{}, {Dim::Y, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Coord::X, {Dim::X, 5}, {1, 2, 3, 4, 5});
+  d.insert(Coord::Y, {Dim::Y, 2}, {1, 2});
+  d.insert(Data::Value, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Value{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Value, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Variance{}, "a", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
-  d.insert(Data::Variance{}, "b", {{Dim::Y, 2}, {Dim::X, 4}},
+  d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
 
   auto view_a_x0 = d["a"](Dim::X, 0);
@@ -1044,30 +1038,30 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
   EXPECT_NO_THROW(view_a_x1 -= view_a_x0);
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {1, 2, 3, 4, 5}));
-  EXPECT_TRUE(equals(d.get(Coord::Y{}), {1, 2}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {1, 2, 3, 4, 5}));
+  EXPECT_TRUE(equals(d.get(Coord::Y), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "a"), {1, 1, 3, 4, 5, 1, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "a"), {1, 3, 3, 4, 5, 11, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
   auto view_a_x01 = d["a"](Dim::X, 0, 1);
   auto view_a_x12 = d["a"](Dim::X, 1, 2);
-  ASSERT_EQ(view_a_x01[0].tag(), Coord::X{});
+  ASSERT_EQ(view_a_x01[0].tag(), Coord::X);
   // View extent is 1 so we get 2 edges.
   ASSERT_EQ(view_a_x01.dimensions()[Dim::X], 1);
   ASSERT_EQ(view_a_x01[0].dimensions()[Dim::X], 2);
-  EXPECT_TRUE(equals(view_a_x01[0].get(Coord::X{}), {1, 2}));
-  EXPECT_TRUE(equals(view_a_x12[0].get(Coord::X{}), {2, 3}));
+  EXPECT_TRUE(equals(view_a_x01[0].get(Coord::X), {1, 2}));
+  EXPECT_TRUE(equals(view_a_x12[0].get(Coord::X), {2, 3}));
 
   auto view_a_x02 = d["a"](Dim::X, 0, 2);
   auto view_a_x13 = d["a"](Dim::X, 1, 3);
-  ASSERT_EQ(view_a_x02[0].tag(), Coord::X{});
+  ASSERT_EQ(view_a_x02[0].tag(), Coord::X);
   // View extent is 2 so we get 3 edges.
   ASSERT_EQ(view_a_x02.dimensions()[Dim::X], 2);
   ASSERT_EQ(view_a_x02[0].dimensions()[Dim::X], 3);
-  EXPECT_TRUE(equals(view_a_x02[0].get(Coord::X{}), {1, 2, 3}));
-  EXPECT_TRUE(equals(view_a_x13[0].get(Coord::X{}), {2, 3, 4}));
+  EXPECT_TRUE(equals(view_a_x02[0].get(Coord::X), {1, 2, 3}));
+  EXPECT_TRUE(equals(view_a_x13[0].get(Coord::X), {2, 3, 4}));
 
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
@@ -1082,136 +1076,136 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
 
 TEST(Dataset, unary_minus) {
   Dataset a;
-  a.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
-  a.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
-  a.insert(Data::Value{}, "b", {}, {3});
-  a.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
-  a.insert(Data::Variance{}, "b", {}, {6});
+  a.insert(Coord::X, {Dim::X, 2}, {1, 2});
+  a.insert(Data::Value, "a", {Dim::X, 2}, {1, 2});
+  a.insert(Data::Value, "b", {}, {3});
+  a.insert(Data::Variance, "a", {Dim::X, 2}, {4, 5});
+  a.insert(Data::Variance, "b", {}, {6});
 
   auto b = -a;
-  EXPECT_EQ(b(Coord::X{}), a(Coord::X{}));
-  EXPECT_EQ(b(Data::Value{}, "a"), -a(Data::Value{}, "a"));
-  EXPECT_EQ(b(Data::Value{}, "b"), -a(Data::Value{}, "b"));
+  EXPECT_EQ(b(Coord::X), a(Coord::X));
+  EXPECT_EQ(b(Data::Value, "a"), -a(Data::Value, "a"));
+  EXPECT_EQ(b(Data::Value, "b"), -a(Data::Value, "b"));
   // Note variance not changing sign.
-  EXPECT_EQ(b(Data::Variance{}, "a"), a(Data::Variance{}, "a"));
-  EXPECT_EQ(b(Data::Variance{}, "b"), a(Data::Variance{}, "b"));
+  EXPECT_EQ(b(Data::Variance, "a"), a(Data::Variance, "a"));
+  EXPECT_EQ(b(Data::Variance, "b"), a(Data::Variance, "b"));
 }
 
 TEST(Dataset, binary_assign_with_scalar) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "d1", {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "d2", {}, {3});
-  d.insert(Data::Variance{}, "d1", {Dim::X, 2}, {4, 5});
-  d.insert(Data::Variance{}, "d2", {}, {6});
+  d.insert(Coord::X, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "d1", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "d2", {}, {3});
+  d.insert(Data::Variance, "d1", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance, "d2", {}, {6});
 
   d += 1;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {2, 3}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d1"), {2, 3}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d2"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d2"), {6}));
 
   d -= 2;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {0, 1}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d1"), {0, 1}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d2"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {4, 5}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d1"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d2"), {6}));
 
   d *= 2;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d1"), {0, 2}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "d2"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d1"), {0, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "d2"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d1"), {16, 20}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "d2"), {24}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d1"), {16, 20}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "d2"), {24}));
 }
 
 TEST(DatasetSlice, binary_assign_with_scalar) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "b", {}, {3});
-  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
-  d.insert(Data::Variance{}, "b", {}, {6});
+  d.insert(Coord::X, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "b", {}, {3});
+  d.insert(Data::Variance, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance, "b", {}, {6});
 
   auto slice = d(Dim::X, 1);
 
   slice += 1;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 3}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "a"), {1, 3}));
   // TODO This behavior should be reconsidered and probably change: A slice
   // should not include variables that do not have the dimension, otherwise,
   // e.g., looping over slices will apply an operation to that variable more
   // than once.
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "b"), {4}));
   // Scalar treated as having 0 variance, `+` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {6}));
 
   slice -= 2;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 1}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "a"), {1, 1}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "b"), {2}));
   // Scalar treated as having 0 variance, `-` leaves variance unchanged.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {6}));
 
   slice *= 2;
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "a"), {1, 2}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}, "b"), {4}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "a"), {1, 2}));
+  EXPECT_TRUE(equals(d.get(Data::Value, "b"), {4}));
   // Scalar treated as having 0 variance, `*` affects variance.
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "a"), {4, 20}));
-  EXPECT_TRUE(equals(d.get(Data::Variance{}, "b"), {24}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "a"), {4, 20}));
+  EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {24}));
 }
 
 TEST(Dataset, binary_with_scalar) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "b", {}, {3});
-  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
-  d.insert(Data::Variance{}, "b", {}, {6});
+  d.insert(Coord::X, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "b", {}, {3});
+  d.insert(Data::Variance, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance, "b", {}, {6});
 
   auto sum = d + 1;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {2, 3}));
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {4}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "a"), {2, 3}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "b"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "b"), {6}));
   sum = 2 + d;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {3, 4}));
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "a"), {3, 4}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "b"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "b"), {6}));
 
   auto diff = d - 1;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {0, 1}));
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {2}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "a"), {0, 1}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "b"), {2}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "b"), {6}));
   diff = 2 - d;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {1, 0}));
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {-1}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {4, 5}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "a"), {1, 0}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "b"), {-1}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "a"), {4, 5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "b"), {6}));
 
   auto prod = d * 2;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {2, 4}));
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {6}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {16, 20}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {24}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "a"), {2, 4}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "b"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "a"), {16, 20}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "b"), {24}));
   prod = 3 * d;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {3, 6}));
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {9}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {36, 45}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {54}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "a"), {3, 6}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "b"), {9}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "a"), {36, 45}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "b"), {54}));
 }
 
 TEST(DatasetSlice, binary_with_scalar) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "a", {Dim::X, 2}, {1, 2});
-  d.insert(Data::Value{}, "b", {}, {3});
-  d.insert(Data::Variance{}, "a", {Dim::X, 2}, {4, 5});
-  d.insert(Data::Variance{}, "b", {}, {6});
+  d.insert(Coord::X, {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "a", {Dim::X, 2}, {1, 2});
+  d.insert(Data::Value, "b", {}, {3});
+  d.insert(Data::Variance, "a", {Dim::X, 2}, {4, 5});
+  d.insert(Data::Variance, "b", {}, {6});
 
   auto slice = d(Dim::X, 1);
 
@@ -1219,54 +1213,54 @@ TEST(DatasetSlice, binary_with_scalar) {
   // DatasetSlice to Dataset, so this test is actually testing that conversion,
   // not the binary operation iteself.
   auto sum = slice + 1;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {3}));
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {4}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "a"), {3}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "b"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "a"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "b"), {6}));
   sum = 2 + slice;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "a"), {4}));
-  EXPECT_TRUE(equals(sum.get(Data::Value{}, "b"), {5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "a"), {5}));
-  EXPECT_TRUE(equals(sum.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "a"), {4}));
+  EXPECT_TRUE(equals(sum.get(Data::Value, "b"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "a"), {5}));
+  EXPECT_TRUE(equals(sum.get(Data::Variance, "b"), {6}));
 
   auto diff = slice - 1;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {1}));
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {2}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {5}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "a"), {1}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "b"), {2}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "a"), {5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "b"), {6}));
   diff = 2 - slice;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "a"), {0}));
-  EXPECT_TRUE(equals(diff.get(Data::Value{}, "b"), {-1}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "a"), {5}));
-  EXPECT_TRUE(equals(diff.get(Data::Variance{}, "b"), {6}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "a"), {0}));
+  EXPECT_TRUE(equals(diff.get(Data::Value, "b"), {-1}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "a"), {5}));
+  EXPECT_TRUE(equals(diff.get(Data::Variance, "b"), {6}));
 
   auto prod = slice * 2;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {4}));
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {6}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {20}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {24}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "a"), {4}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "b"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "a"), {20}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "b"), {24}));
   prod = 3 * slice;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "a"), {6}));
-  EXPECT_TRUE(equals(prod.get(Data::Value{}, "b"), {9}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "a"), {45}));
-  EXPECT_TRUE(equals(prod.get(Data::Variance{}, "b"), {54}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "a"), {6}));
+  EXPECT_TRUE(equals(prod.get(Data::Value, "b"), {9}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "a"), {45}));
+  EXPECT_TRUE(equals(prod.get(Data::Variance, "b"), {54}));
 }
 
 Dataset makeTofDataForUnitConversion() {
   Dataset tof;
 
-  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1000, 2000, 3000, 4000});
+  tof.insert(Coord::Tof, {Dim::Tof, 4}, {1000, 2000, 3000, 4000});
 
   Dataset components;
   // Source and sample
   components.insert(
-      Coord::Position{}, {Dim::Component, 2},
+      Coord::Position, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert(Coord::ComponentInfo{}, {}, {components});
-  tof.insert(Coord::Position{}, {Dim::Spectrum, 2},
+  tof.insert(Coord::ComponentInfo, {}, {components});
+  tof.insert(Coord::Position, {Dim::Spectrum, 2},
              {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
+  tof.insert(Data::Value, "", {{Dim::Spectrum, 2}, {Dim::Tof, 3}},
              {1, 2, 3, 4, 5, 6});
   return tof;
 }
@@ -1280,19 +1274,19 @@ TEST(Dataset, convert) {
   ASSERT_TRUE(energy.dimensions().contains(Dim::Energy));
   EXPECT_EQ(energy.dimensions()[Dim::Energy], 3);
 
-  ASSERT_FALSE(energy.contains(Coord::Tof{}));
-  ASSERT_TRUE(energy.contains(Coord::Energy{}));
-  const auto &coord = energy(Coord::Energy{});
+  ASSERT_FALSE(energy.contains(Coord::Tof));
+  ASSERT_TRUE(energy.contains(Coord::Energy));
+  const auto &coord = energy(Coord::Energy);
   // Due to conversion, the coordinate now also depends on Dim::Spectrum.
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 4}}));
   // TODO Check unit.
 
-  const auto values = coord.get(Coord::Energy{});
+  const auto values = coord.get(Coord::Energy);
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 437 * sqrt ( E[meV] )
-  Variable tof_in_seconds = tof(Coord::Tof{}) * 1e-6;
-  const auto tofs = tof_in_seconds.get(Coord::Tof{});
+  Variable tof_in_seconds = tof(Coord::Tof) * 1e-6;
+  const auto tofs = tof_in_seconds.get(Coord::Tof);
   // Spectrum 0 is 11 m from source
   EXPECT_NEAR(values[0], pow((11.0 / tofs[0]) / 437.0, 2), values[0] * 0.01);
   EXPECT_NEAR(values[1], pow((11.0 / tofs[1]) / 437.0, 2), values[1] * 0.01);
@@ -1305,14 +1299,14 @@ TEST(Dataset, convert) {
   EXPECT_NEAR(values[6], pow((L / tofs[2]) / 437.0, 2), values[6] * 0.01);
   EXPECT_NEAR(values[7], pow((L / tofs[3]) / 437.0, 2), values[7] * 0.01);
 
-  ASSERT_TRUE(energy.contains(Data::Value{}));
-  const auto &data = energy(Data::Value{});
+  ASSERT_TRUE(energy.contains(Data::Value));
+  const auto &data = energy(Data::Value);
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
-  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(data.get(Data::Value), {1, 2, 3, 4, 5, 6}));
 
-  ASSERT_TRUE(energy.contains(Coord::Position{}));
-  ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
+  ASSERT_TRUE(energy.contains(Coord::Position));
+  ASSERT_TRUE(energy.contains(Coord::ComponentInfo));
 }
 
 TEST(Dataset, convert_to_energy_fails_for_inelastic) {
@@ -1321,19 +1315,19 @@ TEST(Dataset, convert_to_energy_fails_for_inelastic) {
   // Note these conversion fail only because they are not implemented. It should
   // definitely be possible to support this.
 
-  tof.insert(Coord::Ei{}, {}, {1});
+  tof.insert(Coord::Ei, {}, {1});
   EXPECT_THROW_MSG(convert(tof, Dim::Tof, Dim::Energy), std::runtime_error,
                    "Dataset contains Coord::Ei or Coord::Ef. However, "
                    "conversion to Dim::Energy is currently only supported for "
                    "elastic scattering.");
-  tof.erase(Coord::Ei{});
+  tof.erase(Coord::Ei);
 
-  tof.insert(Coord::Ef{}, {Dim::Spectrum, 2}, {1.0, 1.5});
+  tof.insert(Coord::Ef, {Dim::Spectrum, 2}, {1.0, 1.5});
   EXPECT_THROW_MSG(convert(tof, Dim::Tof, Dim::Energy), std::runtime_error,
                    "Dataset contains Coord::Ei or Coord::Ef. However, "
                    "conversion to Dim::Energy is currently only supported for "
                    "elastic scattering.");
-  tof.erase(Coord::Ef{});
+  tof.erase(Coord::Ef);
 
   EXPECT_NO_THROW(convert(tof, Dim::Tof, Dim::Energy));
 }
@@ -1341,22 +1335,22 @@ TEST(Dataset, convert_to_energy_fails_for_inelastic) {
 TEST(Dataset, convert_direct_inelastic) {
   Dataset tof;
 
-  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1, 2, 3, 4});
+  tof.insert(Coord::Tof, {Dim::Tof, 4}, {1, 2, 3, 4});
 
   Dataset components;
   // Source and sample
   components.insert(
-      Coord::Position{}, {Dim::Component, 2},
+      Coord::Position, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert(Coord::ComponentInfo{}, {}, {components});
-  tof.insert(Coord::Position{}, {Dim::Spectrum, 3},
+  tof.insert(Coord::ComponentInfo, {}, {components});
+  tof.insert(Coord::Position, {Dim::Spectrum, 3},
              {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.0, 0.0, 1.0},
               Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
+  tof.insert(Data::Value, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
              {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-  tof.insert(Coord::Ei{}, {}, {1});
+  tof.insert(Coord::Ei, {}, {1});
 
   auto energy = convert(tof, Dim::Tof, Dim::DeltaE);
 
@@ -1364,51 +1358,51 @@ TEST(Dataset, convert_direct_inelastic) {
   ASSERT_TRUE(energy.dimensions().contains(Dim::DeltaE));
   EXPECT_EQ(energy.dimensions()[Dim::DeltaE], 3);
 
-  ASSERT_FALSE(energy.contains(Coord::Tof{}));
-  ASSERT_TRUE(energy.contains(Coord::DeltaE{}));
-  const auto &coord = energy(Coord::DeltaE{});
+  ASSERT_FALSE(energy.contains(Coord::Tof));
+  ASSERT_TRUE(energy.contains(Coord::DeltaE));
+  const auto &coord = energy(Coord::DeltaE);
   // Due to conversion, the coordinate now also depends on Dim::Spectrum.
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
   EXPECT_FALSE(
-      equals(coord.get(Coord::DeltaE{}), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+      equals(coord.get(Coord::DeltaE), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position see same deltaE.
-  EXPECT_EQ(coord(Dim::Spectrum, 0).get(Coord::DeltaE{})[0],
-            coord(Dim::Spectrum, 1).get(Coord::DeltaE{})[0]);
+  EXPECT_EQ(coord(Dim::Spectrum, 0).get(Coord::DeltaE)[0],
+            coord(Dim::Spectrum, 1).get(Coord::DeltaE)[0]);
 
-  ASSERT_TRUE(energy.contains(Data::Value{}));
-  const auto &data = energy(Data::Value{});
+  ASSERT_TRUE(energy.contains(Data::Value));
+  const auto &data = energy(Data::Value);
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get(Data::Value), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
-  ASSERT_TRUE(energy.contains(Coord::Position{}));
-  ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
-  ASSERT_TRUE(energy.contains(Coord::Ei{}));
+  ASSERT_TRUE(energy.contains(Coord::Position));
+  ASSERT_TRUE(energy.contains(Coord::ComponentInfo));
+  ASSERT_TRUE(energy.contains(Coord::Ei));
 }
 
 TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   Dataset tof;
 
-  tof.insert(Coord::Tof{}, {Dim::Tof, 4}, {1, 2, 3, 4});
+  tof.insert(Coord::Tof, {Dim::Tof, 4}, {1, 2, 3, 4});
 
   Dataset components;
   // Source and sample
   components.insert(
-      Coord::Position{}, {Dim::Component, 2},
+      Coord::Position, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
-  tof.insert(Coord::ComponentInfo{}, {}, {components});
-  tof.insert(Coord::Position{}, {Dim::Spectrum, 3},
+  tof.insert(Coord::ComponentInfo, {}, {components});
+  tof.insert(Coord::Position, {Dim::Spectrum, 3},
              {Eigen::Vector3d{0.0, 0.0, 1.0}, Eigen::Vector3d{0.0, 0.0, 1.0},
               Eigen::Vector3d{0.1, 0.0, 1.0}});
 
-  tof.insert(Data::Value{}, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
+  tof.insert(Data::Value, "", {{Dim::Spectrum, 3}, {Dim::Tof, 3}},
              {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
   // In practice not every spectrum would have a different Ei, more likely we
   // would have an extra dimension, Dim::Ei in addition to Dim::Spectrum.
-  tof.insert(Coord::Ei{}, {Dim::Spectrum, 3}, {1.0, 1.5, 2.0});
+  tof.insert(Coord::Ei, {Dim::Spectrum, 3}, {1.0, 1.5, 2.0});
 
   auto energy = convert(tof, Dim::Tof, Dim::DeltaE);
 
@@ -1416,27 +1410,27 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   ASSERT_TRUE(energy.dimensions().contains(Dim::DeltaE));
   EXPECT_EQ(energy.dimensions()[Dim::DeltaE], 3);
 
-  ASSERT_FALSE(energy.contains(Coord::Tof{}));
-  ASSERT_TRUE(energy.contains(Coord::DeltaE{}));
-  const auto &coord = energy(Coord::DeltaE{});
+  ASSERT_FALSE(energy.contains(Coord::Tof));
+  ASSERT_TRUE(energy.contains(Coord::DeltaE));
+  const auto &coord = energy(Coord::DeltaE);
   // Due to conversion, the coordinate now also depends on Dim::Spectrum.
   ASSERT_EQ(coord.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 4}}));
   // TODO Check actual values here after conversion is fixed.
   EXPECT_FALSE(
-      equals(coord.get(Coord::DeltaE{}), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
+      equals(coord.get(Coord::DeltaE), {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}));
   // 2 spectra at same position, but now their Ei differs, so deltaE is also
   // different (compare to test for single Ei above).
-  EXPECT_NE(coord(Dim::Spectrum, 0).get(Coord::DeltaE{})[0],
-            coord(Dim::Spectrum, 1).get(Coord::DeltaE{})[0]);
+  EXPECT_NE(coord(Dim::Spectrum, 0).get(Coord::DeltaE)[0],
+            coord(Dim::Spectrum, 1).get(Coord::DeltaE)[0]);
 
-  ASSERT_TRUE(energy.contains(Data::Value{}));
-  const auto &data = energy(Data::Value{});
+  ASSERT_TRUE(energy.contains(Data::Value));
+  const auto &data = energy(Data::Value);
   ASSERT_EQ(data.dimensions(),
             Dimensions({{Dim::Spectrum, 3}, {Dim::DeltaE, 3}}));
-  EXPECT_TRUE(equals(data.get(Data::Value{}), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(equals(data.get(Data::Value), {1, 2, 3, 4, 5, 6, 7, 8, 9}));
 
-  ASSERT_TRUE(energy.contains(Coord::Position{}));
-  ASSERT_TRUE(energy.contains(Coord::ComponentInfo{}));
-  ASSERT_TRUE(energy.contains(Coord::Ei{}));
+  ASSERT_TRUE(energy.contains(Coord::Position));
+  ASSERT_TRUE(energy.contains(Coord::ComponentInfo));
+  ASSERT_TRUE(energy.contains(Coord::Ei));
 }

--- a/test/example_instrument_test.cpp
+++ b/test/example_instrument_test.cpp
@@ -14,42 +14,41 @@ TEST(ExampleInstrument, basics) {
   gsl::index ndet = 4;
 
   Dataset detectors;
-  detectors.insert(Coord::DetectorId{}, {Dim::Detector, ndet}, {1, 2, 3, 4});
-  detectors.insert(Coord::Position{}, {Dim::Detector, ndet}, ndet,
+  detectors.insert(Coord::DetectorId, {Dim::Detector, ndet}, {1, 2, 3, 4});
+  detectors.insert(Coord::Position, {Dim::Detector, ndet}, ndet,
                    Eigen::Vector3d{0.0, 0.0, 2.0});
   auto view =
-      zipMD(detectors, MDRead(Coord::DetectorId{}), MDWrite(Coord::Position{}));
+      zipMD(detectors, MDRead(Coord::DetectorId), MDWrite(Coord::Position));
   for (auto &det : view) {
-    det.get<Coord::Position>()[0] = 0.1 * det.get<Coord::DetectorId>();
-    EXPECT_EQ(det.get<Coord::Position>()[0],
-              0.1 * det.get<Coord::DetectorId>());
+    det.get(Coord::Position)[0] = 0.1 * det.get(Coord::DetectorId);
+    EXPECT_EQ(det.get(Coord::Position)[0], 0.1 * det.get(Coord::DetectorId));
   }
 
   // For const access we need to make sure that the implementation is not
   // attempting to compute derived positions based on detector grouping (which
   // does not exist in this case).
-  auto directConstView = zipMD(detectors, MDRead(Coord::Position{}));
+  auto directConstView = zipMD(detectors, MDRead(Coord::Position));
   // If not implemented correctly this would actually segfault, not throw.
-  ASSERT_NO_THROW(directConstView.begin()->get<Coord::Position>());
-  EXPECT_EQ(directConstView.begin()->get<Coord::Position>()[0], 0.1);
+  ASSERT_NO_THROW(directConstView.begin()->get(Coord::Position));
+  EXPECT_EQ(directConstView.begin()->get(Coord::Position)[0], 0.1);
 
   Dataset components;
   // Source and sample
   components.insert(
-      Coord::Position{}, {Dim::Component, 2},
+      Coord::Position, {Dim::Component, 2},
       {Eigen::Vector3d{0.0, 0.0, -10.0}, Eigen::Vector3d{0.0, 0.0, 0.0}});
 
   Dataset d;
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {{0, 1},
                                                                     {2, 3}};
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 2}, grouping);
-  d.insert(Coord::DetectorInfo{}, {}, {detectors});
-  d.insert(Coord::ComponentInfo{}, {}, {components});
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, 2}, grouping);
+  d.insert(Coord::DetectorInfo, {}, {detectors});
+  d.insert(Coord::ComponentInfo, {}, {components});
 
-  EXPECT_ANY_THROW(zipMD(d, MDWrite(Coord::Position{})));
-  ASSERT_NO_THROW(zipMD(d, MDRead(Coord::Position{})));
-  auto specPos = zipMD(d, MDRead(Coord::Position{}));
+  EXPECT_ANY_THROW(zipMD(d, MDWrite(Coord::Position)));
+  ASSERT_NO_THROW(zipMD(d, MDRead(Coord::Position)));
+  auto specPos = zipMD(d, MDRead(Coord::Position));
   ASSERT_EQ(specPos.size(), 2);
-  EXPECT_DOUBLE_EQ(specPos.begin()->get<Coord::Position>()[0], 0.15);
-  EXPECT_DOUBLE_EQ((specPos.begin() + 1)->get<Coord::Position>()[0], 0.35);
+  EXPECT_DOUBLE_EQ(specPos.begin()->get(Coord::Position)[0], 0.15);
+  EXPECT_DOUBLE_EQ((specPos.begin() + 1)->get(Coord::Position)[0], 0.35);
 }

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -15,44 +15,43 @@
 
 TEST(MDZipView, construct) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions{}, {1.1});
-  d.insert(Data::Int{}, "", Dimensions{}, {2});
+  d.insert(Data::Value, "", {}, {1.1});
+  d.insert(Data::Int, "", {}, {2});
   // Empty view forbidden by static_assert:
   // zipMD(d);
-  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Value{}))));
-  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Int{}))));
+  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Value))));
+  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Int))));
   ASSERT_NO_THROW(
-      static_cast<void>(zipMD(d, MDRead(Data::Int{}), MDRead(Data::Value{}))));
-  ASSERT_THROW(static_cast<void>(
-                   zipMD(d, MDRead(Data::Int{}), MDRead(Data::Variance{}))),
-               std::runtime_error);
+      static_cast<void>(zipMD(d, MDRead(Data::Int), MDRead(Data::Value))));
+  ASSERT_THROW(
+      static_cast<void>(zipMD(d, MDRead(Data::Int), MDRead(Data::Variance))),
+      std::runtime_error);
 }
 
 TEST(MDZipView, construct_with_const_Dataset) {
   Dataset d;
-  d.insert(Data::Value{}, "", {Dim::X, 1}, {1.1});
-  d.insert(Data::Int{}, "", Dimensions{}, {2});
+  d.insert(Data::Value, "", {Dim::X, 1}, {1.1});
+  d.insert(Data::Int, "", {}, {2});
   const auto const_d(d);
-  EXPECT_NO_THROW(zipMD(const_d, MDRead(Data::Value{})));
-  EXPECT_NO_THROW(
-      zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value{}))));
-  EXPECT_NO_THROW(zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value{})),
-                        MDRead(Data::Int{})));
+  EXPECT_NO_THROW(zipMD(const_d, MDRead(Data::Value)));
+  EXPECT_NO_THROW(zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value))));
+  EXPECT_NO_THROW(zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value)),
+                        MDRead(Data::Int)));
 }
 
 TEST(MDZipView, iterator) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions{Dim::X, 2}, {1.1, 1.2});
-  d.insert(Data::Int{}, "", Dimensions{Dim::X, 2}, {2, 3});
-  auto view = zipMD(d, MDWrite(Data::Value{}));
+  d.insert(Data::Value, "", Dimensions{Dim::X, 2}, {1.1, 1.2});
+  d.insert(Data::Int, "", Dimensions{Dim::X, 2}, {2, 3});
+  auto view = zipMD(d, MDWrite(Data::Value));
   ASSERT_NO_THROW(view.begin());
   ASSERT_NO_THROW(view.end());
   auto it = view.begin();
   // Note: Cannot assigned dereferenced iterator by value since Dataset::Item
   // should not live outside and iterator.
   // auto item = *it;
-  ASSERT_EQ(it->get<Data::Value>(), 1.1);
-  it->get<Data::Value>() = 2.2;
+  ASSERT_EQ(it->get(Data::Value), 1.1);
+  it->get(Data::Value) = 2.2;
   ASSERT_EQ(it->value(), 2.2);
   ASSERT_EQ(it, it);
   ASSERT_EQ(it, view.begin());
@@ -66,59 +65,59 @@ TEST(MDZipView, iterator) {
 
 TEST(MDZipView, single_column) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 10), 10);
-  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 10), 10);
-  auto var = d.get(Data::Value{});
+  d.insert(Data::Value, "", Dimensions(Dim::Tof, 10), 10);
+  d.insert(Data::Int, "", Dimensions(Dim::Tof, 10), 10);
+  auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[3] = 3.2;
 
-  auto view = zipMD(d, MDWrite(Data::Value{}));
+  auto view = zipMD(d, MDWrite(Data::Value));
   auto it = view.begin();
-  ASSERT_EQ(it->get<Data::Value>(), 0.2);
+  ASSERT_EQ(it->get(Data::Value), 0.2);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 0.0);
+  ASSERT_EQ(it->get(Data::Value), 0.0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 0.0);
+  ASSERT_EQ(it->get(Data::Value), 0.0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 3.2);
+  ASSERT_EQ(it->get(Data::Value), 3.2);
   it += 7;
   ASSERT_EQ(it, view.end());
 }
 
 TEST(MDZipView, multi_column) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
-  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get(Data::Value{});
+  d.insert(Data::Value, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Int, "", Dimensions(Dim::Tof, 2), 2);
+  auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  auto view = zipMD(d, MDRead(Data::Value{}), MDRead(Data::Int{}));
+  auto view = zipMD(d, MDRead(Data::Value), MDRead(Data::Int));
   auto it = view.begin();
-  ASSERT_EQ(it->get<Data::Value>(), 0.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 0.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 3.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 3.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
 }
 
 TEST(MDZipView, multi_column_mixed_dimension) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
-  d.insert(Data::Int{}, "", Dimensions{}, 1);
-  auto var = d.get(Data::Value{});
+  d.insert(Data::Value, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Int, "", {}, 1);
+  auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value{}), MDWrite(Data::Int{})));
-  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value{}), MDRead(Data::Int{})));
-  auto view = zipMD(d, MDWrite(Data::Value{}), MDRead(Data::Int{}));
+  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Int)));
+  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Int)));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
   auto it = view.begin();
-  ASSERT_EQ(it->get<Data::Value>(), 0.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 0.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 3.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 3.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
 }
 
 TEST(MDZipView, multi_column_transposed) {
@@ -130,24 +129,24 @@ TEST(MDZipView, multi_column_transposed) {
   dimsYX.add(Dim::Y, 3);
   dimsYX.add(Dim::X, 2);
 
-  d.insert(Data::Value{}, "", dimsXY, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert(Data::Int{}, "", dimsYX, {1, 3, 5, 2, 4, 6});
+  d.insert(Data::Value, "", dimsXY, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+  d.insert(Data::Int, "", dimsYX, {1, 3, 5, 2, 4, 6});
   // TODO Current dimension check is too strict and fails unless data with
   // transposed dimensions is accessed as const.
-  auto view = zipMD(d, MDWrite(Data::Value{}), MDRead(Data::Int{}));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
   auto it = view.begin();
   ASSERT_NE(++it, view.end());
-  ASSERT_EQ(it->get<Data::Value>(), 2.0);
-  ASSERT_EQ(it->get<Data::Int>(), 2);
+  ASSERT_EQ(it->get(Data::Value), 2.0);
+  ASSERT_EQ(it->get(Data::Int), 2);
   for (const auto &item : view)
-    ASSERT_EQ(item.get<Data::Value>(), item.get<Data::Int>());
+    ASSERT_EQ(item.get(Data::Value), item.get(Data::Int));
 }
 
 TEST(MDZipView, multi_column_unrelated_dimension) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int{}, "", Dimensions(Dim::Y, 3), 3);
-  auto view = zipMD(d, MDWrite(Data::Value{}));
+  d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int, "", Dimensions(Dim::Y, 3), 3);
+  auto view = zipMD(d, MDWrite(Data::Value));
   auto it = view.begin();
   ASSERT_TRUE(it < view.end());
   it += 2;
@@ -158,9 +157,9 @@ TEST(MDZipView, multi_column_unrelated_dimension) {
 
 TEST(MDZipView, multi_column_orthogonal_fail) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int{}, "", Dimensions(Dim::Y, 3), 3);
-  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value{}), MDRead(Data::Int{})),
+  d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int, "", Dimensions(Dim::Y, 3), 3);
+  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value), MDRead(Data::Int)),
                    std::runtime_error,
                    "Variables requested for iteration do not span a joint "
                    "space. In case one of the variables represents bin edges "
@@ -170,46 +169,48 @@ TEST(MDZipView, multi_column_orthogonal_fail) {
 
 TEST(MDZipView, nested_MDZipView) {
   Dataset d;
-  d.insert(Data::Value{}, "", {{Dim::Y, 3}, {Dim::X, 2}},
+  d.insert(Data::Value, "", {{Dim::Y, 3}, {Dim::X, 2}},
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert(Data::Int{}, "", {Dim::X, 2}, {10, 20});
-  auto nested = MDNested(MDRead(Data::Value{}));
-  using nested_t = decltype(nested)::type;
-  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int{}));
+  d.insert(Data::Int, "", {Dim::X, 2}, {10, 20});
+  auto nested = MDNested(MDRead(Data::Value));
+  // TODO This is a very bad way of indexing nested views.
+  auto Nested = decltype(nested)::type(d);
+  ;
+  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int));
   ASSERT_EQ(view.size(), 2);
   double base = 0.0;
   for (const auto &item : view) {
-    auto subview = item.get<nested_t>();
+    auto subview = item.get(Nested);
     ASSERT_EQ(subview.size(), 3);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 3.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 5.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 3.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 5.0);
     base += 1.0;
   }
 }
 
 TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   Dataset d;
-  d.insert(
-      Data::Value{}, "", Dimensions({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}}),
-      {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
-       13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
+  d.insert(Data::Value, "", Dimensions({{Dim::Z, 2}, {Dim::Y, 3}, {Dim::X, 4}}),
+           {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+            17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
-  auto nested = zipMD(d, MDRead(Data::Value{}));
+  auto nested = zipMD(d, MDRead(Data::Value));
   auto viewX = zipMD(d, {Dim::Y, Dim::Z}, MDWrite(nested));
   ASSERT_EQ(viewX.size(), 4);
   double base = 0.0;
   for (const auto &item : viewX) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 6);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 5.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 9.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 13.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 17.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 21.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 5.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 9.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 13.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 17.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 21.0);
     base += 1.0;
   }
 
@@ -217,17 +218,17 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   ASSERT_EQ(viewY.size(), 3);
   base = 0.0;
   for (const auto &item : viewY) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 8);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 2.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 3.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 4.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 13.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 14.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 15.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 16.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 2.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 3.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 4.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 13.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 14.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 15.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 16.0);
     base += 4.0;
   }
 
@@ -235,21 +236,21 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   ASSERT_EQ(viewZ.size(), 2);
   base = 0.0;
   for (const auto &item : viewZ) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 12);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 2.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 3.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 4.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 5.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 6.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 7.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 8.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 9.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 10.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 11.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 12.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 2.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 3.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 4.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 5.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 6.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 7.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 8.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 9.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 10.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 11.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 12.0);
     base += 12.0;
   }
 
@@ -257,13 +258,13 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   ASSERT_EQ(viewYZ.size(), 6);
   base = 0.0;
   for (const auto &item : viewYZ) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 4);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 2.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 3.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 4.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 2.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 3.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 4.0);
     base += 4.0;
   }
 
@@ -271,12 +272,12 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   ASSERT_EQ(viewXZ.size(), 8);
   base = 0.0;
   for (const auto &item : viewXZ) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 3);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 5.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 9.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 5.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 9.0);
     base += 1.0;
     // Jump to next Z
     if (base == 4.0)
@@ -287,46 +288,46 @@ TEST(MDZipView, nested_MDZipView_all_subdimension_combinations_3D) {
   ASSERT_EQ(viewXY.size(), 12);
   base = 0.0;
   for (const auto &item : viewXY) {
-    auto subview = item.get<decltype(nested)>();
+    auto subview = item.get(nested);
     ASSERT_EQ(subview.size(), 2);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 13.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 13.0);
     base += 1.0;
   }
 }
 
 TEST(MDZipView, nested_MDZipView_constant_variable) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions({{Dim::Z, 2}, {Dim::X, 4}}),
+  d.insert(Data::Value, "", Dimensions({{Dim::Z, 2}, {Dim::X, 4}}),
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
-  d.insert(Coord::X{}, {Dim::X, 4}, {10.0, 20.0, 30.0, 40.0});
+  d.insert(Coord::X, {Dim::X, 4}, {10.0, 20.0, 30.0, 40.0});
 
   // Coord::X has fewer dimensions, throws if not const when not nested...
   EXPECT_THROW_MSG(
-      zipMD(d, MDRead(Data::Value{}), MDWrite(Coord::X{})), std::runtime_error,
+      zipMD(d, MDRead(Data::Value), MDWrite(Coord::X)), std::runtime_error,
       "Variables requested for iteration have different dimensions");
   // ... and also when nested.
   // TODO Dim::Z is just a dummy so we can create the nested label without
   // failing, it is actually ignored.
-  auto nested = zipMD(d, {Dim::Z}, MDRead(Data::Value{}), MDWrite(Coord::X{}));
+  auto nested = zipMD(d, {Dim::Z}, MDRead(Data::Value), MDWrite(Coord::X));
   EXPECT_THROW_MSG(
       zipMD(d, {Dim::X}, MDWrite(nested)), std::runtime_error,
       "Variables requested for iteration have different dimensions");
 
-  auto goodNested = zipMD(d, MDRead(Data::Value{}), MDRead(Coord::X{}));
+  auto goodNested = zipMD(d, MDRead(Data::Value), MDRead(Coord::X));
   auto view = zipMD(d, {Dim::X}, MDWrite(goodNested));
   ASSERT_EQ(view.size(), 2);
   double value = 0.0;
   for (const auto &item : view) {
-    auto subview = item.get<decltype(goodNested)>();
+    auto subview = item.get(goodNested);
     ASSERT_EQ(subview.size(), 4);
     double x = 0.0;
     for (const auto &subitem : subview) {
       x += 10.0;
       value += 1.0;
-      EXPECT_EQ(subitem.get<Coord::X>(), x);
-      EXPECT_EQ(subitem.get<Data::Value>(), value);
+      EXPECT_EQ(subitem.get(Coord::X), x);
+      EXPECT_EQ(subitem.get(Data::Value), value);
     }
   }
 }
@@ -334,27 +335,28 @@ TEST(MDZipView, nested_MDZipView_constant_variable) {
 TEST(MDZipView, histogram_using_nested_MDZipView) {
   Dataset d;
   // Edges do not have Dim::Spectrum, "shared" by all histograms.
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), {10.0, 20.0, 30.0});
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), {10.0, 20.0, 30.0});
   Dimensions dims;
   dims.add(Dim::Tof, 2);
   dims.add(Dim::Spectrum, 4);
-  d.insert(Data::Value{}, "sample", dims,
+  d.insert(Data::Value, "sample", dims,
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
-  d.insert(Data::Variance{}, "sample", dims, 8);
-  d.insert(Coord::SpectrumNumber{}, {Dim::Spectrum, 4}, {1, 2, 3, 4});
+  d.insert(Data::Variance, "sample", dims, 8);
+  d.insert(Coord::SpectrumNumber, {Dim::Spectrum, 4}, {1, 2, 3, 4});
 
-  auto nested =
-      MDNested(MDRead(Bin<Coord::Tof>{}), MDWrite(Data::Value{}, "sample"),
-               MDWrite(Data::Variance{}, "sample"));
-  using HistogramView = decltype(nested)::type;
-  auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Coord::SpectrumNumber{}));
+  auto nested = MDNested(MDRead(Bin<decltype(Coord::Tof)>{}),
+                         MDWrite(Data::Value, "sample"),
+                         MDWrite(Data::Variance, "sample"));
+  // TODO Nested access needs to change!
+  auto HistogramView = decltype(nested)::type(d, "sample", {Dim::Spectrum});
+  auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Coord::SpectrumNumber));
 
   EXPECT_EQ(view.size(), 4);
   int32_t specNum = 1;
   double value = 1.0;
   for (const auto &item : view) {
-    EXPECT_EQ(item.get<Coord::SpectrumNumber>(), specNum++);
-    auto histview = item.get<HistogramView>();
+    EXPECT_EQ(item.get(Coord::SpectrumNumber), specNum++);
+    auto histview = item.get(HistogramView);
     EXPECT_EQ(histview.size(), 2);
     double edge = 10.0;
     for (const auto &bin : histview) {
@@ -366,37 +368,37 @@ TEST(MDZipView, histogram_using_nested_MDZipView) {
   }
 
   auto it = view.begin();
-  auto histogram = it->get<HistogramView>();
+  auto histogram = it->get(HistogramView);
   EXPECT_EQ(histogram.size(), 2);
   auto bin = histogram.begin();
   EXPECT_EQ(bin->value(), 1.0);
   ++bin;
   EXPECT_EQ(bin->value(), 2.0);
   bin->value() += 0.2;
-  EXPECT_EQ(d.get(Data::Value{}, "sample")[1], 2.2);
+  EXPECT_EQ(d.get(Data::Value, "sample")[1], 2.2);
   it++;
-  EXPECT_EQ(it->get<HistogramView>().begin()->value(), 3.0);
+  EXPECT_EQ(it->get(HistogramView).begin()->value(), 3.0);
 }
 
 TEST(MDZipView, single_column_edges) {
   Dataset d;
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get(Coord::Tof{});
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int, "name2", Dimensions(Dim::Tof, 2), 2);
+  auto var = d.get(Coord::Tof);
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[2] = 2.2;
 
-  auto view = zipMD(d, MDRead(Coord::Tof{}));
+  auto view = zipMD(d, MDRead(Coord::Tof));
   auto it = view.begin();
   ASSERT_LT(it, view.end());
-  ASSERT_EQ(it->get<Coord::Tof>(), 0.2);
+  ASSERT_EQ(it->get(Coord::Tof), 0.2);
   it++;
   ASSERT_LT(it, view.end());
-  ASSERT_EQ(it->get<Coord::Tof>(), 0.0);
+  ASSERT_EQ(it->get(Coord::Tof), 0.0);
   ASSERT_LT(it, view.end());
   it++;
-  ASSERT_EQ(it->get<Coord::Tof>(), 2.2);
+  ASSERT_EQ(it->get(Coord::Tof), 2.2);
   ASSERT_LT(it, view.end());
   it++;
   ASSERT_EQ(it, view.end());
@@ -404,15 +406,15 @@ TEST(MDZipView, single_column_edges) {
 
 TEST(MDZipView, single_column_bins) {
   Dataset d;
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get(Coord::Tof{});
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int, "name2", Dimensions(Dim::Tof, 2), 2);
+  auto var = d.get(Coord::Tof);
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[1] = 1.2;
   var[2] = 2.2;
 
-  auto view = zipMD(d, MDRead(Bin<Coord::Tof>{}));
+  auto view = zipMD(d, MDRead(Bin<decltype(Coord::Tof)>{}));
   auto it = view.begin();
   it++;
   ASSERT_NE(it, view.end());
@@ -423,24 +425,24 @@ TEST(MDZipView, single_column_bins) {
 
 TEST(MDZipView, multi_column_edges) {
   Dataset d;
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get(Coord::Tof{});
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
+  d.insert(Data::Int, "", Dimensions(Dim::Tof, 2), 2);
+  auto var = d.get(Coord::Tof);
   var[0] = 0.2;
   var[1] = 1.2;
   var[2] = 2.2;
 
   // Cannot simultaneously iterate edges and non-edges, so this throws.
-  EXPECT_THROW_MSG(zipMD(d, MDRead(Coord::Tof{}), MDRead(Data::Int{})),
+  EXPECT_THROW_MSG(zipMD(d, MDRead(Coord::Tof), MDRead(Data::Int)),
                    std::runtime_error,
                    "Variables requested for iteration do not span a joint "
                    "space. In case one of the variables represents bin edges "
                    "direct joint iteration is not possible. Use the Bin<> "
                    "wrapper to iterate over bins defined by edges instead.");
 
-  auto view = zipMD(d, MDRead(Bin<Coord::Tof>{}), MDWrite(Data::Int{}));
+  auto view = zipMD(d, MDRead(Bin<decltype(Coord::Tof)>{}), MDWrite(Data::Int));
   // TODO What are good names for named getters? tofCenter(), etc.?
-  const auto &bin = view.begin()->get<Bin<Coord::Tof>>();
+  const auto &bin = view.begin()->get(Bin<decltype(Coord::Tof)>{});
   EXPECT_EQ(bin.center(), 0.7);
   EXPECT_EQ(bin.width(), 1.0);
   EXPECT_EQ(bin.left(), 0.2);
@@ -449,54 +451,54 @@ TEST(MDZipView, multi_column_edges) {
 
 TEST(MDZipView, multi_dimensional_edges) {
   Dataset d;
-  d.insert(Coord::X{}, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
+  d.insert(Coord::X, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
   // TODO There is currently a bug in MDZipView: If `Bin` iteration is
   // requested but the dataset contains only edges the shape calculation gives
   // wrong results.
-  d.insert(Data::Value{}, "", {Dim::X, 2});
+  d.insert(Data::Value, "", {Dim::X, 2});
 
-  auto view = zipMD(d, MDRead(Bin<Coord::X>{}));
+  auto view = zipMD(d, MDRead(Bin<decltype(Coord::X)>{}));
   ASSERT_EQ(view.size(), 4);
   auto it = view.begin();
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().left(), 1.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().left(), 2.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().left(), 4.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().left(), 5.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).left(), 1.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).left(), 2.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).left(), 4.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).left(), 5.0);
   it -= 4;
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().right(), 2.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().right(), 3.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().right(), 5.0);
-  EXPECT_EQ(it++->get<Bin<Coord::X>>().right(), 6.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).right(), 2.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).right(), 3.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).right(), 5.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::X)>{}).right(), 6.0);
 }
 
 TEST(MDZipView, edges_are_not_inner_dimension) {
   Dataset d;
-  d.insert(Coord::Y{}, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
+  d.insert(Coord::Y, Dimensions({{Dim::Y, 2}, {Dim::X, 3}}),
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert(Data::Value{}, "", {Dim::Y, 1});
+  d.insert(Data::Value, "", {Dim::Y, 1});
 
-  auto view = zipMD(d, MDRead(Bin<Coord::Y>{}));
+  auto view = zipMD(d, MDRead(Bin<decltype(Coord::Y)>{}));
   ASSERT_EQ(view.size(), 3);
   auto it = view.begin();
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().left(), 1.0);
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().left(), 2.0);
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().left(), 3.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).left(), 1.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).left(), 2.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).left(), 3.0);
   it -= 3;
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().right(), 4.0);
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().right(), 5.0);
-  EXPECT_EQ(it++->get<Bin<Coord::Y>>().right(), 6.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).right(), 4.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).right(), 5.0);
+  EXPECT_EQ(it++->get(Bin<decltype(Coord::Y)>{}).right(), 6.0);
 }
 
 TEST(MDZipView, named_getter) {
   Dataset d;
-  d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
-  auto var = d.get(Coord::Tof{});
+  d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
+  auto var = d.get(Coord::Tof);
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[2] = 2.2;
 
-  auto view = zipMD(d, MDRead(Coord::Tof{}));
+  auto view = zipMD(d, MDRead(Coord::Tof));
   auto it = view.begin();
   ASSERT_EQ(it->tof(), 0.2);
   it++;
@@ -507,42 +509,42 @@ TEST(MDZipView, named_getter) {
 
 TEST(MDZipView, duplicate_data_tag) {
   Dataset d;
-  d.insert(Data::Value{}, "name1", Dimensions{}, 1);
-  d.insert(Data::Value{}, "name2", Dimensions{}, 1);
+  d.insert(Data::Value, "name1", {}, 1);
+  d.insert(Data::Value, "name2", {}, 1);
 
-  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value{})), std::runtime_error,
+  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value)), std::runtime_error,
                    "Dataset with 2 variables, could not find variable with tag "
                    "Data::Value and name ``.");
-  EXPECT_NO_THROW(zipMD(d, MDRead(Data::Value{}, "name2")));
+  EXPECT_NO_THROW(zipMD(d, MDRead(Data::Value, "name2")));
 }
 
 TEST(MDZipView, named_variable_and_coordinate) {
   Dataset d;
-  d.insert(Coord::X{}, Dimensions{}, 1);
-  d.insert(Data::Value{}, "name", Dimensions{}, 1);
+  d.insert(Coord::X, {}, 1);
+  d.insert(Data::Value, "name", {}, 1);
 
-  EXPECT_NO_THROW(zipMD(d, MDRead(Coord::X{}), MDRead(Data::Value{}, "name")));
+  EXPECT_NO_THROW(zipMD(d, MDRead(Coord::X), MDRead(Data::Value, "name")));
 }
 
 TEST(MDZipView, spectrum_position) {
   Dataset dets;
-  dets.insert(Coord::Position{}, {Dim::Detector, 4},
+  dets.insert(Coord::Position, {Dim::Detector, 4},
               {Eigen::Vector3d{1.0, 0.0, 0.0}, Eigen::Vector3d{2.0, 0.0, 0.0},
                Eigen::Vector3d{4.0, 0.0, 0.0}, Eigen::Vector3d{8.0, 0.0, 0.0}});
 
   Dataset d;
-  d.insert(Coord::DetectorInfo{}, {}, {dets});
+  d.insert(Coord::DetectorInfo, {}, {dets});
   Vector<boost::container::small_vector<gsl::index, 1>> grouping = {
       {0, 2}, {1}, {}};
-  d.insert(Coord::DetectorGrouping{}, {Dim::Spectrum, 3}, grouping);
+  d.insert(Coord::DetectorGrouping, {Dim::Spectrum, 3}, grouping);
 
-  auto view = zipMD(d, MDRead(Coord::Position{}));
+  auto view = zipMD(d, MDRead(Coord::Position));
   auto it = view.begin();
-  EXPECT_EQ(it->get<Coord::Position>()[0], 2.5);
+  EXPECT_EQ(it->get(Coord::Position)[0], 2.5);
   ++it;
-  EXPECT_EQ(it->get<Coord::Position>()[0], 2.0);
+  EXPECT_EQ(it->get(Coord::Position)[0], 2.0);
   ++it;
-  EXPECT_THROW_MSG(it->get<Coord::Position>(), std::runtime_error,
+  EXPECT_THROW_MSG(it->get(Coord::Position), std::runtime_error,
                    "Spectrum has no detectors, cannot get position.");
   ++it;
   ASSERT_EQ(it, view.end());
@@ -550,71 +552,70 @@ TEST(MDZipView, spectrum_position) {
 
 TEST(MDZipView, derived_standard_deviation) {
   Dataset d;
-  d.insert(Data::Variance{}, "", {Dim::X, 3}, {4.0, 9.0, -1.0});
-  auto view = zipMD(d, MDRead(Data::StdDev{}));
+  d.insert(Data::Variance, "", {Dim::X, 3}, {4.0, 9.0, -1.0});
+  auto view = zipMD(d, MDRead(Data::StdDev));
   auto it = view.begin();
-  EXPECT_EQ(it->get<Data::StdDev>(), 2.0);
+  EXPECT_EQ(it->get(Data::StdDev), 2.0);
   ++it;
-  EXPECT_EQ(it->get<Data::StdDev>(), 3.0);
+  EXPECT_EQ(it->get(Data::StdDev), 3.0);
   ++it;
-  EXPECT_TRUE(std::isnan(it->get<Data::StdDev>()));
+  EXPECT_TRUE(std::isnan(it->get(Data::StdDev)));
 }
 
 TEST(MDZipView, create_from_labels) {
   Dataset d;
-  d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int{}, "", Dimensions{}, 1);
-  auto var = d.get(Data::Value{});
+  d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int, "", {}, 1);
+  auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value{}), MDWrite(Data::Int{})));
-  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value{}), MDRead(Data::Int{})));
-  auto view = zipMD(d, MDWrite(Data::Value{}), MDRead(Data::Int{}));
+  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Int)));
+  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Int)));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
   auto it = view.begin();
-  ASSERT_EQ(it->get<Data::Value>(), 0.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 0.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 3.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 3.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
 }
 
 TEST(MDZipView, create_from_labels_with_name) {
   Dataset d;
-  d.insert(Data::Value{}, "name", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int{}, "name", Dimensions{}, 1);
-  auto var = d.get(Data::Value{}, "name");
+  d.insert(Data::Value, "name", Dimensions(Dim::X, 2), 2);
+  d.insert(Data::Int, "name", {}, 1);
+  auto var = d.get(Data::Value, "name");
   var[0] = 0.2;
   var[1] = 3.2;
 
-  auto view =
-      zipMD(d, MDWrite(Data::Value{}, "name"), MDRead(Data::Int{}, "name"));
+  auto view = zipMD(d, MDWrite(Data::Value, "name"), MDRead(Data::Int, "name"));
   auto it = view.begin();
-  ASSERT_EQ(it->get<Data::Value>(), 0.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 0.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
   it++;
-  ASSERT_EQ(it->get<Data::Value>(), 3.2);
-  ASSERT_EQ(it->get<Data::Int>(), 0);
+  ASSERT_EQ(it->get(Data::Value), 3.2);
+  ASSERT_EQ(it->get(Data::Int), 0);
 }
 
 TEST(MDZipView, create_from_labels_nested) {
   Dataset d;
-  d.insert(Data::Value{}, "", {{Dim::Y, 3}, {Dim::X, 2}}, {1, 2, 3, 4, 5, 6});
-  d.insert(Data::Int{}, "", {Dim::X, 2}, {10, 20});
+  d.insert(Data::Value, "", {{Dim::Y, 3}, {Dim::X, 2}}, {1, 2, 3, 4, 5, 6});
+  d.insert(Data::Int, "", {Dim::X, 2}, {10, 20});
 
-  auto nested = MDNested(MDRead(Data::Value{}));
-  using nested_t = decltype(nested)::type;
-  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int{}));
+  auto nested = MDNested(MDRead(Data::Value));
+  auto Nested = decltype(nested)::type(d);
+  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int));
 
   ASSERT_EQ(view.size(), 2);
   double base = 0.0;
   for (const auto &item : view) {
-    auto subview = item.get<nested_t>();
+    auto subview = item.get(Nested);
     ASSERT_EQ(subview.size(), 3);
     auto it = subview.begin();
-    EXPECT_EQ(it++->get<Data::Value>(), base + 1.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 3.0);
-    EXPECT_EQ(it++->get<Data::Value>(), base + 5.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 1.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 3.0);
+    EXPECT_EQ(it++->get(Data::Value), base + 5.0);
     base += 1.0;
   }
 }

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -68,7 +68,7 @@ TEST(MDZipView, single_column) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 10), 10);
   d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 10), 10);
-  auto var = d.get<Data::Value>();
+  auto var = d.get(Data::Value{});
   var[0] = 0.2;
   var[3] = 3.2;
 
@@ -89,7 +89,7 @@ TEST(MDZipView, multi_column) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
   d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get<Data::Value>();
+  auto var = d.get(Data::Value{});
   var[0] = 0.2;
   var[1] = 3.2;
 
@@ -106,7 +106,7 @@ TEST(MDZipView, multi_column_mixed_dimension) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions(Dim::Tof, 2), 2);
   d.insert(Data::Int{}, "", Dimensions{}, 1);
-  auto var = d.get<Data::Value>();
+  auto var = d.get(Data::Value{});
   var[0] = 0.2;
   var[1] = 3.2;
 
@@ -373,7 +373,7 @@ TEST(MDZipView, histogram_using_nested_MDZipView) {
   ++bin;
   EXPECT_EQ(bin->value(), 2.0);
   bin->value() += 0.2;
-  EXPECT_EQ(d.get<Data::Value>("sample")[1], 2.2);
+  EXPECT_EQ(d.get(Data::Value{}, "sample")[1], 2.2);
   it++;
   EXPECT_EQ(it->get<HistogramView>().begin()->value(), 3.0);
 }
@@ -382,7 +382,7 @@ TEST(MDZipView, single_column_edges) {
   Dataset d;
   d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
   d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get<Coord::Tof>();
+  auto var = d.get(Coord::Tof{});
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[2] = 2.2;
@@ -406,7 +406,7 @@ TEST(MDZipView, single_column_bins) {
   Dataset d;
   d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
   d.insert(Data::Int{}, "name2", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get<Coord::Tof>();
+  auto var = d.get(Coord::Tof{});
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[1] = 1.2;
@@ -425,7 +425,7 @@ TEST(MDZipView, multi_column_edges) {
   Dataset d;
   d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
   d.insert(Data::Int{}, "", Dimensions(Dim::Tof, 2), 2);
-  auto var = d.get<Coord::Tof>();
+  auto var = d.get(Coord::Tof{});
   var[0] = 0.2;
   var[1] = 1.2;
   var[2] = 2.2;
@@ -491,7 +491,7 @@ TEST(MDZipView, edges_are_not_inner_dimension) {
 TEST(MDZipView, named_getter) {
   Dataset d;
   d.insert(Coord::Tof{}, Dimensions(Dim::Tof, 3), 3);
-  auto var = d.get<Coord::Tof>();
+  auto var = d.get(Coord::Tof{});
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
   var[2] = 2.2;
@@ -564,7 +564,7 @@ TEST(MDZipView, create_from_labels) {
   Dataset d;
   d.insert(Data::Value{}, "", Dimensions(Dim::X, 2), 2);
   d.insert(Data::Int{}, "", Dimensions{}, 1);
-  auto var = d.get<Data::Value>();
+  auto var = d.get(Data::Value{});
   var[0] = 0.2;
   var[1] = 3.2;
 
@@ -583,7 +583,7 @@ TEST(MDZipView, create_from_labels_with_name) {
   Dataset d;
   d.insert(Data::Value{}, "name", Dimensions(Dim::X, 2), 2);
   d.insert(Data::Int{}, "name", Dimensions{}, 1);
-  auto var = d.get<Data::Value>("name");
+  auto var = d.get(Data::Value{}, "name");
   var[0] = 0.2;
   var[1] = 3.2;
 

--- a/test/tags_test.cpp
+++ b/test/tags_test.cpp
@@ -8,9 +8,9 @@
 #include "tags.h"
 
 TEST(Tags, isDimensionCoord) {
-  EXPECT_TRUE(isDimensionCoord[Coord::Tof{}.value()]);
-  EXPECT_TRUE(isDimensionCoord[Coord::X{}.value()]);
-  EXPECT_TRUE(isDimensionCoord[Coord::Y{}.value()]);
-  EXPECT_TRUE(isDimensionCoord[Coord::Z{}.value()]);
-  EXPECT_FALSE(isDimensionCoord[Coord::Position{}.value()]);
+  EXPECT_TRUE(isDimensionCoord[Coord::Tof.value()]);
+  EXPECT_TRUE(isDimensionCoord[Coord::X.value()]);
+  EXPECT_TRUE(isDimensionCoord[Coord::Y.value()]);
+  EXPECT_TRUE(isDimensionCoord[Coord::Z.value()]);
+  EXPECT_FALSE(isDimensionCoord[Coord::Position.value()]);
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -13,26 +13,26 @@
 #include "variable.h"
 
 TEST(Variable, construct) {
-  ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2)));
-  ASSERT_NO_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 2), 2));
-  const Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  const auto &data = a.get(Data::Value{});
+  ASSERT_NO_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 2)));
+  ASSERT_NO_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 2), 2));
+  const Variable a(Data::Value, Dimensions(Dim::Tof, 2));
+  const auto &data = a.get(Data::Value);
   EXPECT_EQ(data.size(), 2);
 }
 
 TEST(Variable, construct_fail) {
-  ASSERT_ANY_THROW(Variable(Data::Value{}, Dimensions(), 2));
-  ASSERT_ANY_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 1), 2));
-  ASSERT_ANY_THROW(Variable(Data::Value{}, Dimensions(Dim::Tof, 3), 2));
+  ASSERT_ANY_THROW(Variable(Data::Value, Dimensions(), 2));
+  ASSERT_ANY_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 1), 2));
+  ASSERT_ANY_THROW(Variable(Data::Value, Dimensions(Dim::Tof, 3), 2));
 }
 
 TEST(Variable, makeVariable_custom_type) {
-  auto doubles = makeVariable<double>(Data::Value{}, {});
-  auto floats = makeVariable<float>(Data::Value{}, {});
+  auto doubles = makeVariable<double>(Data::Value, {});
+  auto floats = makeVariable<float>(Data::Value, {});
 
-  ASSERT_NO_THROW(doubles.get(Data::Value{}));
+  ASSERT_NO_THROW(doubles.get(Data::Value));
   // Data::Value defaults to double, so this throws.
-  ASSERT_ANY_THROW(floats.get(Data::Value{}));
+  ASSERT_ANY_THROW(floats.get(Data::Value));
 
   ASSERT_NO_THROW(doubles.span<double>());
   ASSERT_NO_THROW(floats.span<float>());
@@ -47,8 +47,8 @@ TEST(Variable, makeVariable_custom_type) {
 }
 
 TEST(Variable, makeVariable_custom_type_initializer_list) {
-  Variable doubles(Data::Value{}, {Dim::X, 2}, {1, 2});
-  auto ints = makeVariable<int32_t>(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable doubles(Data::Value, {Dim::X, 2}, {1, 2});
+  auto ints = makeVariable<int32_t>(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   // Passed ints but uses default type based on tag.
   ASSERT_NO_THROW(doubles.span<double>());
@@ -57,8 +57,8 @@ TEST(Variable, makeVariable_custom_type_initializer_list) {
 }
 
 TEST(Variable, dtype) {
-  auto doubles = makeVariable<double>(Data::Value{}, {});
-  auto floats = makeVariable<float>(Data::Value{}, {});
+  auto doubles = makeVariable<double>(Data::Value, {});
+  auto floats = makeVariable<float>(Data::Value, {});
   EXPECT_EQ(doubles.dtype(), dtype<double>);
   EXPECT_NE(doubles.dtype(), dtype<float>);
   EXPECT_NE(floats.dtype(), dtype<double>);
@@ -69,15 +69,15 @@ TEST(Variable, dtype) {
 }
 
 TEST(Variable, span_references_Variable) {
-  Variable a(Data::Value{}, Dimensions(Dim::Tof, 2));
-  auto observer = a.get(Data::Value{});
+  Variable a(Data::Value, Dimensions(Dim::Tof, 2));
+  auto observer = a.get(Data::Value);
   // This line does not compile, const-correctness works:
   // observer[0] = 1.0;
 
   // Note: This also has the "usual" problem of copy-on-write: This non-const
   // call can invalidate the references stored in observer if the underlying
   // data was shared.
-  auto span = a.get(Data::Value{});
+  auto span = a.get(Data::Value);
 
   EXPECT_EQ(span.size(), 2);
   span[0] = 1.0;
@@ -85,24 +85,24 @@ TEST(Variable, span_references_Variable) {
 }
 
 TEST(Variable, copy) {
-  const Variable a1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
-  const auto &data1 = a1.get(Data::Value{});
+  const Variable a1(Data::Value, {Dim::Tof, 2}, {1.1, 2.2});
+  const auto &data1 = a1.get(Data::Value);
   EXPECT_EQ(data1[0], 1.1);
   EXPECT_EQ(data1[1], 2.2);
   auto a2(a1);
-  EXPECT_NE(&a1.get(Data::Value{})[0], &a2.get(Data::Value{})[0]);
-  EXPECT_NE(&a1.get(Data::Value{})[0], &a2.get(Data::Value{})[0]);
-  const auto &data2 = a2.get(Data::Value{});
+  EXPECT_NE(&a1.get(Data::Value)[0], &a2.get(Data::Value)[0]);
+  EXPECT_NE(&a1.get(Data::Value)[0], &a2.get(Data::Value)[0]);
+  const auto &data2 = a2.get(Data::Value);
   EXPECT_EQ(data2[0], 1.1);
   EXPECT_EQ(data2[1], 2.2);
 }
 
 TEST(Variable, operator_equals) {
-  const Variable a(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
+  const Variable a(Data::Value, {Dim::Tof, 2}, {1.1, 2.2});
   const auto a_copy(a);
-  const Variable b(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.2});
-  const Variable diff1(Data::Value{}, {Dim::Tof, 2}, {1.1, 2.1});
-  const Variable diff2(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  const Variable b(Data::Value, {Dim::Tof, 2}, {1.1, 2.2});
+  const Variable diff1(Data::Value, {Dim::Tof, 2}, {1.1, 2.1});
+  const Variable diff2(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto diff3(a);
   diff3.setName("test");
   auto diff4(a);
@@ -118,28 +118,28 @@ TEST(Variable, operator_equals) {
 }
 
 TEST(Variable, operator_unary_minus) {
-  const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  const Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a;
-  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 2.2);
-  EXPECT_EQ(b.get(Data::Value{})[0], -1.1);
-  EXPECT_EQ(b.get(Data::Value{})[1], -2.2);
+  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 2.2);
+  EXPECT_EQ(b.get(Data::Value)[0], -1.1);
+  EXPECT_EQ(b.get(Data::Value)[1], -2.2);
 }
 
 TEST(VariableSlice, unary_minus) {
-  const Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  const Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a(Dim::X, 1);
-  EXPECT_EQ(a.get(Data::Value{})[0], 1.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 2.2);
-  EXPECT_EQ(b.get(Data::Value{})[0], -2.2);
+  EXPECT_EQ(a.get(Data::Value)[0], 1.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 2.2);
+  EXPECT_EQ(b.get(Data::Value)[0], -2.2);
 }
 
 TEST(Variable, operator_plus_equal) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   EXPECT_NO_THROW(a += a);
-  EXPECT_EQ(a.get(Data::Value{})[0], 2.2);
-  EXPECT_EQ(a.get(Data::Value{})[1], 4.4);
+  EXPECT_EQ(a.get(Data::Value)[0], 2.2);
+  EXPECT_EQ(a.get(Data::Value)[1], 4.4);
 
   auto different_name(a);
   different_name.setName("test");
@@ -147,40 +147,40 @@ TEST(Variable, operator_plus_equal) {
 }
 
 TEST(Variable, operator_plus_equal_automatic_broadcast_of_rhs) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
-  Variable fewer_dimensions(Data::Value{}, {}, {1.0});
+  Variable fewer_dimensions(Data::Value, {}, {1.0});
 
   EXPECT_NO_THROW(a += fewer_dimensions);
-  EXPECT_EQ(a.get(Data::Value{})[0], 2.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 3.2);
+  EXPECT_EQ(a.get(Data::Value)[0], 2.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 3.2);
 }
 
 TEST(Variable, operator_plus_equal_transpose) {
-  Variable a(Data::Value{}, Dimensions({{Dim::Y, 3}, {Dim::X, 2}}),
+  Variable a(Data::Value, Dimensions({{Dim::Y, 3}, {Dim::X, 2}}),
              {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  Variable transpose(Data::Value{}, Dimensions({{Dim::X, 2}, {Dim::Y, 3}}),
+  Variable transpose(Data::Value, Dimensions({{Dim::X, 2}, {Dim::Y, 3}}),
                      {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
   EXPECT_NO_THROW(a += transpose);
-  EXPECT_EQ(a.get(Data::Value{})[0], 2.0);
-  EXPECT_EQ(a.get(Data::Value{})[1], 4.0);
-  EXPECT_EQ(a.get(Data::Value{})[2], 6.0);
-  EXPECT_EQ(a.get(Data::Value{})[3], 8.0);
-  EXPECT_EQ(a.get(Data::Value{})[4], 10.0);
-  EXPECT_EQ(a.get(Data::Value{})[5], 12.0);
+  EXPECT_EQ(a.get(Data::Value)[0], 2.0);
+  EXPECT_EQ(a.get(Data::Value)[1], 4.0);
+  EXPECT_EQ(a.get(Data::Value)[2], 6.0);
+  EXPECT_EQ(a.get(Data::Value)[3], 8.0);
+  EXPECT_EQ(a.get(Data::Value)[4], 10.0);
+  EXPECT_EQ(a.get(Data::Value)[5], 12.0);
 }
 
 TEST(Variable, operator_plus_equal_different_dimensions) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
-  Variable different_dimensions(Data::Value{}, {Dim::Y, 2}, {1.1, 2.2});
+  Variable different_dimensions(Data::Value, {Dim::Y, 2}, {1.1, 2.2});
   EXPECT_THROW_MSG(a += different_dimensions, std::runtime_error,
                    "Expected {{Dim::X, 2}} to contain {{Dim::Y, 2}}.");
 }
 
 TEST(Variable, operator_plus_equal_different_unit) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   auto different_unit(a);
   different_unit.setUnit(Unit::Id::Length);
@@ -189,36 +189,36 @@ TEST(Variable, operator_plus_equal_different_unit) {
 }
 
 TEST(Variable, operator_plus_equal_non_arithmetic_type) {
-  Variable a(Data::String{}, {Dim::X, 1}, {std::string("test")});
+  Variable a(Data::String, {Dim::X, 1}, {std::string("test")});
   EXPECT_THROW_MSG(a += a, std::runtime_error,
                    "Cannot apply operation, requires addable type.");
 }
 
 TEST(Variable, operator_plus_equal_different_variables_different_element_type) {
-  Variable a(Data::Value{}, {Dim::X, 1}, {1.0});
-  Variable b(Data::Int{}, {Dim::X, 1}, {2});
+  Variable a(Data::Value, {Dim::X, 1}, {1.0});
+  Variable b(Data::Int, {Dim::X, 1}, {2});
   EXPECT_THROW_MSG(a += b, std::runtime_error,
                    "Cannot apply arithmetic operation to Variables: Underlying "
                    "data types do not match.");
 }
 
 TEST(Variable, operator_plus_equal_different_variables_same_element_type) {
-  Variable a(Data::Value{}, {Dim::X, 1}, {1.0});
-  Variable b(Data::Variance{}, {Dim::X, 1}, {2.0});
+  Variable a(Data::Value, {Dim::X, 1}, {1.0});
+  Variable b(Data::Variance, {Dim::X, 1}, {2.0});
   EXPECT_NO_THROW(a += b);
-  EXPECT_EQ(a.get(Data::Value{})[0], 3.0);
+  EXPECT_EQ(a.get(Data::Value)[0], 3.0);
 }
 
 TEST(Variable, operator_plus_equal_scalar) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {1.1, 2.2});
+  Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   EXPECT_NO_THROW(a += 1.0);
-  EXPECT_EQ(a.get(Data::Value{})[0], 2.1);
-  EXPECT_EQ(a.get(Data::Value{})[1], 3.2);
+  EXPECT_EQ(a.get(Data::Value)[0], 2.1);
+  EXPECT_EQ(a.get(Data::Value)[1], 3.2);
 }
 
 TEST(Variable, operator_plus_equal_custom_type) {
-  auto a = makeVariable<float>(Data::Value{}, {Dim::X, 2}, {1.1f, 2.2f});
+  auto a = makeVariable<float>(Data::Value, {Dim::X, 2}, {1.1f, 2.2f});
 
   EXPECT_NO_THROW(a += a);
   EXPECT_EQ(a.span<float>()[0], 2.2f);
@@ -230,63 +230,63 @@ TEST(Variable, operator_plus_equal_custom_type) {
 }
 
 TEST(Variable, operator_times_equal) {
-  Variable a(Coord::X{}, {Dim::X, 2}, {2.0, 3.0});
+  Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), Unit::Id::Length);
   EXPECT_NO_THROW(a *= a);
-  EXPECT_EQ(a.get(Coord::X{})[0], 4.0);
-  EXPECT_EQ(a.get(Coord::X{})[1], 9.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 4.0);
+  EXPECT_EQ(a.get(Coord::X)[1], 9.0);
   EXPECT_EQ(a.unit(), Unit::Id::Area);
 }
 
 TEST(Variable, operator_times_equal_scalar) {
-  Variable a(Coord::X{}, {Dim::X, 2}, {2.0, 3.0});
+  Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), Unit::Id::Length);
   EXPECT_NO_THROW(a *= 2.0);
-  EXPECT_EQ(a.get(Coord::X{})[0], 4.0);
-  EXPECT_EQ(a.get(Coord::X{})[1], 6.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 4.0);
+  EXPECT_EQ(a.get(Coord::X)[1], 6.0);
   EXPECT_EQ(a.unit(), Unit::Id::Length);
 }
 
 TEST(Variable, operator_divide_equal) {
-  Variable a(Data::Value{}, {Dim::X, 2}, {2.0, 3.0});
-  Variable b(Data::Value{}, {}, {2.0});
+  Variable a(Data::Value, {Dim::X, 2}, {2.0, 3.0});
+  Variable b(Data::Value, {}, {2.0});
   b.setUnit(Unit::Id::Length);
 
   EXPECT_NO_THROW(a /= b);
-  EXPECT_EQ(a.get(Data::Value{})[0], 1.0);
-  EXPECT_EQ(a.get(Data::Value{})[1], 1.5);
+  EXPECT_EQ(a.get(Data::Value)[0], 1.0);
+  EXPECT_EQ(a.get(Data::Value)[1], 1.5);
   EXPECT_EQ(a.unit(), Unit::Id::InverseLength);
 }
 
 TEST(Variable, operator_divide_equal_self) {
-  Variable a(Coord::X{}, {Dim::X, 2}, {2.0, 3.0});
+  Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
   EXPECT_EQ(a.unit(), Unit::Id::Length);
   EXPECT_NO_THROW(a /= a);
-  EXPECT_EQ(a.get(Coord::X{})[0], 1.0);
-  EXPECT_EQ(a.get(Coord::X{})[1], 1.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 1.0);
+  EXPECT_EQ(a.get(Coord::X)[1], 1.0);
   EXPECT_EQ(a.unit(), Unit::Id::Dimensionless);
 }
 
 TEST(Variable, operator_divide_equal_scalar) {
-  Variable a(Coord::X{}, {Dim::X, 2}, {2.0, 4.0});
+  Variable a(Coord::X, {Dim::X, 2}, {2.0, 4.0});
 
   EXPECT_EQ(a.unit(), Unit::Id::Length);
   EXPECT_NO_THROW(a /= 2.0);
-  EXPECT_EQ(a.get(Coord::X{})[0], 1.0);
-  EXPECT_EQ(a.get(Coord::X{})[1], 2.0);
+  EXPECT_EQ(a.get(Coord::X)[0], 1.0);
+  EXPECT_EQ(a.get(Coord::X)[1], 2.0);
   EXPECT_EQ(a.unit(), Unit::Id::Length);
 }
 
 TEST(Variable, setSlice) {
   Dimensions dims(Dim::Tof, 1);
   const Variable parent(
-      Data::Value{}, Dimensions({{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}),
+      Data::Value, Dimensions({{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
        13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
-  const Variable empty(Data::Value{},
+  const Variable empty(Data::Value,
                        Dimensions({{Dim::X, 4}, {Dim::Y, 2}, {Dim::Z, 3}}), 24);
 
   auto d(empty);
@@ -311,7 +311,7 @@ TEST(Variable, setSlice) {
 TEST(Variable, slice) {
   Dimensions dims(Dim::Tof, 1);
   const Variable parent(
-      Data::Value{}, Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
+      Data::Value, Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
        13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
@@ -319,18 +319,18 @@ TEST(Variable, slice) {
     Variable sliceX = parent(Dim::X, index);
     ASSERT_EQ(sliceX.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::Y, 2}}));
     auto base = static_cast<double>(index);
-    EXPECT_EQ(sliceX.get(Data::Value{})[0], base + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[1], base + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[2], base + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[3], base + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[4], base + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[5], base + 21.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[0], base + 1.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[1], base + 5.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[2], base + 9.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[3], base + 13.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[4], base + 17.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[5], base + 21.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index);
     ASSERT_EQ(sliceY.dimensions(), Dimensions({{Dim::Z, 3}, {Dim::X, 4}}));
-    const auto &data = sliceY.get(Data::Value{});
+    const auto &data = sliceY.get(Data::Value);
     auto base = static_cast<double>(index);
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * base + 8 * static_cast<double>(z) + 1.0);
@@ -343,7 +343,7 @@ TEST(Variable, slice) {
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceZ = parent(Dim::Z, index);
     ASSERT_EQ(sliceZ.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value{});
+    const auto &data = sliceZ.get(Data::Value);
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -352,7 +352,7 @@ TEST(Variable, slice) {
 TEST(Variable, slice_range) {
   Dimensions dims(Dim::Tof, 1);
   const Variable parent(
-      Data::Value{}, Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
+      Data::Value, Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 4}}),
       {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
        13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0});
 
@@ -360,37 +360,37 @@ TEST(Variable, slice_range) {
     Variable sliceX = parent(Dim::X, index, index + 1);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 1}}));
-    EXPECT_EQ(sliceX.get(Data::Value{})[0], index + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[1], index + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[2], index + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[3], index + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[4], index + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[5], index + 21.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[0], index + 1.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[1], index + 5.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[2], index + 9.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[3], index + 13.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[4], index + 17.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[5], index + 21.0);
   }
 
   for (const gsl::index index : {0, 1, 2}) {
     Variable sliceX = parent(Dim::X, index, index + 2);
     ASSERT_EQ(sliceX.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}}));
-    EXPECT_EQ(sliceX.get(Data::Value{})[0], index + 1.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[1], index + 2.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[2], index + 5.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[3], index + 6.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[4], index + 9.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[5], index + 10.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[6], index + 13.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[7], index + 14.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[8], index + 17.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[9], index + 18.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[10], index + 21.0);
-    EXPECT_EQ(sliceX.get(Data::Value{})[11], index + 22.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[0], index + 1.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[1], index + 2.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[2], index + 5.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[3], index + 6.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[4], index + 9.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[5], index + 10.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[6], index + 13.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[7], index + 14.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[8], index + 17.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[9], index + 18.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[10], index + 21.0);
+    EXPECT_EQ(sliceX.get(Data::Value)[11], index + 22.0);
   }
 
   for (const gsl::index index : {0, 1}) {
     Variable sliceY = parent(Dim::Y, index, index + 1);
     ASSERT_EQ(sliceY.dimensions(),
               Dimensions({{Dim::Z, 3}, {Dim::Y, 1}, {Dim::X, 4}}));
-    const auto &data = sliceY.get(Data::Value{});
+    const auto &data = sliceY.get(Data::Value);
     for (const gsl::index z : {0, 1, 2}) {
       EXPECT_EQ(data[4 * z + 0], 4 * index + 8 * z + 1.0);
       EXPECT_EQ(data[4 * z + 1], 4 * index + 8 * z + 2.0);
@@ -408,7 +408,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 1);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 1}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value{});
+    const auto &data = sliceZ.get(Data::Value);
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
   }
@@ -417,7 +417,7 @@ TEST(Variable, slice_range) {
     Variable sliceZ = parent(Dim::Z, index, index + 2);
     ASSERT_EQ(sliceZ.dimensions(),
               Dimensions({{Dim::Z, 2}, {Dim::Y, 2}, {Dim::X, 4}}));
-    const auto &data = sliceZ.get(Data::Value{});
+    const auto &data = sliceZ.get(Data::Value);
     for (gsl::index xy = 0; xy < 8; ++xy)
       EXPECT_EQ(data[xy], 1.0 + xy + 8 * index);
     for (gsl::index xy = 0; xy < 8; ++xy)
@@ -427,28 +427,28 @@ TEST(Variable, slice_range) {
 
 TEST(Variable, concatenate) {
   Dimensions dims(Dim::Tof, 1);
-  Variable a(Data::Value{}, dims, {1.0});
-  Variable b(Data::Value{}, dims, {2.0});
+  Variable a(Data::Value, dims, {1.0});
+  Variable b(Data::Value, dims, {2.0});
   a.setUnit(Unit::Id::Length);
   b.setUnit(Unit::Id::Length);
   auto ab = concatenate(a, b, Dim::Tof);
   ASSERT_EQ(ab.size(), 2);
   EXPECT_EQ(ab.unit(), Unit(Unit::Id::Length));
-  const auto &data = ab.get(Data::Value{});
+  const auto &data = ab.get(Data::Value);
   EXPECT_EQ(data[0], 1.0);
   EXPECT_EQ(data[1], 2.0);
   auto ba = concatenate(b, a, Dim::Tof);
   const auto abba = concatenate(ab, ba, Dim::Q);
   ASSERT_EQ(abba.size(), 4);
   EXPECT_EQ(abba.dimensions().count(), 2);
-  const auto &data2 = abba.get(Data::Value{});
+  const auto &data2 = abba.get(Data::Value);
   EXPECT_EQ(data2[0], 1.0);
   EXPECT_EQ(data2[1], 2.0);
   EXPECT_EQ(data2[2], 2.0);
   EXPECT_EQ(data2[3], 1.0);
   const auto ababbaba = concatenate(abba, abba, Dim::Tof);
   ASSERT_EQ(ababbaba.size(), 8);
-  const auto &data3 = ababbaba.get(Data::Value{});
+  const auto &data3 = ababbaba.get(Data::Value);
   EXPECT_EQ(data3[0], 1.0);
   EXPECT_EQ(data3[1], 2.0);
   EXPECT_EQ(data3[2], 1.0);
@@ -459,7 +459,7 @@ TEST(Variable, concatenate) {
   EXPECT_EQ(data3[7], 1.0);
   const auto abbaabba = concatenate(abba, abba, Dim::Q);
   ASSERT_EQ(abbaabba.size(), 8);
-  const auto &data4 = abbaabba.get(Data::Value{});
+  const auto &data4 = abbaabba.get(Data::Value);
   EXPECT_EQ(data4[0], 1.0);
   EXPECT_EQ(data4[1], 2.0);
   EXPECT_EQ(data4[2], 2.0);
@@ -471,22 +471,22 @@ TEST(Variable, concatenate) {
 }
 
 TEST(Variable, concatenate_volume_with_slice) {
-  Variable a(Data::Value{}, {Dim::X, 1}, {1.0});
+  Variable a(Data::Value, {Dim::X, 1}, {1.0});
   auto aa = concatenate(a, a, Dim::X);
   EXPECT_NO_THROW(concatenate(aa, a, Dim::X));
 }
 
 TEST(Variable, concatenate_slice_with_volume) {
-  Variable a(Data::Value{}, {Dim::X, 1}, {1.0});
+  Variable a(Data::Value, {Dim::X, 1}, {1.0});
   auto aa = concatenate(a, a, Dim::X);
   EXPECT_NO_THROW(concatenate(a, aa, Dim::X));
 }
 
 TEST(Variable, concatenate_fail) {
   Dimensions dims(Dim::Tof, 1);
-  Variable a(Data::Value{}, dims, {1.0});
-  Variable b(Data::Value{}, dims, {2.0});
-  Variable c(Data::Variance{}, dims, {2.0});
+  Variable a(Data::Value, dims, {1.0});
+  Variable b(Data::Value, dims, {2.0});
+  Variable c(Data::Variance, dims, {2.0});
   a.setName("data");
   EXPECT_THROW_MSG(concatenate(a, b, Dim::Tof), std::runtime_error,
                    "Cannot concatenate Variables: Names do not match.");
@@ -501,7 +501,7 @@ TEST(Variable, concatenate_fail) {
 
 TEST(Variable, concatenate_unit_fail) {
   Dimensions dims(Dim::X, 1);
-  Variable a(Data::Value{}, dims, {1.0});
+  Variable a(Data::Value, dims, {1.0});
   auto b(a);
   EXPECT_NO_THROW(concatenate(a, b, Dim::X));
   a.setUnit(Unit::Id::Length);
@@ -512,51 +512,51 @@ TEST(Variable, concatenate_unit_fail) {
 }
 
 TEST(Variable, rebin) {
-  Variable var(Data::Value{}, {Dim::X, 2}, {1.0, 2.0});
-  const Variable oldEdge(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
-  const Variable newEdge(Coord::X{}, {Dim::X, 2}, {1.0, 3.0});
+  Variable var(Data::Value, {Dim::X, 2}, {1.0, 2.0});
+  const Variable oldEdge(Coord::X, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  const Variable newEdge(Coord::X, {Dim::X, 2}, {1.0, 3.0});
   auto rebinned = rebin(var, oldEdge, newEdge);
   ASSERT_EQ(rebinned.dimensions().count(), 1);
   ASSERT_EQ(rebinned.dimensions().volume(), 1);
-  ASSERT_EQ(rebinned.get(Data::Value{}).size(), 1);
-  EXPECT_EQ(rebinned.get(Data::Value{})[0], 3.0);
+  ASSERT_EQ(rebinned.get(Data::Value).size(), 1);
+  EXPECT_EQ(rebinned.get(Data::Value)[0], 3.0);
 }
 
 TEST(Variable, sum) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto sumX = sum(var, Dim::X);
   ASSERT_EQ(sumX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(sumX.get(Data::Value{}), {3.0, 7.0}));
+  EXPECT_TRUE(equals(sumX.get(Data::Value), {3.0, 7.0}));
   auto sumY = sum(var, Dim::Y);
   ASSERT_EQ(sumY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(sumY.get(Data::Value{}), {4.0, 6.0}));
+  EXPECT_TRUE(equals(sumY.get(Data::Value), {4.0, 6.0}));
 }
 
 TEST(Variable, mean) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto meanX = mean(var, Dim::X);
   ASSERT_EQ(meanX.dimensions(), (Dimensions{Dim::Y, 2}));
-  EXPECT_TRUE(equals(meanX.get(Data::Value{}), {1.5, 3.5}));
+  EXPECT_TRUE(equals(meanX.get(Data::Value), {1.5, 3.5}));
   auto meanY = mean(var, Dim::Y);
   ASSERT_EQ(meanY.dimensions(), (Dimensions{Dim::X, 2}));
-  EXPECT_TRUE(equals(meanY.get(Data::Value{}), {2.0, 3.0}));
+  EXPECT_TRUE(equals(meanY.get(Data::Value), {2.0, 3.0}));
 }
 
 TEST(VariableSlice, full_const_view) {
-  const Variable var(Coord::X{}, {{Dim::X, 3}});
+  const Variable var(Coord::X, {{Dim::X, 3}});
   ConstVariableSlice view(var);
-  EXPECT_EQ(var.get(Coord::X{}).data(), view.get(Coord::X{}).data());
+  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
 }
 
 TEST(VariableSlice, full_mutable_view) {
-  Variable var(Coord::X{}, {{Dim::X, 3}});
+  Variable var(Coord::X, {{Dim::X, 3}});
   VariableSlice view(var);
-  EXPECT_EQ(var.get(Coord::X{}).data(), view.get(Coord::X{}).data());
-  EXPECT_EQ(var.get(Coord::X{}).data(), view.get(Coord::X{}).data());
+  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
+  EXPECT_EQ(var.get(Coord::X).data(), view.get(Coord::X).data());
 }
 
 TEST(VariableSlice, strides) {
-  Variable var(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
+  Variable var(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
   EXPECT_EQ(var(Dim::X, 0).strides(), (std::vector<gsl::index>{3}));
   EXPECT_EQ(var(Dim::X, 1).strides(), (std::vector<gsl::index>{3}));
   EXPECT_EQ(var(Dim::Y, 0).strides(), (std::vector<gsl::index>{1}));
@@ -573,25 +573,25 @@ TEST(VariableSlice, strides) {
   EXPECT_EQ(var(Dim::X, 0, 1)(Dim::Y, 0, 1).strides(),
             (std::vector<gsl::index>{3, 1}));
 
-  Variable var3D(Data::Value{}, {{Dim::Z, 4}, {Dim::Y, 3}, {Dim::X, 2}});
+  Variable var3D(Data::Value, {{Dim::Z, 4}, {Dim::Y, 3}, {Dim::X, 2}});
   EXPECT_EQ(var3D(Dim::X, 0, 1)(Dim::Z, 0, 1).strides(),
             (std::vector<gsl::index>{6, 2, 1}));
 }
 
 TEST(VariableSlice, get) {
-  const Variable var(Data::Value{}, {Dim::X, 3}, {1, 2, 3});
-  EXPECT_EQ(var(Dim::X, 1, 2).get(Data::Value{})[0], 2.0);
+  const Variable var(Data::Value, {Dim::X, 3}, {1, 2, 3});
+  EXPECT_EQ(var(Dim::X, 1, 2).get(Data::Value)[0], 2.0);
 }
 
 TEST(VariableSlice, slicing_does_not_transpose) {
-  Variable var(Data::Value{}, {{Dim::X, 3}, {Dim::Y, 3}});
+  Variable var(Data::Value, {{Dim::X, 3}, {Dim::Y, 3}});
   Dimensions expected{{Dim::X, 1}, {Dim::Y, 1}};
   EXPECT_EQ(var(Dim::X, 1, 2)(Dim::Y, 1, 2).dimensions(), expected);
   EXPECT_EQ(var(Dim::Y, 1, 2)(Dim::X, 1, 2).dimensions(), expected);
 }
 
 TEST(VariableSlice, minus_equals_failures) {
-  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   EXPECT_THROW_MSG(var -= var(Dim::X, 0, 1), std::runtime_error,
                    "Expected {{Dim::X, 2}, {Dim::Y, 2}} to contain {{Dim::X, "
@@ -599,10 +599,10 @@ TEST(VariableSlice, minus_equals_failures) {
 }
 
 TEST(VariableSlice, self_overlapping_view_operation) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var -= var(Dim::Y, 0);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   // This is the critical part: After subtracting for y=0 the view points to
@@ -613,11 +613,11 @@ TEST(VariableSlice, self_overlapping_view_operation) {
 }
 
 TEST(VariableSlice, minus_equals_slice_const_outer) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   const auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -630,11 +630,11 @@ TEST(VariableSlice, minus_equals_slice_const_outer) {
 }
 
 TEST(VariableSlice, minus_equals_slice_outer) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
   var -= copy(Dim::Y, 0);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 2.0);
@@ -647,11 +647,11 @@ TEST(VariableSlice, minus_equals_slice_outer) {
 }
 
 TEST(VariableSlice, minus_equals_slice_inner) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
   var -= copy(Dim::X, 0);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 1.0);
   EXPECT_EQ(data[2], 0.0);
@@ -664,11 +664,11 @@ TEST(VariableSlice, minus_equals_slice_inner) {
 }
 
 TEST(VariableSlice, minus_equals_slice_of_slice) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
   auto copy(var);
 
   var -= copy(Dim::X, 1)(Dim::Y, 1);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], -3.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -676,39 +676,39 @@ TEST(VariableSlice, minus_equals_slice_of_slice) {
 }
 
 TEST(VariableSlice, minus_equals_nontrivial_slices) {
-  Variable source(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}},
+  Variable source(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}},
                   {11.0, 12.0, 13.0, 21.0, 22.0, 23.0, 31.0, 32.0, 33.0});
   {
-    Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
+    Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 0, 2);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], -21.0);
     EXPECT_EQ(data[3], -22.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
+    Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 0, 2);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -12.0);
     EXPECT_EQ(data[1], -13.0);
     EXPECT_EQ(data[2], -22.0);
     EXPECT_EQ(data[3], -23.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
+    Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 0, 2)(Dim::Y, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -21.0);
     EXPECT_EQ(data[1], -22.0);
     EXPECT_EQ(data[2], -31.0);
     EXPECT_EQ(data[3], -32.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
+    Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
     target -= source(Dim::X, 1, 3)(Dim::Y, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -22.0);
     EXPECT_EQ(data[1], -23.0);
     EXPECT_EQ(data[2], -32.0);
@@ -717,10 +717,10 @@ TEST(VariableSlice, minus_equals_nontrivial_slices) {
 }
 
 TEST(VariableSlice, slice_inner_minus_equals) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::X, 0) -= var(Dim::X, 1);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], -1.0);
   EXPECT_EQ(data[1], 2.0);
   EXPECT_EQ(data[2], -1.0);
@@ -728,10 +728,10 @@ TEST(VariableSlice, slice_inner_minus_equals) {
 }
 
 TEST(VariableSlice, slice_outer_minus_equals) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   var(Dim::Y, 0) -= var(Dim::Y, 1);
-  const auto data = var.get(Data::Value{});
+  const auto data = var.get(Data::Value);
   EXPECT_EQ(data[0], -2.0);
   EXPECT_EQ(data[1], -2.0);
   EXPECT_EQ(data[2], 3.0);
@@ -740,11 +740,11 @@ TEST(VariableSlice, slice_outer_minus_equals) {
 
 TEST(VariableSlice, nontrivial_slice_minus_equals) {
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -756,11 +756,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source;
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -772,11 +772,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -788,11 +788,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                     {11.0, 12.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source;
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -807,11 +807,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals) {
 
 TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], -11.0);
     EXPECT_EQ(data[1], -12.0);
     EXPECT_EQ(data[2], 0.0);
@@ -823,11 +823,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], -11.0);
     EXPECT_EQ(data[2], -12.0);
@@ -839,11 +839,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -855,11 +855,11 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
     EXPECT_EQ(data[8], 0.0);
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
-    Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                     {666.0, 11.0, 12.0, 666.0, 21.0, 22.0});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3) -= source(Dim::X, 1, 3);
-    const auto data = target.get(Data::Value{});
+    const auto data = target.get(Data::Value);
     EXPECT_EQ(data[0], 0.0);
     EXPECT_EQ(data[1], 0.0);
     EXPECT_EQ(data[2], 0.0);
@@ -873,14 +873,14 @@ TEST(VariableSlice, nontrivial_slice_minus_equals_slice) {
 }
 
 TEST(VariableSlice, slice_minus_lower_dimensional) {
-  Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}});
-  Variable source(Data::Value{}, {Dim::X, 2}, {1.0, 2.0});
+  Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}});
+  Variable source(Data::Value, {Dim::X, 2}, {1.0, 2.0});
   EXPECT_EQ(target(Dim::Y, 1, 2).dimensions(),
             (Dimensions{{Dim::Y, 1}, {Dim::X, 2}}));
 
   target(Dim::Y, 1, 2) -= source;
 
-  const auto data = target.get(Data::Value{});
+  const auto data = target.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], -1.0);
@@ -888,97 +888,97 @@ TEST(VariableSlice, slice_minus_lower_dimensional) {
 }
 
 TEST(VariableSlice, variable_copy_from_slice) {
-  const Variable source(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}},
+  const Variable source(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}},
                         {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
   Variable target1(source(Dim::X, 0, 2)(Dim::Y, 0, 2));
   EXPECT_EQ(target1.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target1.get(Data::Value{}), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target1.get(Data::Value), {11, 12, 21, 22}));
 
   Variable target2(source(Dim::X, 1, 3)(Dim::Y, 0, 2));
   EXPECT_EQ(target2.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target2.get(Data::Value{}), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target2.get(Data::Value), {12, 13, 22, 23}));
 
   Variable target3(source(Dim::X, 0, 2)(Dim::Y, 1, 3));
   EXPECT_EQ(target3.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target3.get(Data::Value{}), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target3.get(Data::Value), {21, 22, 31, 32}));
 
   Variable target4(source(Dim::X, 1, 3)(Dim::Y, 1, 3));
   EXPECT_EQ(target4.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target4.get(Data::Value{}), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target4.get(Data::Value), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_assign_from_slice) {
-  Variable target(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
-  const Variable source(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}},
+  Variable target(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
+  const Variable source(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}},
                         {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
   target = source(Dim::X, 0, 2)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value{}), {11, 12, 21, 22}));
+  EXPECT_TRUE(equals(target.get(Data::Value), {11, 12, 21, 22}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 0, 2);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value{}), {12, 13, 22, 23}));
+  EXPECT_TRUE(equals(target.get(Data::Value), {12, 13, 22, 23}));
 
   target = source(Dim::X, 0, 2)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value{}), {21, 22, 31, 32}));
+  EXPECT_TRUE(equals(target.get(Data::Value), {21, 22, 31, 32}));
 
   target = source(Dim::X, 1, 3)(Dim::Y, 1, 3);
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value{}), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get(Data::Value), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, variable_self_assign_via_slice) {
-  Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}},
+  Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}},
                   {11, 12, 13, 21, 22, 23, 31, 32, 33});
 
   target = target(Dim::X, 1, 3)(Dim::Y, 1, 3);
   // Note: This test does not actually fail if self-assignment is broken. Had to
   // run address sanitizer to see that it is reading from free'ed memory.
   EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 2}, {Dim::X, 2}}));
-  EXPECT_TRUE(equals(target.get(Data::Value{}), {22, 23, 32, 33}));
+  EXPECT_TRUE(equals(target.get(Data::Value), {22, 23, 32, 33}));
 }
 
 TEST(VariableSlice, slice_assign_from_variable) {
-  const Variable source(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}},
+  const Variable source(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
                         {11, 12, 21, 22});
 
   // We might want to mimick Python's __setitem__, but operator= would (and
   // should!?) assign the view contents, not the data.
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
-        equals(target.get(Data::Value{}), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
+        equals(target.get(Data::Value), {11, 12, 0, 21, 22, 0, 0, 0, 0}));
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 0, 2).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
-        equals(target.get(Data::Value{}), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
+        equals(target.get(Data::Value), {0, 11, 12, 0, 21, 22, 0, 0, 0}));
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 0, 2)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
-        equals(target.get(Data::Value{}), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
+        equals(target.get(Data::Value), {0, 0, 0, 11, 12, 0, 21, 22, 0}));
   }
   {
-    Variable target(Data::Value{}, {{Dim::Y, 3}, {Dim::X, 3}});
+    Variable target(Data::Value, {{Dim::Y, 3}, {Dim::X, 3}});
     target(Dim::X, 1, 3)(Dim::Y, 1, 3).assign(source);
     EXPECT_EQ(target.dimensions(), (Dimensions{{Dim::Y, 3}, {Dim::X, 3}}));
     EXPECT_TRUE(
-        equals(target.get(Data::Value{}), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
+        equals(target.get(Data::Value), {0, 0, 0, 0, 11, 12, 0, 21, 22}));
   }
 }
 
 TEST(VariableSlice, slice_binary_operations) {
-  Variable v(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
+  Variable v(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
   // Note: There does not seem to be a way to test whether this is using the
   // operators that convert the second argument to Variable (it should not), or
   // keep it as a view. See variable_benchmark.cpp for an attempt to verify
@@ -987,33 +987,33 @@ TEST(VariableSlice, slice_binary_operations) {
   auto difference = v(Dim::X, 0) - v(Dim::X, 1);
   auto product = v(Dim::X, 0) * v(Dim::X, 1);
   auto ratio = v(Dim::X, 0) / v(Dim::X, 1);
-  EXPECT_TRUE(equals(sum.get(Data::Value{}), {3, 7}));
-  EXPECT_TRUE(equals(difference.get(Data::Value{}), {-1, -1}));
-  EXPECT_TRUE(equals(product.get(Data::Value{}), {2, 12}));
-  EXPECT_TRUE(equals(ratio.get(Data::Value{}), {1.0 / 2.0, 3.0 / 4.0}));
+  EXPECT_TRUE(equals(sum.get(Data::Value), {3, 7}));
+  EXPECT_TRUE(equals(difference.get(Data::Value), {-1, -1}));
+  EXPECT_TRUE(equals(product.get(Data::Value), {2, 12}));
+  EXPECT_TRUE(equals(ratio.get(Data::Value), {1.0 / 2.0, 3.0 / 4.0}));
 }
 
 TEST(Variable, reshape) {
-  const Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}},
+  const Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 3}},
                      {1, 2, 3, 4, 5, 6});
   auto view = var.reshape({Dim::Row, 6});
   ASSERT_EQ(view.size(), 6);
   ASSERT_EQ(view.dimensions(), Dimensions({Dim::Row, 6}));
-  EXPECT_TRUE(equals(view.get(Data::Value{}), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get(Data::Value), {1, 2, 3, 4, 5, 6}));
 
   auto view2 = var.reshape({{Dim::Row, 3}, {Dim::Z, 2}});
   ASSERT_EQ(view2.size(), 6);
   ASSERT_EQ(view2.dimensions(), Dimensions({{Dim::Row, 3}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(view2.get(Data::Value{}), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view2.get(Data::Value), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, reshape_temporary) {
-  const Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Row, 4}},
+  const Variable var(Data::Value, {{Dim::X, 2}, {Dim::Row, 4}},
                      {1, 2, 3, 4, 5, 6, 7, 8});
   auto reshaped = sum(var, Dim::X).reshape({{Dim::Y, 2}, {Dim::Z, 2}});
   ASSERT_EQ(reshaped.size(), 4);
   ASSERT_EQ(reshaped.dimensions(), Dimensions({{Dim::Y, 2}, {Dim::Z, 2}}));
-  EXPECT_TRUE(equals(reshaped.get(Data::Value{}), {6, 8, 10, 12}));
+  EXPECT_TRUE(equals(reshaped.get(Data::Value), {6, 8, 10, 12}));
 
   // This is not a temporary, we get a view into `var`.
   EXPECT_EQ(typeid(decltype(std::move(var).reshape({}))),
@@ -1021,18 +1021,18 @@ TEST(Variable, reshape_temporary) {
 }
 
 TEST(Variable, reshape_fail) {
-  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
   EXPECT_THROW_MSG(var.reshape({Dim::Row, 5}), std::runtime_error,
                    "Cannot reshape to dimensions with different volume");
 }
 
 TEST(Variable, reshape_and_slice) {
-  Variable var(Data::Value{}, {Dim::Spectrum, 16},
+  Variable var(Data::Value, {Dim::Spectrum, 16},
                {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
 
   auto slice =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3);
-  EXPECT_TRUE(equals(slice.get(Data::Value{}), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(slice.get(Data::Value), {6, 7, 10, 11}));
 
   Variable center =
       var.reshape({{Dim::X, 4}, {Dim::Y, 4}})(Dim::X, 1, 3)(Dim::Y, 1, 3)
@@ -1040,23 +1040,23 @@ TEST(Variable, reshape_and_slice) {
 
   ASSERT_EQ(center.size(), 4);
   ASSERT_EQ(center.dimensions(), Dimensions({Dim::Spectrum, 4}));
-  EXPECT_TRUE(equals(center.get(Data::Value{}), {6, 7, 10, 11}));
+  EXPECT_TRUE(equals(center.get(Data::Value), {6, 7, 10, 11}));
 }
 
 TEST(Variable, reshape_mutable) {
-  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
   const auto copy(var);
 
   auto view = var.reshape({Dim::Row, 6});
-  view.get(Data::Value{})[3] = 0;
+  view.get(Data::Value)[3] = 0;
 
-  EXPECT_TRUE(equals(view.get(Data::Value{}), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {1, 2, 3, 0, 5, 6}));
-  EXPECT_TRUE(equals(copy.get(Data::Value{}), {1, 2, 3, 4, 5, 6}));
+  EXPECT_TRUE(equals(view.get(Data::Value), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {1, 2, 3, 0, 5, 6}));
+  EXPECT_TRUE(equals(copy.get(Data::Value), {1, 2, 3, 4, 5, 6}));
 }
 
 TEST(Variable, access_typed_view) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}}, {1, 2, 3, 4, 5, 6});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}}, {1, 2, 3, 4, 5, 6});
   const auto values =
       getView<double>(var, {{Dim::Y, 2}, {Dim::Z, 4}, {Dim::X, 3}});
   ASSERT_EQ(values.size(), 24);
@@ -1076,7 +1076,7 @@ TEST(Variable, access_typed_view) {
 TEST(Variable, access_typed_view_edges) {
   // If a variable contains bin edges we want to "skip" the last edge. Say bins
   // is in direction Y:
-  Variable var(Data::Value{}, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
+  Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 3}}, {1, 2, 3, 4, 5, 6});
   const auto values =
       getView<double>(var, {{Dim::Y, 2}, {Dim::Z, 4}, {Dim::X, 2}});
   ASSERT_EQ(values.size(), 16);
@@ -1092,43 +1092,43 @@ TEST(Variable, access_typed_view_edges) {
 }
 
 TEST(Variable, non_in_place_scalar_operations) {
-  Variable var(Data::Value{}, {{Dim::X, 2}}, {1, 2});
+  Variable var(Data::Value, {{Dim::X, 2}}, {1, 2});
 
   auto sum = var + 1;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}), {2, 3}));
+  EXPECT_TRUE(equals(sum.get(Data::Value), {2, 3}));
   sum = 2 + var;
-  EXPECT_TRUE(equals(sum.get(Data::Value{}), {3, 4}));
+  EXPECT_TRUE(equals(sum.get(Data::Value), {3, 4}));
 
   auto diff = var - 1;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}), {0, 1}));
+  EXPECT_TRUE(equals(diff.get(Data::Value), {0, 1}));
   diff = 2 - var;
-  EXPECT_TRUE(equals(diff.get(Data::Value{}), {1, 0}));
+  EXPECT_TRUE(equals(diff.get(Data::Value), {1, 0}));
 
   auto prod = var * 2;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}), {2, 4}));
+  EXPECT_TRUE(equals(prod.get(Data::Value), {2, 4}));
   prod = 3 * var;
-  EXPECT_TRUE(equals(prod.get(Data::Value{}), {3, 6}));
+  EXPECT_TRUE(equals(prod.get(Data::Value), {3, 6}));
 
   auto ratio = var / 2;
-  EXPECT_TRUE(equals(ratio.get(Data::Value{}), {1.0 / 2.0, 1.0}));
+  EXPECT_TRUE(equals(ratio.get(Data::Value), {1.0 / 2.0, 1.0}));
   ratio = 3 / var;
-  EXPECT_TRUE(equals(ratio.get(Data::Value{}), {3.0, 1.5}));
+  EXPECT_TRUE(equals(ratio.get(Data::Value), {3.0, 1.5}));
 }
 
 TEST(VariableSlice, scalar_operations) {
-  Variable var(Data::Value{}, {{Dim::Y, 2}, {Dim::X, 3}},
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 3}},
                {11, 12, 13, 21, 22, 23});
 
   var(Dim::X, 0) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {12, 12, 13, 22, 22, 23}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 13, 22, 22, 23}));
   var(Dim::Y, 1) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {12, 12, 13, 23, 23, 24}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 13, 23, 23, 24}));
   var(Dim::X, 1, 3) += 1;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {12, 13, 14, 23, 24, 25}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {12, 13, 14, 23, 24, 25}));
   var(Dim::X, 1) -= 1;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {12, 12, 14, 23, 23, 25}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 14, 23, 23, 25}));
   var(Dim::X, 2) *= 0;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {12, 12, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {12, 12, 0, 23, 23, 0}));
   var(Dim::Y, 0) /= 2;
-  EXPECT_TRUE(equals(var.get(Data::Value{}), {6, 6, 0, 23, 23, 0}));
+  EXPECT_TRUE(equals(var.get(Data::Value), {6, 6, 0, 23, 23, 0}));
 }

--- a/test/zip_view_test.cpp
+++ b/test/zip_view_test.cpp
@@ -45,12 +45,12 @@ TEST(ZipView, push_back_1_variable) {
   d.insert(Coord::X{}, {Dim::X, 3});
   ZipView<Coord::X> view(d);
   view.push_back({1.1});
-  ASSERT_EQ(d.get<Coord::X>().size(), 4);
+  ASSERT_EQ(d.get(Coord::X{}).size(), 4);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
   view.push_back(2.2);
-  ASSERT_EQ(d.get<Coord::X>().size(), 5);
+  ASSERT_EQ(d.get(Coord::X{}).size(), 5);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  const auto data = d.get<Coord::X>();
+  const auto data = d.get(Coord::X{});
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 0.0);
@@ -64,18 +64,18 @@ TEST(ZipView, push_back_2_variables) {
   d.insert(Data::Value{}, "", {Dim::X, 2});
   ZipView<Coord::X, Data::Value> view(d);
   view.push_back({1.1, 1.2});
-  ASSERT_EQ(d.get<Coord::X>().size(), 3);
+  ASSERT_EQ(d.get(Coord::X{}).size(), 3);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 3);
   view.push_back({2.2, 2.3});
-  ASSERT_EQ(d.get<Coord::X>().size(), 4);
+  ASSERT_EQ(d.get(Coord::X{}).size(), 4);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
 
-  const auto coord = d.get<Coord::X>();
+  const auto coord = d.get(Coord::X{});
   EXPECT_EQ(coord[0], 0.0);
   EXPECT_EQ(coord[1], 0.0);
   EXPECT_EQ(coord[2], 1.1);
   EXPECT_EQ(coord[3], 2.2);
-  const auto data = d.get<Data::Value>();
+  const auto data = d.get(Data::Value{});
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 1.2);
@@ -96,18 +96,18 @@ TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
     return std::make_tuple(x, v);
   });
 
-  ASSERT_EQ(d.get<Coord::X>().size(), 5);
+  ASSERT_EQ(d.get(Coord::X{}).size(), 5);
   ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  ASSERT_EQ(d.get<Data::Value>().size(), 5);
+  ASSERT_EQ(d.get(Data::Value{}).size(), 5);
   ASSERT_EQ(d(Data::Value{}).dimensions().size(0), 5);
 
   rng = std::mt19937{};
-  for (const auto x : d.get<Coord::X>()) {
+  for (const auto x : d.get(Coord::X{})) {
     rng();
     EXPECT_EQ(x, rng());
   }
   rng = std::mt19937{};
-  for (const auto v : d.get<Data::Value>()) {
+  for (const auto v : d.get(Data::Value{})) {
     EXPECT_EQ(v, rng());
     rng();
   }
@@ -137,8 +137,8 @@ TEST(ZipView, iterator_modify) {
   for (auto item : view)
     std::get<1>(item) *= 2.0;
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.2, 4.2, 6.2}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.2, 4.2, 6.2}));
 }
 
 TEST(ZipView, iterator_copy) {
@@ -155,13 +155,13 @@ TEST(ZipView, iterator_copy) {
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<Data::Value>(), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
 
   std::copy(source_view.begin(), source_view.end(), view.begin() + 1);
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<Data::Value>(), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_copy_if) {
@@ -178,14 +178,14 @@ TEST(ZipView, iterator_copy_if) {
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.1, 3.1}));
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get<Data::Value>(), {2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_sort) {
@@ -200,5 +200,5 @@ TEST(ZipView, iterator_sort) {
     return std::get<0>(a) < std::get<0>(b);
   });
 
-  EXPECT_TRUE(equals(d.get<Coord::X>(), {0.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Coord::X{}), {0.0, 1.0, 2.0, 3.0}));
 }

--- a/test/zip_view_test.cpp
+++ b/test/zip_view_test.cpp
@@ -16,41 +16,45 @@
 TEST(ZipView, construct_fail) {
   Dataset d;
 
-  d.insert(Coord::X{}, {Dim::X, 3});
-  d.insert(Data::Value{}, "", {Dim::X, 3});
+  d.insert(Coord::X, {Dim::X, 3});
+  d.insert(Data::Value, "", {Dim::X, 3});
   EXPECT_THROW_MSG(
-      ZipView<Coord::X> view(d), std::runtime_error,
+      ZipView<std::remove_cv_t<decltype(Coord::X)>> view(d), std::runtime_error,
       "ZipView must be constructed based on *all* variables in a dataset.");
-  d.erase(Data::Value{});
+  d.erase(Data::Value);
 
-  d.insert(Data::Value{}, "", {});
-  EXPECT_THROW_MSG((ZipView<Coord::X, Data::Value>(d)), std::runtime_error,
+  d.insert(Data::Value, "", {});
+  EXPECT_THROW_MSG((ZipView<std::remove_cv_t<decltype(Coord::X)>,
+                            std::remove_cv_t<decltype(Data::Value)>>(d)),
+                   std::runtime_error,
                    "ZipView supports only datasets where all variables are "
                    "1-dimensional.");
-  d.erase(Data::Value{});
+  d.erase(Data::Value);
 
-  d.insert(Coord::Y{}, {Dim::Y, 3});
-  EXPECT_THROW_MSG((ZipView<Coord::X, Coord::Y>(d)), std::runtime_error,
+  d.insert(Coord::Y, {Dim::Y, 3});
+  EXPECT_THROW_MSG((ZipView<std::remove_cv_t<decltype(Coord::X)>,
+                            std::remove_cv_t<decltype(Coord::Y)>>(d)),
+                   std::runtime_error,
                    "ZipView supports only 1-dimensional datasets.");
 }
 
 TEST(ZipView, construct) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 3});
-  EXPECT_NO_THROW(ZipView<Coord::X> view(d));
+  d.insert(Coord::X, {Dim::X, 3});
+  EXPECT_NO_THROW(ZipView<std::remove_cv_t<decltype(Coord::X)>> view(d));
 }
 
 TEST(ZipView, push_back_1_variable) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 3});
-  ZipView<Coord::X> view(d);
+  d.insert(Coord::X, {Dim::X, 3});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>> view(d);
   view.push_back({1.1});
-  ASSERT_EQ(d.get(Coord::X{}).size(), 4);
-  ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
+  ASSERT_EQ(d.get(Coord::X).size(), 4);
+  ASSERT_EQ(d(Coord::X).dimensions().size(0), 4);
   view.push_back(2.2);
-  ASSERT_EQ(d.get(Coord::X{}).size(), 5);
-  ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  const auto data = d.get(Coord::X{});
+  ASSERT_EQ(d.get(Coord::X).size(), 5);
+  ASSERT_EQ(d(Coord::X).dimensions().size(0), 5);
+  const auto data = d.get(Coord::X);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 0.0);
@@ -60,22 +64,24 @@ TEST(ZipView, push_back_1_variable) {
 
 TEST(ZipView, push_back_2_variables) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 2});
-  d.insert(Data::Value{}, "", {Dim::X, 2});
-  ZipView<Coord::X, Data::Value> view(d);
+  d.insert(Coord::X, {Dim::X, 2});
+  d.insert(Data::Value, "", {Dim::X, 2});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      view(d);
   view.push_back({1.1, 1.2});
-  ASSERT_EQ(d.get(Coord::X{}).size(), 3);
-  ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 3);
+  ASSERT_EQ(d.get(Coord::X).size(), 3);
+  ASSERT_EQ(d(Coord::X).dimensions().size(0), 3);
   view.push_back({2.2, 2.3});
-  ASSERT_EQ(d.get(Coord::X{}).size(), 4);
-  ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 4);
+  ASSERT_EQ(d.get(Coord::X).size(), 4);
+  ASSERT_EQ(d(Coord::X).dimensions().size(0), 4);
 
-  const auto coord = d.get(Coord::X{});
+  const auto coord = d.get(Coord::X);
   EXPECT_EQ(coord[0], 0.0);
   EXPECT_EQ(coord[1], 0.0);
   EXPECT_EQ(coord[2], 1.1);
   EXPECT_EQ(coord[3], 2.2);
-  const auto data = d.get(Data::Value{});
+  const auto data = d.get(Data::Value);
   EXPECT_EQ(data[0], 0.0);
   EXPECT_EQ(data[1], 0.0);
   EXPECT_EQ(data[2], 1.2);
@@ -84,10 +90,12 @@ TEST(ZipView, push_back_2_variables) {
 
 TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 0});
-  d.insert(Data::Value{}, "", {Dim::X, 0});
+  d.insert(Coord::X, {Dim::X, 0});
+  d.insert(Data::Value, "", {Dim::X, 0});
 
-  ZipView<Coord::X, Data::Value> view(d);
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      view(d);
 
   std::mt19937 rng;
   std::generate_n(std::back_inserter(view), 5, [&] {
@@ -96,18 +104,18 @@ TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
     return std::make_tuple(x, v);
   });
 
-  ASSERT_EQ(d.get(Coord::X{}).size(), 5);
-  ASSERT_EQ(d(Coord::X{}).dimensions().size(0), 5);
-  ASSERT_EQ(d.get(Data::Value{}).size(), 5);
-  ASSERT_EQ(d(Data::Value{}).dimensions().size(0), 5);
+  ASSERT_EQ(d.get(Coord::X).size(), 5);
+  ASSERT_EQ(d(Coord::X).dimensions().size(0), 5);
+  ASSERT_EQ(d.get(Data::Value).size(), 5);
+  ASSERT_EQ(d(Data::Value).dimensions().size(0), 5);
 
   rng = std::mt19937{};
-  for (const auto x : d.get(Coord::X{})) {
+  for (const auto x : d.get(Coord::X)) {
     rng();
     EXPECT_EQ(x, rng());
   }
   rng = std::mt19937{};
-  for (const auto v : d.get(Data::Value{})) {
+  for (const auto v : d.get(Data::Value)) {
     EXPECT_EQ(v, rng());
     rng();
   }
@@ -115,8 +123,8 @@ TEST(ZipView, std_algorithm_generate_n_with_back_inserter) {
 
 TEST(ZipView, iterator_1_variable) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
-  ZipView<Coord::X> view(d);
+  d.insert(Coord::X, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>> view(d);
   EXPECT_EQ(std::distance(view.begin(), view.end()), 3);
   auto it = view.begin();
   EXPECT_EQ(std::get<0>(*it++), 1.0);
@@ -127,9 +135,11 @@ TEST(ZipView, iterator_1_variable) {
 
 TEST(ZipView, iterator_modify) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
-  d.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  ZipView<Coord::X, Data::Value> view(d);
+  d.insert(Coord::X, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  d.insert(Data::Value, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      view(d);
 
   // Note this peculiarity: `item` is returned by value but it is a proxy
   // object, i.e., it containts references that can be used to modify the
@@ -137,61 +147,69 @@ TEST(ZipView, iterator_modify) {
   for (auto item : view)
     std::get<1>(item) *= 2.0;
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.2, 4.2, 6.2}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value), {2.2, 4.2, 6.2}));
 }
 
 TEST(ZipView, iterator_copy) {
   Dataset source;
-  source.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
-  source.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  ZipView<Coord::X, Data::Value> source_view(source);
+  source.insert(Coord::X, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  source.insert(Data::Value, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      source_view(source);
 
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 0});
-  d.insert(Data::Value{}, "", {Dim::X, 0});
-  ZipView<Coord::X, Data::Value> view(d);
+  d.insert(Coord::X, {Dim::X, 0});
+  d.insert(Data::Value, "", {Dim::X, 0});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      view(d);
 
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
   std::copy(source_view.begin(), source_view.end(), std::back_inserter(view));
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {1.0, 2.0, 3.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value), {1.1, 2.1, 3.1, 1.1, 2.1, 3.1}));
 
   std::copy(source_view.begin(), source_view.end(), view.begin() + 1);
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {1.0, 1.0, 2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value), {1.1, 1.1, 2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_copy_if) {
   Dataset source;
-  source.insert(Coord::X{}, {Dim::X, 3}, {1.0, 2.0, 3.0});
-  source.insert(Data::Value{}, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
-  ZipView<Coord::X, Data::Value> source_view(source);
+  source.insert(Coord::X, {Dim::X, 3}, {1.0, 2.0, 3.0});
+  source.insert(Data::Value, "", {Dim::X, 3}, {1.1, 2.1, 3.1});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      source_view(source);
 
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 0});
-  d.insert(Data::Value{}, "", {Dim::X, 0});
-  ZipView<Coord::X, Data::Value> view(d);
+  d.insert(Coord::X, {Dim::X, 0});
+  d.insert(Data::Value, "", {Dim::X, 0});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>,
+          std::remove_cv_t<decltype(Data::Value)>>
+      view(d);
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value), {2.1, 3.1}));
 
   std::copy_if(source_view.begin(), source_view.end(), std::back_inserter(view),
                [](const auto &item) { return std::get<1>(item) > 2.0; });
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {2.0, 3.0, 2.0, 3.0}));
-  EXPECT_TRUE(equals(d.get(Data::Value{}), {2.1, 3.1, 2.1, 3.1}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {2.0, 3.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Data::Value), {2.1, 3.1, 2.1, 3.1}));
 }
 
 TEST(ZipView, iterator_sort) {
   Dataset d;
-  d.insert(Coord::X{}, {Dim::X, 4}, {3.0, 2.0, 1.0, 0.0});
-  ZipView<Coord::X> view(d);
+  d.insert(Coord::X, {Dim::X, 4}, {3.0, 2.0, 1.0, 0.0});
+  ZipView<std::remove_cv_t<decltype(Coord::X)>> view(d);
 
   // Note: Unlike other std algorithms, std::sort does not work with these
   // iterators, must use ranges::sort.
@@ -200,5 +218,5 @@ TEST(ZipView, iterator_sort) {
     return std::get<0>(a) < std::get<0>(b);
   });
 
-  EXPECT_TRUE(equals(d.get(Coord::X{}), {0.0, 1.0, 2.0, 3.0}));
+  EXPECT_TRUE(equals(d.get(Coord::X), {0.0, 1.0, 2.0, 3.0}));
 }


### PR DESCRIPTION
After the copy-on-write mechanism was removed we no longer require the distinction between `Tag` and `const Tag` (with exceptions, see `MDZipView`). To avoid a cluttered API with lots of `{}` we therefore change the tags to be passed by value. Methods like `Dataset::get` can then deduce the type from their argument instead of passing it as on explicit template argument.

The hope is that some follow-up refactoring will also be possible, in particular the Python exports (not so trivial, so this is left for another PR).

Unfortunately the changes here left `MDZipView` and in particular nested access in a very messy state. As mentioned previously this view needs a major refactor, so this should be seen as an intermediate state. I think it cannot be fixed quickly as part of this refactor.