### PR TITLE
Event list proxy

### DIFF
--- a/src/event_list_proxy.h
+++ b/src/event_list_proxy.h
@@ -41,8 +41,10 @@ public:
       const Dataset *d(m_dataset);
       return ranges::view::zip(d->get(Data::Tof), d->get(Data::PulseTime));
     }
-    return ranges::view::zip(gsl::make_span(*m_tofs),
-                             gsl::make_span(*m_pulseTimes));
+    return ranges::view::zip(
+        gsl::make_span(m_tofs->data(), m_tofs->data() + m_tofs->size()),
+        gsl::make_span(m_pulseTimes->data(),
+                       m_pulseTimes->data() + m_tofs->size()));
   }
 
 private:

--- a/src/event_list_proxy.h
+++ b/src/event_list_proxy.h
@@ -29,15 +29,20 @@ public:
   // want to support read-only access if only a subset of all fields is
   // requested, e.g., for reading only TOF, without need to know whether also
   // pulse-times or weights are present.
-  template <class... Tags> ZipView<Tags...> get(const Tags... tags) const {
+  template <class... Tags>
+  ZipView<Tags...> getMutable(const Tags... tags) const {
     return ZipView<Tags...>(*m_dataset);
   }
 
-  auto get2() const {
-    if (m_dataset)
-      throw std::runtime_error(
-          "TODO implement get for Data::Events storage format");
-    return ranges::view::zip(*m_tofs, *m_pulseTimes);
+  // TODO This should be template/overloaded for different field combination,
+  // e.g., Tof-only, with weights, ...
+  auto get() const {
+    if (m_dataset) {
+      const Dataset *d(m_dataset);
+      return ranges::view::zip(d->get(Data::Tof), d->get(Data::PulseTime));
+    }
+    return ranges::view::zip(gsl::make_span(*m_tofs),
+                             gsl::make_span(*m_pulseTimes));
   }
 
 private:

--- a/src/event_list_proxy.h
+++ b/src/event_list_proxy.h
@@ -1,0 +1,30 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#ifndef EVENT_LIST_PROXY_H
+#define EVENT_LIST_PROXY_H
+
+#include "dataset.h"
+#include "zip_view.h"
+
+// Need also ConstEventListProxy?
+class EventListProxy {
+public:
+  EventListProxy(Dataset &dataset) : m_dataset(&dataset) {}
+
+  // TODO Either ZipView must be generalized, or we need to use a different view
+  // type here, once we support another event storage format. Furthermore, we
+  // want to support read-only access if only a subset of all fields is
+  // requested, e.g., for reading only TOF, without need to know whether also
+  // pulse-times or weights are present.
+  template <class... Tags> ZipView<Tags...> get(const Tags... tags) const {
+    return ZipView<Tags...>(*m_dataset);
+  }
+
+private:
+  Dataset *m_dataset;
+};
+
+#endif // EVENT_LIST_PROXY_H

--- a/src/event_list_proxy.h
+++ b/src/event_list_proxy.h
@@ -6,13 +6,23 @@
 #ifndef EVENT_LIST_PROXY_H
 #define EVENT_LIST_PROXY_H
 
+#include "range/v3/view/zip.hpp"
+
 #include "dataset.h"
 #include "zip_view.h"
 
-// Need also ConstEventListProxy?
+// TODO Rename to ConstEventListProxy and add EventListProxy, inheriting from
+// ConstEventListProxy.
 class EventListProxy {
 public:
+  // TODO Fix ZipView to work with const Dataset, or use something else here.
   EventListProxy(Dataset &dataset) : m_dataset(&dataset) {}
+  EventListProxy(const typename Data::EventTofs_t::type &tofs,
+                 const typename Data::EventPulseTimes_t::type &pulseTimes)
+      : m_tofs(&tofs), m_pulseTimes(&pulseTimes) {
+    if (tofs.size() != pulseTimes.size())
+      throw std::runtime_error("Size mismatch for fields of event list.");
+  }
 
   // TODO Either ZipView must be generalized, or we need to use a different view
   // type here, once we support another event storage format. Furthermore, we
@@ -23,8 +33,17 @@ public:
     return ZipView<Tags...>(*m_dataset);
   }
 
+  auto get2() const {
+    if (m_dataset)
+      throw std::runtime_error(
+          "TODO implement get for Data::Events storage format");
+    return ranges::view::zip(*m_tofs, *m_pulseTimes);
+  }
+
 private:
-  Dataset *m_dataset;
+  Dataset *m_dataset{nullptr};
+  const typename Data::EventTofs_t::type *m_tofs{nullptr};
+  const typename Data::EventPulseTimes_t::type *m_pulseTimes{nullptr};
 };
 
 #endif // EVENT_LIST_PROXY_H

--- a/src/md_zip_view.h
+++ b/src/md_zip_view.h
@@ -430,8 +430,8 @@ template <class D> struct UnitHelper<D, Data::Events_t> {
                   const std::string &name = std::string{}) {
     static_cast<void>(name);
     if (dataset.contains(Data::Events))
-      return dataset(Data::Events).unit();
-    return Unit::Id::Dimensionless;
+      return dataset.get(Data::Events)[0](Data::Tof).unit();
+    return dataset(Data::EventTofs).unit();
   }
 };
 

--- a/src/md_zip_view.h
+++ b/src/md_zip_view.h
@@ -87,16 +87,19 @@ template <class D, class Tag> struct ref_type<D, Bin<Tag>> {
 // we can probably refactor a lot of the helpers to be constexpr based on the
 // value, rather then using detail::value_type_t, etc.
 template <class D>
-struct ref_type<D, const std::remove_cv_t<decltype(Coord::Position)>> {
-  using type = std::pair<gsl::span<const typename std::remove_cv_t<decltype(
-                             Coord::Position)>::type>,
-                         gsl::span<const typename std::remove_cv_t<decltype(
-                             Coord::DetectorGrouping)>::type>>;
+struct ref_type<D, const Coord::Position_t> {
+  using type =
+      std::pair<gsl::span<const typename Coord::Position_t::type>,
+                gsl::span<const typename Coord::DetectorGrouping_t::type>>;
 };
 template <class D>
-struct ref_type<D, std::remove_cv_t<decltype(Data::StdDev)>> {
-  using type =
-      typename ref_type<D, std::remove_cv_t<decltype(Data::Variance)>>::type;
+struct ref_type<D, Data::Events_t> {
+  // TODO To add support for another event storage format, add more elements to
+  // the tuple, see similar technique used for Coord::Position.
+  using type = std::tuple<gsl::span<typename Data::Events_t::type>>;
+};
+template <class D> struct ref_type<D, Data::StdDev_t> {
+  using type = typename ref_type<D, Data::Variance_t>::type;
 };
 template <class D, class... Tags>
 struct ref_type<D, MDZipViewImpl<D, Tags...>> {
@@ -129,13 +132,9 @@ template <class D, class Tag> struct ItemHelper {
 
 // Note: Special case! Coord::Position can be either derived based on detectors,
 // or stored directly.
-template <class D>
-struct ItemHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
-  static element_return_type_t<
-      D, const std::remove_cv_t<decltype(Coord::Position)>>
-  get(const ref_type_t<D, const std::remove_cv_t<decltype(Coord::Position)>>
-          &data,
-      gsl::index index) {
+template <class D> struct ItemHelper<D, const Coord::Position_t> {
+  static element_return_type_t<D, const Coord::Position_t>
+  get(const ref_type_t<D, const Coord::Position_t> &data, gsl::index index) {
     if (data.second.empty())
       return data.first[index];
     if (data.second[index].empty())
@@ -145,6 +144,13 @@ struct ItemHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
     for (const auto det : data.second[index])
       position += data.first[det];
     return position /= static_cast<double>(data.second[index].size());
+  }
+};
+
+template <class D> struct ItemHelper<D, Data::Events_t> {
+  static element_return_type_t<D, Data::Events_t>
+  get(const ref_type_t<D, Data::Events_t> &data, gsl::index index) {
+    return {std::get<0>(data)[index]};
   }
 };
 
@@ -404,14 +410,23 @@ template <class D, class Tag> struct UnitHelper<D, Bin<Tag>> {
   }
 };
 
-template <class D>
-struct UnitHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
+template <class D> struct UnitHelper<D, const Coord::Position_t> {
   static Unit get(const Dataset &dataset,
                   const std::string &name = std::string{}) {
     static_cast<void>(name);
     if (dataset.contains(Coord::Position))
       return dataset(Coord::Position).unit();
     return dataset.get(Coord::DetectorInfo)[0](Coord::Position).unit();
+  }
+};
+
+template <class D> struct UnitHelper<D, Data::Events_t> {
+  static Unit get(const Dataset &dataset,
+                  const std::string &name = std::string{}) {
+    static_cast<void>(name);
+    if (dataset.contains(Data::Events))
+      return dataset(Data::Events).unit();
+    return Unit::Id::Dimensionless;
   }
 };
 
@@ -455,8 +470,7 @@ template <class D, class Tag> struct DimensionHelper<D, Bin<Tag>> {
   }
 };
 
-template <class D>
-struct DimensionHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
+template <class D> struct DimensionHelper<D, const Coord::Position_t> {
   static Dimensions get(const Dataset &dataset,
                         const std::set<Dim> &fixedDimensions,
                         const std::string &name = std::string{}) {
@@ -467,6 +481,19 @@ struct DimensionHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
     // Note: We do *not* return the dimensions of the nested positions in
     // Coord::DetectorInfo since those are not dimensions of the dataset.
     return dataset(Coord::DetectorGrouping).dimensions();
+  }
+};
+
+template <class D> struct DimensionHelper<D, Data::Events_t> {
+  static Dimensions get(const Dataset &dataset,
+                        const std::set<Dim> &fixedDimensions,
+                        const std::string &name = std::string{}) {
+    static_cast<void>(fixedDimensions);
+    static_cast<void>(name);
+    if (dataset.contains(Data::Events))
+      return dataset(Data::Events).dimensions();
+    throw std::runtime_error(
+        "not implemented yet, need to look for Data::EventTofs or similar");
   }
 };
 
@@ -551,8 +578,7 @@ template <class D, class Tag> struct DataHelper<D, Bin<Tag>> {
   }
 };
 
-template <class D>
-struct DataHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
+template <class D> struct DataHelper<D, const Coord::Position_t> {
   static auto get(const Dataset &dataset, const Dimensions &,
                   const std::string &name = std::string{}) {
     static_cast<void>(name);
@@ -560,17 +586,24 @@ struct DataHelper<D, const std::remove_cv_t<decltype(Coord::Position)>> {
     // Coord::DetectorGrouping/Coord::DetectorInfo. We should never have both, I
     // think.
     if (dataset.contains(Coord::Position))
-      return ref_type_t<D, const std::remove_cv_t<decltype(Coord::Position)>>(
-          dataset.get(detail::value_type_t<
-                      std::remove_cv_t<decltype(Coord::Position)>>{}),
-          gsl::span<const typename std::remove_cv_t<decltype(
-              Coord::DetectorGrouping)>::type>{});
+      return ref_type_t<D, const Coord::Position_t>(
+          dataset.get(detail::value_type_t<Coord::Position_t>{}),
+          gsl::span<const typename Coord::DetectorGrouping_t::type>{});
     const auto &detInfo = dataset.get(Coord::DetectorInfo)[0];
-    return ref_type_t<D, const std::remove_cv_t<decltype(Coord::Position)>>(
-        detInfo.get(detail::value_type_t<
-                    std::remove_cv_t<decltype(Coord::Position)>>{}),
-        dataset.get(detail::value_type_t<
-                    std::remove_cv_t<decltype(Coord::DetectorGrouping)>>{}));
+    return ref_type_t<D, const Coord::Position_t>(
+        detInfo.get(detail::value_type_t<Coord::Position_t>{}),
+        dataset.get(detail::value_type_t<Coord::DetectorGrouping_t>{}));
+  }
+};
+
+template <class D> struct DataHelper<D, Data::Events_t> {
+  static auto get(Dataset &dataset, const Dimensions &,
+                  const std::string &name = std::string{}) {
+    static_cast<void>(name);
+    if (dataset.contains(Data::Events))
+      return ref_type_t<D, Data::Events_t>(
+          dataset.get(detail::value_type_t<Data::Events_t>{}));
+    throw std::runtime_error("TODO no events found, implement other options");
   }
 };
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -210,13 +210,22 @@ struct DataDef {
     using type = Dataset;
     static constexpr auto unit = Unit::Id::Dimensionless;
   };
+  struct EventTofs {
+    using type = boost::container::small_vector<double, 8>;
+    static constexpr auto unit = Unit::Id::Dimensionless;
+  };
+  struct EventPulseTimes {
+    using type = boost::container::small_vector<double, 8>;
+    static constexpr auto unit = Unit::Id::Dimensionless;
+  };
   struct Table {
     using type = Dataset;
     static constexpr auto unit = Unit::Id::Dimensionless;
   };
 
-  using tags = std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int,
-                          DimensionSize, String, Events, Table>;
+  using tags =
+      std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, DimensionSize,
+                 String, Events, EventTofs, EventPulseTimes, Table>;
 };
 
 struct AttrDef {
@@ -301,6 +310,8 @@ struct Data {
   using DimensionSize_t = detail::TagImpl<detail::DataDef::DimensionSize>;
   using String_t = detail::TagImpl<detail::DataDef::String>;
   using Events_t = detail::TagImpl<detail::DataDef::Events>;
+  using EventTofs_t = detail::TagImpl<detail::DataDef::EventTofs>;
+  using EventPulseTimes_t = detail::TagImpl<detail::DataDef::EventPulseTimes>;
   using Table_t = detail::TagImpl<detail::DataDef::Table>;
 
   static constexpr Tof_t Tof{};
@@ -312,6 +323,8 @@ struct Data {
   static constexpr DimensionSize_t DimensionSize{};
   static constexpr String_t String{};
   static constexpr Events_t Events{};
+  static constexpr EventTofs_t EventTofs{};
+  static constexpr EventPulseTimes_t EventPulseTimes{};
   static constexpr Table_t Table{};
 };
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -415,6 +415,11 @@ template <class D, class Tags> struct element_return_type<D, Bin<Tags>> {
   using type = DataBin;
 };
 
+class EventListProxy;
+template <class D> struct element_return_type<D, Data::Events_t> {
+  using type = EventListProxy;
+};
+
 template <class D, class... Ts> class MDZipViewImpl;
 template <class D, class... Tags>
 struct element_return_type<D, MDZipViewImpl<D, Tags...>> {

--- a/src/traits.h
+++ b/src/traits.h
@@ -33,11 +33,6 @@ template <class T> struct is_const<const T> : std::true_type {};
 
 template <class D, class... Ts>
 struct is_const<MDZipViewImpl<D, Ts...>> : and_<is_const<Ts>...> {};
-
-template <class... Tags>
-using MaybeConstDataset =
-    std::conditional_t<detail::and_<detail::is_const<Tags>...>::value,
-                       const Dataset, Dataset>;
 } // namespace detail
 
 #endif // TRAITS_H

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -707,12 +707,12 @@ INSTANTIATE(gsl::index)
 INSTANTIATE(std::pair<gsl::index, gsl::index>)
 #endif
 INSTANTIATE(boost::container::small_vector<gsl::index, 1>)
+INSTANTIATE(boost::container::small_vector<double, 8>)
 INSTANTIATE(std::vector<std::string>)
 INSTANTIATE(std::vector<gsl::index>)
 INSTANTIATE(Dataset)
 INSTANTIATE(std::array<double, 3>)
 INSTANTIATE(std::array<double, 4>)
-INSTANTIATE(std::shared_ptr<std::array<double, 100>>)
 INSTANTIATE(Eigen::Vector3d)
 
 template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {

--- a/src/variable.h
+++ b/src/variable.h
@@ -300,8 +300,7 @@ template <class T>
 Variable makeVariable(Tag tag, const Dimensions &dimensions) {
   return Variable(
       tag, unit(tag), std::move(dimensions),
-      Vector<T>(dimensions.volume(),
-                detail::default_init<typename TagT::type>::value()));
+      Vector<T>(dimensions.volume(), detail::default_init<T>::value()));
 }
 
 template <class T, class T2>

--- a/src/variable.h
+++ b/src/variable.h
@@ -117,6 +117,20 @@ class ConstVariableSlice;
 class VariableSlice;
 template <class T1, class T2> T1 &plus_equals(T1 &, const T2 &);
 
+namespace detail {
+template <class T> struct default_init {
+  static T value() { return T(); }
+};
+// Eigen does not zero-initialize matrices (vectors), which is a recurrent
+// source of bugs. Variable does zero-init instead.
+template <class T, int Rows, int Cols>
+struct default_init<Eigen::Matrix<T, Rows, Cols>> {
+  static Eigen::Matrix<T, Rows, Cols> value() {
+    return Eigen::Matrix<T, Rows, Cols>::Zero();
+  }
+};
+}
+
 /// Variable is a type-erased handle to any data structure representing a
 /// multi-dimensional array. It has a name, a unit, and a set of named
 /// dimensions.
@@ -130,7 +144,9 @@ public:
   template <class TagT>
   Variable(TagT tag, const Dimensions &dimensions)
       : Variable(tag, TagT::unit, std::move(dimensions),
-                 Vector<typename TagT::type>(dimensions.volume())) {}
+                 Vector<typename TagT::type>(
+                     dimensions.volume(),
+                     detail::default_init<typename TagT::type>::value())) {}
   template <class TagT>
   Variable(TagT tag, const Dimensions &dimensions,
            Vector<typename TagT::type> object)
@@ -282,8 +298,10 @@ private:
 
 template <class T>
 Variable makeVariable(Tag tag, const Dimensions &dimensions) {
-  return Variable(tag, unit(tag), std::move(dimensions),
-                  Vector<T>(dimensions.volume()));
+  return Variable(
+      tag, unit(tag), std::move(dimensions),
+      Vector<T>(dimensions.volume(),
+                detail::default_init<typename TagT::type>::value()));
 }
 
 template <class T, class T2>

--- a/src/zip_view.h
+++ b/src/zip_view.h
@@ -9,7 +9,6 @@
 #include "range/v3/view/zip.hpp"
 
 #include "dataset.h"
-#include "traits.h"
 
 template <class... Tags> struct AccessHelper {
   static void push_back(std::array<Dimensions *, sizeof...(Tags)> &dimensions,
@@ -39,11 +38,17 @@ template <class Tag1, class Tag2> struct AccessHelper<Tag1, Tag2> {
   }
 };
 
+// TODO Should also have a const version of this, and support names, similar to
+// zipMD. Note that this is simpler to do in this case since const-ness does not
+// matter --- creation with mismatching dimensions is anyway not possible. On
+// the other hand, this view exists mainly to support length changes, zipMD can
+// be used if that is not required, i.e., maybe we do *not* need `ConstZipView`
+// (if so, only for consistency?)?
 template <class... Tags> class ZipView {
 public:
   using value_type = std::tuple<typename Tags::type...>;
 
-  ZipView(detail::MaybeConstDataset<Tags...> &dataset) {
+  ZipView(Dataset &dataset) {
     // As long as we do not support passing names, duplicate tags are not
     // supported, so this check should be enough.
     if (sizeof...(Tags) != dataset.size())

--- a/test/Workspace2D_test.cpp
+++ b/test/Workspace2D_test.cpp
@@ -22,7 +22,8 @@ TEST(Workspace2D, multi_dimensional_merging_and_slicing) {
   // Scalar part of instrument, e.g., something like this:
   // d.insert(Coord::Instrument, {}, Beamline::ComponentInfo{});
   dets.insert(Coord::DetectorId, {Dim::Detector, 4}, {1001, 1002, 1003, 1004});
-  dets.insert(Coord::Position, {Dim::Detector, 4});
+  dets.insert(Coord::Position, {Dim::Detector, 4}, 4,
+              Eigen::Vector3d{1.0, 0.0, 0.0});
   d.insert(Coord::DetectorInfo, {}, {dets});
 
   // Spectrum to detector mapping and spectrum numbers.

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -631,10 +631,6 @@ TEST(MDZipView, event_lists_mutable) {
   d.insert(Data::Events, "", {Dim::Spectrum, 3}, 3, eventList);
 
   auto view = zipMD(d, MDWrite(Data::Events));
-  // Remove code below this comment, then
-  // Workspace2D.multi_dimensional_merging_and_slicing test fails with gcc (not
-  // with clang). Remove the line above and it works again. What is going on? Is
-  // this a gcc linker bug? It works neither for Release nor Debug build.
   for (const auto &item : view) {
     // TODO Would be nice to simplify this, such that the event-list column
     // types are specified only once, at construction time of the main view, not

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -621,7 +621,7 @@ TEST(MDZipView, create_from_labels_nested) {
   }
 }
 
-TEST(MDZipView, event_lists) {
+TEST(MDZipView, event_lists_option1) {
   Dataset eventList;
   eventList.insert(Data::Tof, "", {Dim::Event, 4}, {1, 2, 3, 4});
   eventList.insert(Data::PulseTime, "", {Dim::Event, 4}, {5, 6, 7, 8});
@@ -651,4 +651,22 @@ TEST(MDZipView, event_lists) {
     EXPECT_EQ(eventList(Data::Tof).size(), 5);
     EXPECT_EQ(eventList(Data::PulseTime).size(), 5);
   }
+}
+
+TEST(MDZipView, event_lists_option2) {
+  Dataset d;
+  d.insert(Data::EventTofs, "", {Dim::Spectrum, 3});
+  d.insert(Data::EventPulseTimes, "", {Dim::Spectrum, 3});
+  auto tofs = d.get(Data::EventTofs);
+  auto pulseTimes = d.get(Data::EventPulseTimes);
+  tofs[0] = {1.0, 2.0};
+  tofs[2] = {1.0, 2.0, 3.0};
+  pulseTimes[0] = {3.0, 4.0};
+  pulseTimes[2] = {3.0, 4.0, 5.0};
+
+  auto view = zipMD(d, MDWrite(Data::Events));
+  auto it = view.begin();
+  EXPECT_EQ((it + 0)->get(Data::Events).get2().size(), 2);
+  EXPECT_EQ((it + 1)->get(Data::Events).get2().size(), 0);
+  EXPECT_EQ((it + 2)->get(Data::Events).get2().size(), 3);
 }


### PR DESCRIPTION
This adds:
- A new (more efficient) way of storing event data (this is similar to what I have in mind as a more efficient default format).
- A very basic implementation of an event-list proxy, which can be used to access the (for now) two different storage formats in a uniform manner.

In its current form the implementation is lacking a lot, so for now this is mostly an example of how it can be done, so we can do a proper implementation in the near or medium-term future.

Current shortcomings, which should be overlooked for now:
- `const` issues (need `ConstEventListProxy` and `EventListProxy`).
- Need a proxy that can change lengths. This is supported here for the nested case, but not for the other one, since `ZipView` is too inflexible currently.
- Need to support views that to not contain certain data, e.g., only TOF but not pulse-times. For such a view length changes will be impossible.
- Field types (TOF, pulse-times, ...) should ideally be given at creation time of the global view (`MDZipView` in this case), so they do not have to be repeated for every event list. This should then also avoid the need for the`get()` chaining we have now.
- `ranges::view::zip` is convenient, but the tuple-type it returns is maybe not. Need to consider other options?

I think all of these changes are possible with what is shown here, it "just" needs to be fleshed out properly.

This also adds zero-init for `Eigen` objects stored in a default-initialized variable.