### PR TITLE
Switch default backend on osx for matplotlib

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,2 +1,8 @@
 from .dataset import *
 from .xarray_compat import as_xarray
+# Following fix for problem described here https://stackoverflow.com/questions/21784641/installation-issue-with-matplotlib-python
+import platform
+if platform.system() == 'Darwin':
+    import matplotlib
+    # Switch backends
+    matplotlib.use('TkAgg')


### PR DESCRIPTION
- Pip installing matplotlib is nice and works mostly well cross platform
- This prevents the need to modify the test files themselves, sets default backend