### PR TITLE
Minor additions to coord exports

### DIFF
--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -58,6 +58,10 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(repr(var), "CoordVariable(Coord::X, )")
         var = Variable(Data.Value, [Dim.X], np.arange(1))
         self.assertEqual(repr(var), "DataVariable(Data::Value, )")
+        var = Variable(Coord.SpectrumNumber, [Dim.X], np.arange(1))
+        self.assertEqual(repr(var), "CoordVariable(Coord::SpectrumNumber, )")
+        var = Variable(Coord.Mask, [Dim.X], np.arange(1))
+        self.assertEqual(repr(var), "CoordVariable(Coord::Mask, )")
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -88,6 +88,10 @@ std::string to_string(const Tag tag) {
     return "Coord::Y";
   case Coord::Z.value():
     return "Coord::Z";
+  case Coord::SpectrumNumber.value():
+    return "Coord::SpectrumNumber";
+  case Coord::Mask.value():
+    return "Coord::Mask";
   case Coord::Position.value():
     return "Coord::Position";
   case Coord::DetectorGrouping.value():


### PR DESCRIPTION
Other exports + tests Do not merge until #35 is merged.

Note that we should probably come up with a better way of doing these rather than relying on the existing switch statement. For example, `tags.h` could define ....
```
template <typename T> static std::string to_string(T) = delete;
template <> static std::string to_string(X_t) { return "Coord::X"; }
template <> static std::string to_string(Y_t) { return "Coord::Y"; }
```

