### PR TITLE
Python exports: Start adding dtype support

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -125,7 +125,7 @@ void insertNamed(
   self.insert(std::move(var));
 }
 
-template <class Tag, class Var>
+template <class Var>
 void insert(Dataset &self, const std::pair<Tag, const std::string &> &key,
             const Var &var) {
   const auto &tag = std::get<Tag>(key);
@@ -133,8 +133,10 @@ void insert(Dataset &self, const std::pair<Tag, const std::string &> &key,
   if (self.contains(tag, name))
     if (self(tag, name) == var)
       return;
-  const auto &data = var.get(Tag{});
-  self.insert(Tag{}, name, var.dimensions(), data.begin(), data.end());
+  Variable copy(var);
+  copy.setTag(tag);
+  copy.setName(name);
+  self.insert(std::move(copy));
 }
 
 void insertDefaultInit(
@@ -531,10 +533,8 @@ PYBIND11_MODULE(dataset, m) {
       .def("__setitem__", detail::insertCoordT<double>)
       .def("__setitem__", detail::insertCoord1D<Coord::RowLabel_t>)
       .def("__setitem__", detail::insertNamed)
-      .def("__setitem__", detail::insert<Data::Value_t, Variable>)
-      .def("__setitem__", detail::insert<Data::Variance_t, Variable>)
-      .def("__setitem__", detail::insert<Data::Value_t, VariableSlice>)
-      .def("__setitem__", detail::insert<Data::Variance_t, VariableSlice>)
+      .def("__setitem__", detail::insert<Variable>)
+      .def("__setitem__", detail::insert<VariableSlice>)
       .def("__setitem__", detail::insertDefaultInit)
       // TODO Make sure we have all overloads covered to avoid implicit
       // conversion of DatasetSlice to Dataset.

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -228,11 +228,6 @@ VariableSlice pySlice(VariableSlice &view,
 
 template <class T> struct MakePyBufferInfoT {
   static py::buffer_info apply(VariableSlice &view) {
-    // Note: Currently this always triggers copy-on-write ---
-    // py::buffer_info does currently not support the `readonly` flag of
-    // the Python buffer protocol. We can probably get this fixed
-    // upstream, see discussion and sample implementation here:
-    // https://github.com/pybind/pybind11/issues/863.
     return py::buffer_info(
         view.template span<T>().data(),     /* Pointer to buffer */
         sizeof(T),                          /* Size of one scalar */

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -352,27 +352,19 @@ PYBIND11_MODULE(dataset, m) {
 
   py::class_<Tag>(m, "Tag").def(py::self == py::self);
 
+  // Runtime tags are sufficient in Python, not exporting Tag child classes.
   auto data_tags = m.def_submodule("Data");
-  py::class_<Data::Value_t, Tag>(data_tags, "_Value");
-  py::class_<Data::Variance_t, Tag>(data_tags, "_Variance");
-  data_tags.attr("Value") = Data::Value;
-  data_tags.attr("Variance") = Data::Variance;
+  data_tags.attr("Value") = Tag(Data::Value);
+  data_tags.attr("Variance") = Tag(Data::Variance);
 
   auto coord_tags = m.def_submodule("Coord");
-  py::class_<Coord::Mask_t, Tag>(coord_tags, "_Mask");
-  py::class_<Coord::X_t, Tag>(coord_tags, "_X");
-  py::class_<Coord::Y_t, Tag>(coord_tags, "_Y");
-  py::class_<Coord::Z_t, Tag>(coord_tags, "_Z");
-  py::class_<Coord::Tof_t, Tag>(coord_tags, "_Tof");
-  py::class_<Coord::RowLabel_t, Tag>(coord_tags, "_RowLabel");
-  py::class_<Coord::SpectrumNumber_t, Tag>(coord_tags, "_SpectrumNumber");
-  coord_tags.attr("Mask") = Coord::Mask;
-  coord_tags.attr("X") = Coord::X;
-  coord_tags.attr("Y") = Coord::Y;
-  coord_tags.attr("Z") = Coord::Z;
-  coord_tags.attr("Tof") = Coord::Tof;
-  coord_tags.attr("RowLabel") = Coord::RowLabel;
-  coord_tags.attr("SpectrumNumber") = Coord::SpectrumNumber;
+  coord_tags.attr("Mask") = Tag(Coord::Mask);
+  coord_tags.attr("X") = Tag(Coord::X);
+  coord_tags.attr("Y") = Tag(Coord::Y);
+  coord_tags.attr("Z") = Tag(Coord::Z);
+  coord_tags.attr("Tof") = Tag(Coord::Tof);
+  coord_tags.attr("RowLabel") = Tag(Coord::RowLabel);
+  coord_tags.attr("SpectrumNumber") = Tag(Coord::SpectrumNumber);
 
   declare_span<double>(m, "double");
   declare_span<float>(m, "float");

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -123,8 +123,8 @@ Variable makeVariableDefaultInit(const Tag tag, const std::vector<Dim> &labels,
 void insertCoord(
     Dataset &self, const Tag tag,
     const std::tuple<const std::vector<Dim> &, py::array &> &data) {
-  const auto dtypeTag = defaultDType(tag);
   const auto & [ labels, array ] = data;
+  const auto dtypeTag = convertDType(array.dtype());
   auto var = CallDType<double, float, int64_t, int32_t,
                        char>::apply<detail::MakeVariable>(dtypeTag, tag, labels,
                                                           array);
@@ -371,11 +371,14 @@ PYBIND11_MODULE(dataset, m) {
   coord_tags.attr("SpectrumNumber") = Coord::SpectrumNumber;
 
   declare_span<double>(m, "double");
+  declare_span<float>(m, "float");
   declare_span<const double>(m, "double_const");
   declare_span<const std::string>(m, "string_const");
   declare_span<const Dim>(m, "Dim_const");
 
   declare_VariableView<double>(m, "double");
+  declare_VariableView<float>(m, "float");
+  declare_VariableView<int64_t>(m, "int64");
   declare_VariableView<int32_t>(m, "int32");
   declare_VariableView<std::string>(m, "string");
   declare_VariableView<char>(m, "char");

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -456,8 +456,6 @@ PYBIND11_MODULE(dataset, m) {
                slice = slice(item.first, item.second);
              return slice;
            })
-      // TODO Make these using py::array instead of py::array_t, then cast based
-      // on tag?
       .def("__setitem__", &detail::setVariableSlice)
       .def("__setitem__", &detail::setVariableSliceRange)
       .def_property_readonly(

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -248,7 +248,7 @@ class TestDataset(unittest.TestCase):
 
     def test_rebin(self):
         dataset = Dataset()
-        dataset[Data.Value, "data"] = ([Dim.X], np.array(10*[1]))
+        dataset[Data.Value, "data"] = ([Dim.X], np.array(10*[1.0]))
         dataset[Coord.X] = ([Dim.X], np.arange(11.0))
         new_coord = Variable(Coord.X, [Dim.X], np.arange(0.0, 11, 2))
         dataset = rebin(dataset, new_coord)
@@ -281,8 +281,8 @@ class TestDatasetExamples(unittest.TestCase):
         table = Dataset()
         table[Coord.RowLabel] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
         self.assertSequenceEqual(table[Coord.RowLabel].data, ['a', 'bb', 'ccc', 'dddd'])
-        table[Data.Value, "col1"] = ([Dim.Row], [3,2,1,0])
-        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4))
+        table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
+        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
         self.assertEqual(len(table), 3)
 
         table[Data.Value, "sum"] = ([Dim.Row], (len(table[Coord.RowLabel]),))
@@ -322,8 +322,8 @@ class TestDatasetExamples(unittest.TestCase):
 
         # Add columns
         table[Coord.RowLabel] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
-        table[Data.Value, "col1"] = ([Dim.Row], [3,2,1,0])
-        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4))
+        table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
+        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
         table[Data.Value, "sum"] = ([Dim.Row], (4,))
 
         # Do something for each column (here: sum)
@@ -416,8 +416,8 @@ class TestDatasetExamples(unittest.TestCase):
         d[Coord.Tof] = ([Dim.Tof], np.arange(1000))
 
         # Add data with uncertainties
-        d[Data.Value, "sample1"] = ([Dim.Spectrum, Dim.Tof], np.random.poisson(size=100*1000).reshape([100, 1000]))
-        d[Data.Variance, "sample1"] = ([Dim.Spectrum, Dim.Tof], d[Data.Value, "sample1"].numpy)
+        d[Data.Value, "sample1"] = ([Dim.Spectrum, Dim.Tof], np.random.exponential(size=100*1000).reshape([100, 1000]))
+        d[Data.Variance, "sample1"] = d[Data.Value, "sample1"]
 
         # Create a mask and use it to extract some of the spectra
         select = Variable(Coord.Mask, [Dim.Spectrum], np.isin(d[Coord.SpectrumNumber], np.arange(10, 20)))

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -102,6 +102,16 @@ class TestDataset(unittest.TestCase):
         d[Data.Variance, "data2"] = d[Data.Value, "data1"]
         self.assertEqual(len(d), 3)
 
+    def test_set_data(self):
+        d = Dataset()
+        d[Data.Value, "data1"] = ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2))
+        self.assertEqual(d[Data.Value, "data1"].numpy.dtype, np.int64)
+        d[Data.Value, "data1"] = np.arange(24).reshape(4,3,2)
+        self.assertEqual(d[Data.Value, "data1"].numpy.dtype, np.int64)
+        # For existing items we do *not* change the dtype, but convert.
+        d[Data.Value, "data1"] = np.arange(24.0).reshape(4,3,2)
+        self.assertEqual(d[Data.Value, "data1"].numpy.dtype, np.int64)
+
     def test_dimensions(self):
         self.assertEqual(self.dataset.dimensions().size(Dim.X), 2)
         self.assertEqual(self.dataset.dimensions().size(Dim.Y), 3)

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -85,6 +85,23 @@ class TestDataset(unittest.TestCase):
         self.assertRaisesRegex(RuntimeError, "Cannot insert variable into Dataset: Dimensions do not match.",
                 d.__setitem__, (Data.Value, "data2"), ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,2,3)))
 
+    def test_insert_variable(self):
+        d = Dataset()
+        d[Data.Value, "data1"] = ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2))
+
+        var = Variable(Data.Value, [Dim.X], np.arange(2))
+        d[Data.Value, "data2"] = var
+        d[Data.Variance, "data2"] = var
+        self.assertEqual(len(d), 3)
+
+    def test_insert_variable_slice(self):
+        d = Dataset()
+        d[Data.Value, "data1"] = ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2))
+
+        d[Data.Value, "data2"] = d[Data.Value, "data1"]
+        d[Data.Variance, "data2"] = d[Data.Value, "data1"]
+        self.assertEqual(len(d), 3)
+
     def test_dimensions(self):
         self.assertEqual(self.dataset.dimensions().size(Dim.X), 2)
         self.assertEqual(self.dataset.dimensions().size(Dim.Y), 3)

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -249,8 +249,8 @@ class TestDataset(unittest.TestCase):
     def test_rebin(self):
         dataset = Dataset()
         dataset[Data.Value, "data"] = ([Dim.X], np.array(10*[1]))
-        dataset[Coord.X] = ([Dim.X], np.arange(11))
-        new_coord = Variable(Coord.X, [Dim.X], np.arange(0, 11, 2))
+        dataset[Coord.X] = ([Dim.X], np.arange(11.0))
+        new_coord = Variable(Coord.X, [Dim.X], np.arange(0.0, 11, 2))
         dataset = rebin(dataset, new_coord)
         np.testing.assert_array_equal(dataset[Data.Value, "data"].numpy, np.array(5*[2]))
         np.testing.assert_array_equal(dataset[Coord.X].numpy, np.arange(0, 11, 2))
@@ -374,7 +374,7 @@ class TestDatasetExamples(unittest.TestCase):
         d = Dataset()
 
         # Add bin-edge axis for X
-        d[Coord.X] = ([Dim.X], np.arange(L+1))
+        d[Coord.X] = ([Dim.X], np.arange(L+1).astype(np.float64))
         # ... and normal axes for Y and Z
         d[Coord.Y] = ([Dim.Y], np.arange(L))
         d[Coord.Z] = ([Dim.Z], np.arange(L))
@@ -389,9 +389,9 @@ class TestDatasetExamples(unittest.TestCase):
         square = d * d
 
         # Rebin the X axis
-        d = rebin(d, Variable(Coord.X, [Dim.X], np.arange(0, L+1, 2)))
+        d = rebin(d, Variable(Coord.X, [Dim.X], np.arange(0, L+1, 2).astype(np.float64)))
         # Rebin to different axis for every y
-        rebinned = rebin(d, Variable(Coord.X, [Dim.Y, Dim.X], np.arange(0, 2*L).reshape([L,2])))
+        rebinned = rebin(d, Variable(Coord.X, [Dim.Y, Dim.X], np.arange(0, 2*L).reshape([L,2]).astype(np.float64)))
 
         # Do something with numpy and insert result
         d[Data.Value, "dz(p)"] = ([Dim.Z, Dim.Y, Dim.X], np.gradient(d[Data.Value, "pressure"], d[Coord.Z], axis=0))

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -7,10 +7,20 @@ class TestVariable(unittest.TestCase):
     def test_create_coord(self):
         var = Variable(Coord.X, [Dim.X], np.arange(4))
         self.assertEqual(var.name, "")
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
+        np.testing.assert_array_equal(var.numpy, np.arange(4))
+
+    def test_create_coord_different_default_dtype(self):
+        var = Variable(Coord.Mask, [Dim.X], np.arange(4))
+        self.assertEqual(var.name, "")
+        self.assertEqual(var.numpy.dtype, np.dtype(np.int8))
+        np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_data(self):
         var = Variable(Data.Value, [Dim.X], np.arange(4))
         self.assertEqual(var.name, "")
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
+        np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_default_init(self):
         var = Variable(Coord.X, [Dim.X], (4,))

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -5,19 +5,19 @@ import numpy as np
 
 class TestVariable(unittest.TestCase):
     def test_create_coord(self):
-        var = Variable(Coord.X, [Dim.X], np.arange(4))
+        var = Variable(Coord.X, [Dim.X], np.arange(4.0))
         self.assertEqual(var.name, "")
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         np.testing.assert_array_equal(var.numpy, np.arange(4))
 
     def test_create_coord_different_default_dtype(self):
-        var = Variable(Coord.Mask, [Dim.X], np.arange(4))
+        var = Variable(Coord.Mask, [Dim.X], np.array([True, False, True, False]))
         self.assertEqual(var.name, "")
-        self.assertEqual(var.numpy.dtype, np.dtype(np.int8))
-        np.testing.assert_array_equal(var.numpy, np.arange(4))
+        self.assertEqual(var.numpy.dtype, np.dtype(np.bool))
+        np.testing.assert_array_equal(var.numpy, np.array([True, False, True, False]))
 
     def test_create_data(self):
-        var = Variable(Data.Value, [Dim.X], np.arange(4))
+        var = Variable(Data.Value, [Dim.X], np.arange(4.0))
         self.assertEqual(var.name, "")
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         np.testing.assert_array_equal(var.numpy, np.arange(4))
@@ -27,6 +27,13 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(var.name, "")
 
     def test_create_dtype(self):
+        print("start")
+        var = Variable(Coord.X, [Dim.X], np.arange(4))
+        var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.int32))
+        var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.float64))
+        var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.float32))
+        #var = Variable(Coord.X, [Dim.X], ['a', 'bb', 'ccc', 'dddd'])
+        print("end")
         var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float64))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float32))

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -12,6 +12,20 @@ class TestVariable(unittest.TestCase):
         var = Variable(Data.Value, [Dim.X], np.arange(4))
         self.assertEqual(var.name, "")
 
+    def test_create_default_init(self):
+        var = Variable(Coord.X, [Dim.X], (4,))
+        self.assertEqual(var.name, "")
+
+    def test_create_dtype(self):
+        var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float64))
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
+        var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float32))
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float32))
+        var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.int64))
+        self.assertEqual(var.numpy.dtype, np.dtype(np.int64))
+        var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.int32))
+        self.assertEqual(var.numpy.dtype, np.dtype(np.int32))
+
     def test_coord_set_name_fails(self):
         var = Variable(Coord.X, [Dim.X], np.arange(4))
         with self.assertRaises(RuntimeError):

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -512,7 +512,7 @@ Dataset operator+(Dataset a, const double b) { return std::move(a += b); }
 Dataset operator-(Dataset a, const double b) { return std::move(a -= b); }
 Dataset operator*(Dataset a, const double b) { return std::move(a *= b); }
 Dataset operator+(const double a, Dataset b) { return std::move(b += a); }
-Dataset operator-(const double a, Dataset b) { return std::move(-(b -= a)); }
+Dataset operator-(const double a, Dataset b) { return -(b -= a); }
 Dataset operator*(const double a, Dataset b) { return std::move(b *= a); }
 
 std::vector<Dataset> split(const Dataset &d, const Dim dim,

--- a/src/tags.h
+++ b/src/tags.h
@@ -19,6 +19,15 @@
 #include "unit.h"
 #include "value_with_delta.h"
 
+enum class DType { Unknown, Double, Float, Int32, Int64, String, Char };
+template <class T> constexpr DType dtype = DType::Unknown;
+template <> constexpr DType dtype<double> = DType::Double;
+template <> constexpr DType dtype<float> = DType::Float;
+template <> constexpr DType dtype<int32_t> = DType::Int32;
+template <> constexpr DType dtype<int64_t> = DType::Int64;
+template <> constexpr DType dtype<std::string> = DType::String;
+template <> constexpr DType dtype<char> = DType::Char;
+
 // Adding new tags
 // ===============
 //
@@ -378,9 +387,23 @@ constexpr std::array<Unit::Id, std::tuple_size<detail::Tags>::value>
 make_unit_table(const std::tuple<Ts...> &) {
   return {Ts::unit...};
 }
+template <class... Ts>
+constexpr std::array<DType, std::tuple_size<detail::Tags>::value>
+make_dtype_table(const std::tuple<Ts...> &) {
+  return {dtype<typename Ts::type>...};
+}
 constexpr auto unit_table = make_unit_table(detail::Tags{});
+constexpr auto dtype_table = make_dtype_table(detail::Tags{});
 } // namespace detail
-constexpr auto unit(const Tag tag) { return detail::unit_table[tag.value()]; }
+
+/// Return the default unit for a runtime tag.
+constexpr auto defaultUnit(const Tag tag) {
+  return detail::unit_table[tag.value()];
+}
+/// Return the default dtype for a runtime tag.
+constexpr auto defaultDType(const Tag tag) {
+  return detail::dtype_table[tag.value()];
+}
 
 class DataBin {
 public:
@@ -423,14 +446,5 @@ struct element_return_type<D, MDZipViewImpl<D, Tags...>> {
 
 template <class D, class Tag>
 using element_return_type_t = typename element_return_type<D, Tag>::type;
-
-enum class DType { Unknown, Double, Float, Int32, Int64, String, Char };
-template <class T> constexpr DType dtype = DType::Unknown;
-template <> constexpr DType dtype<double> = DType::Double;
-template <> constexpr DType dtype<float> = DType::Float;
-template <> constexpr DType dtype<int32_t> = DType::Int32;
-template <> constexpr DType dtype<int64_t> = DType::Int64;
-template <> constexpr DType dtype<std::string> = DType::String;
-template <> constexpr DType dtype<char> = DType::Char;
 
 #endif // TAGS_H

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1069,7 +1069,7 @@ Variable operator-(Variable a, const double b) { return std::move(a -= b); }
 Variable operator*(Variable a, const double b) { return std::move(a *= b); }
 Variable operator/(Variable a, const double b) { return std::move(a /= b); }
 Variable operator+(const double a, Variable b) { return std::move(b += a); }
-Variable operator-(const double a, Variable b) { return std::move(-(b -= a)); }
+Variable operator-(const double a, Variable b) { return -(b -= a); }
 Variable operator*(const double a, Variable b) { return std::move(b *= a); }
 Variable operator/(const double a, Variable b) {
   b.setUnit(Unit::Id::Dimensionless / b.unit());

--- a/src/variable.h
+++ b/src/variable.h
@@ -466,7 +466,7 @@ public:
     return this->template cast<typename TagT::type>();
   }
 
-  template <class T> auto span() { return cast<T>(); }
+  template <class T> auto span() const { return cast<T>(); }
 
   // Note: We want to support things like `var(Dim::X, 0) += var2`, i.e., when
   // the left-hand-side is a temporary. This is ok since data is modified in

--- a/src/variable.h
+++ b/src/variable.h
@@ -213,6 +213,7 @@ public:
 
   DType dtype() const noexcept { return data().dtype(); }
   Tag tag() const { return m_tag; }
+  void setTag(const Tag tag) { m_tag = tag; }
   bool isCoord() const {
     return m_tag < std::tuple_size<detail::CoordDef::tags>::value;
   }

--- a/src/variable.h
+++ b/src/variable.h
@@ -294,6 +294,12 @@ Variable makeVariable(Tag tag, const Dimensions &dimensions,
                   Vector<T>(values.begin(), values.end()));
 }
 
+template <class T, class... Args>
+Variable makeVariable(Tag tag, const Dimensions &dimensions, Args &&... args) {
+  return Variable(tag, defaultUnit(tag), std::move(dimensions),
+                  Vector<T>(std::forward<Args>(args)...));
+}
+
 /// Non-mutable view into (a subset of) a Variable.
 class ConstVariableSlice {
 public:

--- a/src/variable.h
+++ b/src/variable.h
@@ -283,14 +283,14 @@ private:
 
 template <class T>
 Variable makeVariable(Tag tag, const Dimensions &dimensions) {
-  return Variable(tag, unit(tag), std::move(dimensions),
+  return Variable(tag, defaultUnit(tag), std::move(dimensions),
                   Vector<T>(dimensions.volume()));
 }
 
 template <class T, class T2>
 Variable makeVariable(Tag tag, const Dimensions &dimensions,
                       std::initializer_list<T2> values) {
-  return Variable(tag, unit(tag), std::move(dimensions),
+  return Variable(tag, defaultUnit(tag), std::move(dimensions),
                   Vector<T>(values.begin(), values.end()));
 }
 


### PR DESCRIPTION
This is an attempt to partially cleanup the exports while adding `dtype` support.

Note the long chain of `__setitem__` overloads. Actually we may require even more. I am not sure there is another way to do this?

Not all code is as unified as I would like, with a fair bit of near-duplication. I would like to clean this up more, but there is no quick solution I think.