### PR TITLE
Fix and extend comparison for Dataset

### DIFF
--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -171,8 +171,13 @@ void Dataset::mergeDimensions(const Dimensions &dims, const Dim coordDim) {
 }
 
 bool Dataset::operator==(const Dataset &other) const {
-  return (m_dimensions == other.m_dimensions) &&
-         (m_variables == other.m_variables);
+  if (size() != other.size())
+    return false;
+  for (const auto &var : m_variables)
+    if (!other.contains(var.tag(), var.name()) ||
+        (var != other(var.tag(), var.name())))
+      return false;
+  return true;
 }
 
 VariableSlice DatasetSlice::operator()(const Tag tag, const std::string &name) {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -485,52 +485,52 @@ Dataset ConstDatasetSlice::operator-() const {
   return -copy;
 }
 
-DatasetSlice DatasetSlice::assign(const Dataset &other) {
+DatasetSlice DatasetSlice::assign(const Dataset &other) const {
   return ::assign(*this, other);
 }
-DatasetSlice DatasetSlice::assign(const ConstDatasetSlice &other) {
+DatasetSlice DatasetSlice::assign(const ConstDatasetSlice &other) const {
   return ::assign(*this, other);
 }
 
-DatasetSlice DatasetSlice::operator+=(const Dataset &other) {
+DatasetSlice DatasetSlice::operator+=(const Dataset &other) const {
   return binary_op_equals(
       [](VariableSlice &a, const Variable &b) { return a += b; }, *this, other);
 }
-DatasetSlice DatasetSlice::operator+=(const ConstDatasetSlice &other) {
+DatasetSlice DatasetSlice::operator+=(const ConstDatasetSlice &other) const {
   return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a += b; },
       *this, other);
 }
-DatasetSlice DatasetSlice::operator+=(const double value) {
+DatasetSlice DatasetSlice::operator+=(const double value) const {
   for (auto var : *this)
     if (var.tag() == Data::Value)
       var += value;
   return *this;
 }
 
-DatasetSlice DatasetSlice::operator-=(const Dataset &other) {
+DatasetSlice DatasetSlice::operator-=(const Dataset &other) const {
   return binary_op_equals(
       [](VariableSlice &a, const Variable &b) { return a -= b; }, *this, other);
 }
-DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) {
+DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) const {
   return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
-DatasetSlice DatasetSlice::operator-=(const double value) {
+DatasetSlice DatasetSlice::operator-=(const double value) const {
   for (auto var : *this)
     if (var.tag() == Data::Value)
       var -= value;
   return *this;
 }
 
-DatasetSlice DatasetSlice::operator*=(const Dataset &other) {
+DatasetSlice DatasetSlice::operator*=(const Dataset &other) const {
   return times_equals(*this, other);
 }
-DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) {
+DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) const {
   return times_equals(*this, other);
 }
-DatasetSlice DatasetSlice::operator*=(const double value) {
+DatasetSlice DatasetSlice::operator*=(const double value) const {
   for (auto var : *this)
     if (var.tag() == Data::Value)
       var *= value;

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -198,6 +198,22 @@ bool ConstDatasetSlice::operator==(const ConstDatasetSlice &other) const {
   return equals(*this, other);
 }
 
+bool Dataset::operator!=(const Dataset &other) const {
+  return !operator==(other);
+}
+
+bool Dataset::operator!=(const ConstDatasetSlice &other) const {
+  return !operator==(other);
+}
+
+bool ConstDatasetSlice::operator!=(const Dataset &other) const {
+  return !operator==(other);
+}
+
+bool ConstDatasetSlice::operator!=(const ConstDatasetSlice &other) const {
+  return !operator==(other);
+}
+
 ConstVariableSlice ConstDatasetSlice::
 operator()(const Tag tag, const std::string &name) const {
   return ConstVariableSlice(operator[](find(*this, tag, name)));

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -187,6 +187,17 @@ bool Dataset::operator==(const ConstDatasetSlice &other) const {
   return equals(*this, other);
 }
 
+bool ConstDatasetSlice::operator==(const Dataset &other) const {
+  return equals(*this, other);
+}
+
+bool ConstDatasetSlice::operator==(const ConstDatasetSlice &other) const {
+  if ((m_dataset == other.m_dataset) && (m_indices == other.m_indices) &&
+      (m_slices == other.m_slices))
+    return true;
+  return equals(*this, other);
+}
+
 ConstVariableSlice ConstDatasetSlice::
 operator()(const Tag tag, const std::string &name) const {
   return ConstVariableSlice(operator[](find(*this, tag, name)));

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -170,17 +170,30 @@ void Dataset::mergeDimensions(const Dimensions &dims, const Dim coordDim) {
   }
 }
 
-bool Dataset::operator==(const Dataset &other) const {
-  if (size() != other.size())
+template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
+  if (a.size() != b.size())
     return false;
-  for (const auto &var : m_variables)
-    if (!other.contains(var.tag(), var.name()) ||
-        (var != other(var.tag(), var.name())))
+  for (const auto &var : a)
+    if (!b.contains(var.tag(), var.name()) || (var != b(var.tag(), var.name())))
       return false;
   return true;
 }
 
-VariableSlice DatasetSlice::operator()(const Tag tag, const std::string &name) {
+bool Dataset::operator==(const Dataset &other) const {
+  return equals(*this, other);
+}
+
+bool Dataset::operator==(const ConstDatasetSlice &other) const {
+  return equals(*this, other);
+}
+
+ConstVariableSlice ConstDatasetSlice::
+operator()(const Tag tag, const std::string &name) const {
+  return ConstVariableSlice(operator[](find(*this, tag, name)));
+}
+
+VariableSlice DatasetSlice::operator()(const Tag tag,
+                                       const std::string &name) const {
   return VariableSlice(operator[](find(*this, tag, name)));
 }
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -348,12 +348,8 @@ public:
     return boost::make_transform_iterator(m_indices.end(), IterAccess{*this});
   }
 
-  bool operator==(const ConstDatasetSlice &other) const {
-    if ((m_dataset == other.m_dataset) && (m_indices == other.m_indices) &&
-        (m_slices == other.m_slices))
-      return true;
-    return std::equal(begin(), end(), other.begin(), other.end());
-  }
+  bool operator==(const Dataset &other) const;
+  bool operator==(const ConstDatasetSlice &other) const;
 
   Dataset operator-() const;
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -213,6 +213,7 @@ public:
   const Dimensions &dimensions() const & { return m_dimensions; }
 
   bool operator==(const Dataset &other) const;
+  bool operator==(const ConstDatasetSlice &other) const;
   Dataset operator-() const;
   Dataset &operator+=(const Dataset &other);
   Dataset &operator+=(const ConstDatasetSlice &other);
@@ -356,6 +357,9 @@ public:
 
   Dataset operator-() const;
 
+  ConstVariableSlice operator()(const Tag tag,
+                                const std::string &name = "") const;
+
 protected:
   const Dataset &m_dataset;
   std::vector<gsl::index> m_indices;
@@ -407,7 +411,7 @@ public:
       : ConstDatasetSlice(dataset, select), m_mutableDataset(dataset) {}
 
   using ConstDatasetSlice::operator[];
-  VariableSlice operator[](const gsl::index i) {
+  VariableSlice operator[](const gsl::index i) const {
     return detail::makeSlice(m_mutableDataset[m_indices[i]], m_slices);
   }
 
@@ -419,10 +423,10 @@ public:
   using ConstDatasetSlice::begin;
   using ConstDatasetSlice::end;
 
-  auto begin() {
+  auto begin() const {
     return boost::make_transform_iterator(m_indices.begin(), IterAccess{*this});
   }
-  auto end() {
+  auto end() const {
     return boost::make_transform_iterator(m_indices.end(), IterAccess{*this});
   }
 
@@ -439,7 +443,7 @@ public:
   DatasetSlice operator*=(const ConstDatasetSlice &other);
   DatasetSlice operator*=(const double value);
 
-  VariableSlice operator()(const Tag tag, const std::string &name = "");
+  VariableSlice operator()(const Tag tag, const std::string &name = "") const;
 
 private:
   Dataset &m_mutableDataset;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -214,6 +214,8 @@ public:
 
   bool operator==(const Dataset &other) const;
   bool operator==(const ConstDatasetSlice &other) const;
+  bool operator!=(const Dataset &other) const;
+  bool operator!=(const ConstDatasetSlice &other) const;
   Dataset operator-() const;
   Dataset &operator+=(const Dataset &other);
   Dataset &operator+=(const ConstDatasetSlice &other);
@@ -350,6 +352,8 @@ public:
 
   bool operator==(const Dataset &other) const;
   bool operator==(const ConstDatasetSlice &other) const;
+  bool operator!=(const Dataset &other) const;
+  bool operator!=(const ConstDatasetSlice &other) const;
 
   Dataset operator-() const;
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -431,17 +431,17 @@ public:
   }
 
   // Returning void to avoid potentially returning references to temporaries.
-  DatasetSlice assign(const Dataset &other);
-  DatasetSlice assign(const ConstDatasetSlice &other);
-  DatasetSlice operator+=(const Dataset &other);
-  DatasetSlice operator+=(const ConstDatasetSlice &other);
-  DatasetSlice operator+=(const double value);
-  DatasetSlice operator-=(const Dataset &other);
-  DatasetSlice operator-=(const ConstDatasetSlice &other);
-  DatasetSlice operator-=(const double value);
-  DatasetSlice operator*=(const Dataset &other);
-  DatasetSlice operator*=(const ConstDatasetSlice &other);
-  DatasetSlice operator*=(const double value);
+  DatasetSlice assign(const Dataset &other) const;
+  DatasetSlice assign(const ConstDatasetSlice &other) const;
+  DatasetSlice operator+=(const Dataset &other) const;
+  DatasetSlice operator+=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator+=(const double value) const;
+  DatasetSlice operator-=(const Dataset &other) const;
+  DatasetSlice operator-=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator-=(const double value) const;
+  DatasetSlice operator*=(const Dataset &other) const;
+  DatasetSlice operator*=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator*=(const double value) const;
 
   VariableSlice operator()(const Tag tag, const std::string &name = "") const;
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -731,18 +731,7 @@ template <class T1, class T2> bool equals(const T1 &a, const T2 &b) {
 }
 
 bool Variable::operator==(const Variable &other) const {
-  // Compare even before pointer comparison since data may be shared even if
-  // names differ.
-  if (name() != other.name())
-    return false;
-  if (unit() != other.unit())
-    return false;
-  // Deep comparison
-  if (tag() != other.tag())
-    return false;
-  if (!(dimensions() == other.dimensions()))
-    return false;
-  return data() == other.data();
+  return equals(*this, other);
 }
 
 bool Variable::operator==(const ConstVariableSlice &other) const {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -331,6 +331,7 @@ TEST(Dataset, comparison_with_slice) {
   d2.insert(Data::Variance, "a", {});
   EXPECT_FALSE(d1 == d2);
   EXPECT_TRUE(d1 == d2["a"]);
+  EXPECT_TRUE(d2["a"] == d1);
 }
 
 TEST(Dataset, comparison_with_spatial_slice) {
@@ -339,12 +340,37 @@ TEST(Dataset, comparison_with_spatial_slice) {
   Dataset d2;
   d2.insert(Data::Value, "b", {});
   d2.insert(Data::Value, "a", {Dim::X, 3}, {1, 2, 3});
+
   EXPECT_FALSE(d1 == d2);
+
   EXPECT_FALSE(d1 == d2["a"]);
   EXPECT_FALSE(d1 == d2["a"](Dim::X, 0, 2));
   EXPECT_FALSE(d1 == d2["a"](Dim::X, 0));
   EXPECT_FALSE(d1 == d2["a"](Dim::X, 1));
   EXPECT_TRUE(d1 == d2["a"](Dim::X, 1, 3));
+
+  EXPECT_FALSE(d2["a"] == d1);
+  EXPECT_FALSE(d2["a"](Dim::X, 0, 2) == d1);
+  EXPECT_FALSE(d2["a"](Dim::X, 0) == d1);
+  EXPECT_FALSE(d2["a"](Dim::X, 1) == d1);
+  EXPECT_TRUE(d2["a"](Dim::X, 1, 3) == d1);
+}
+
+TEST(Dataset, comparison_two_slices) {
+  Dataset d;
+  d.insert(Data::Value, "a", {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Data::Value, "b", {Dim::X, 4}, {1, 2, 1, 2});
+
+  // Data is same but name differs.
+  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["b"](Dim::X, 0, 2));
+
+  EXPECT_TRUE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 0, 2));
+  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 1, 3));
+  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 2, 4));
+
+  EXPECT_TRUE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 0, 2));
+  EXPECT_FALSE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 1, 3));
+  EXPECT_TRUE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 2, 4));
 }
 
 TEST(Dataset, operator_plus_equal) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -283,6 +283,44 @@ TEST(Dataset, get_named) {
   EXPECT_EQ(var2[0], 2.2);
 }
 
+TEST(Dataset, comparison_different_insertion_order) {
+  Dataset d1;
+  d1.insert(Data::Value, "a", {});
+  d1.insert(Data::Value, "b", {});
+  Dataset d2;
+  d2.insert(Data::Value, "b", {});
+  d2.insert(Data::Value, "a", {});
+  EXPECT_TRUE(d1 == d1);
+  EXPECT_TRUE(d1 == d2);
+  EXPECT_TRUE(d2 == d1);
+  EXPECT_TRUE(d2 == d2);
+}
+
+TEST(Dataset, comparison_different_data) {
+  Dataset d1;
+  d1.insert(Data::Value, "a", {});
+  d1.insert(Data::Value, "b", {});
+  Dataset d2;
+  d2.insert(Data::Value, "b", {});
+  d2.insert(Data::Value, "a", {}, {1.0});
+  EXPECT_TRUE(d1 == d1);
+  EXPECT_FALSE(d1 == d2);
+  EXPECT_FALSE(d2 == d1);
+  EXPECT_TRUE(d2 == d2);
+}
+
+TEST(Dataset, comparison_missing_variable) {
+  Dataset d1;
+  d1.insert(Data::Value, "a", {});
+  d1.insert(Data::Value, "b", {});
+  Dataset d2;
+  d2.insert(Data::Value, "a", {});
+  EXPECT_TRUE(d1 == d1);
+  EXPECT_FALSE(d1 == d2);
+  EXPECT_FALSE(d2 == d1);
+  EXPECT_TRUE(d2 == d2);
+}
+
 TEST(Dataset, operator_plus_equal) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -290,10 +290,10 @@ TEST(Dataset, comparison_different_insertion_order) {
   Dataset d2;
   d2.insert(Data::Value, "b", {});
   d2.insert(Data::Value, "a", {});
-  EXPECT_TRUE(d1 == d1);
-  EXPECT_TRUE(d1 == d2);
-  EXPECT_TRUE(d2 == d1);
-  EXPECT_TRUE(d2 == d2);
+  EXPECT_EQ(d1, d1);
+  EXPECT_EQ(d1, d2);
+  EXPECT_EQ(d2, d1);
+  EXPECT_EQ(d2, d2);
 }
 
 TEST(Dataset, comparison_different_data) {
@@ -303,10 +303,10 @@ TEST(Dataset, comparison_different_data) {
   Dataset d2;
   d2.insert(Data::Value, "b", {});
   d2.insert(Data::Value, "a", {}, {1.0});
-  EXPECT_TRUE(d1 == d1);
-  EXPECT_FALSE(d1 == d2);
-  EXPECT_FALSE(d2 == d1);
-  EXPECT_TRUE(d2 == d2);
+  EXPECT_EQ(d1, d1);
+  EXPECT_NE(d1, d2);
+  EXPECT_NE(d2, d1);
+  EXPECT_EQ(d2, d2);
 }
 
 TEST(Dataset, comparison_missing_variable) {
@@ -315,10 +315,10 @@ TEST(Dataset, comparison_missing_variable) {
   d1.insert(Data::Value, "b", {});
   Dataset d2;
   d2.insert(Data::Value, "a", {});
-  EXPECT_TRUE(d1 == d1);
-  EXPECT_FALSE(d1 == d2);
-  EXPECT_FALSE(d2 == d1);
-  EXPECT_TRUE(d2 == d2);
+  EXPECT_EQ(d1, d1);
+  EXPECT_NE(d1, d2);
+  EXPECT_NE(d2, d1);
+  EXPECT_EQ(d2, d2);
 }
 
 TEST(Dataset, comparison_with_slice) {
@@ -329,9 +329,9 @@ TEST(Dataset, comparison_with_slice) {
   d2.insert(Data::Value, "b", {});
   d2.insert(Data::Value, "a", {});
   d2.insert(Data::Variance, "a", {});
-  EXPECT_FALSE(d1 == d2);
-  EXPECT_TRUE(d1 == d2["a"]);
-  EXPECT_TRUE(d2["a"] == d1);
+  EXPECT_NE(d1, d2);
+  EXPECT_EQ(d1, d2["a"]);
+  EXPECT_EQ(d2["a"], d1);
 }
 
 TEST(Dataset, comparison_with_spatial_slice) {
@@ -341,19 +341,19 @@ TEST(Dataset, comparison_with_spatial_slice) {
   d2.insert(Data::Value, "b", {});
   d2.insert(Data::Value, "a", {Dim::X, 3}, {1, 2, 3});
 
-  EXPECT_FALSE(d1 == d2);
+  EXPECT_NE(d1, d2);
 
-  EXPECT_FALSE(d1 == d2["a"]);
-  EXPECT_FALSE(d1 == d2["a"](Dim::X, 0, 2));
-  EXPECT_FALSE(d1 == d2["a"](Dim::X, 0));
-  EXPECT_FALSE(d1 == d2["a"](Dim::X, 1));
-  EXPECT_TRUE(d1 == d2["a"](Dim::X, 1, 3));
+  EXPECT_NE(d1, d2["a"]);
+  EXPECT_NE(d1, d2["a"](Dim::X, 0, 2));
+  EXPECT_NE(d1, d2["a"](Dim::X, 0));
+  EXPECT_NE(d1, d2["a"](Dim::X, 1));
+  EXPECT_EQ(d1, d2["a"](Dim::X, 1, 3));
 
-  EXPECT_FALSE(d2["a"] == d1);
-  EXPECT_FALSE(d2["a"](Dim::X, 0, 2) == d1);
-  EXPECT_FALSE(d2["a"](Dim::X, 0) == d1);
-  EXPECT_FALSE(d2["a"](Dim::X, 1) == d1);
-  EXPECT_TRUE(d2["a"](Dim::X, 1, 3) == d1);
+  EXPECT_NE(d2["a"], d1);
+  EXPECT_NE(d2["a"](Dim::X, 0, 2), d1);
+  EXPECT_NE(d2["a"](Dim::X, 0), d1);
+  EXPECT_NE(d2["a"](Dim::X, 1), d1);
+  EXPECT_EQ(d2["a"](Dim::X, 1, 3), d1);
 }
 
 TEST(Dataset, comparison_two_slices) {
@@ -362,15 +362,15 @@ TEST(Dataset, comparison_two_slices) {
   d.insert(Data::Value, "b", {Dim::X, 4}, {1, 2, 1, 2});
 
   // Data is same but name differs.
-  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["b"](Dim::X, 0, 2));
+  EXPECT_NE(d["a"](Dim::X, 0, 2), d["b"](Dim::X, 0, 2));
 
-  EXPECT_TRUE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 0, 2));
-  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 1, 3));
-  EXPECT_FALSE(d["a"](Dim::X, 0, 2) == d["a"](Dim::X, 2, 4));
+  EXPECT_EQ(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 0, 2));
+  EXPECT_NE(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 1, 3));
+  EXPECT_NE(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 2, 4));
 
-  EXPECT_TRUE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 0, 2));
-  EXPECT_FALSE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 1, 3));
-  EXPECT_TRUE(d["b"](Dim::X, 0, 2) == d["b"](Dim::X, 2, 4));
+  EXPECT_EQ(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 0, 2));
+  EXPECT_NE(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 1, 3));
+  EXPECT_EQ(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 2, 4));
 }
 
 TEST(Dataset, operator_plus_equal) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -333,6 +333,20 @@ TEST(Dataset, comparison_with_slice) {
   EXPECT_TRUE(d1 == d2["a"]);
 }
 
+TEST(Dataset, comparison_with_spatial_slice) {
+  Dataset d1;
+  d1.insert(Data::Value, "a", {Dim::X, 2}, {2, 3});
+  Dataset d2;
+  d2.insert(Data::Value, "b", {});
+  d2.insert(Data::Value, "a", {Dim::X, 3}, {1, 2, 3});
+  EXPECT_FALSE(d1 == d2);
+  EXPECT_FALSE(d1 == d2["a"]);
+  EXPECT_FALSE(d1 == d2["a"](Dim::X, 0, 2));
+  EXPECT_FALSE(d1 == d2["a"](Dim::X, 0));
+  EXPECT_FALSE(d1 == d2["a"](Dim::X, 1));
+  EXPECT_TRUE(d1 == d2["a"](Dim::X, 1, 3));
+}
+
 TEST(Dataset, operator_plus_equal) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -321,6 +321,18 @@ TEST(Dataset, comparison_missing_variable) {
   EXPECT_TRUE(d2 == d2);
 }
 
+TEST(Dataset, comparison_with_slice) {
+  Dataset d1;
+  d1.insert(Data::Value, "a", {});
+  d1.insert(Data::Variance, "a", {});
+  Dataset d2;
+  d2.insert(Data::Value, "b", {});
+  d2.insert(Data::Value, "a", {});
+  d2.insert(Data::Variance, "a", {});
+  EXPECT_FALSE(d1 == d2);
+  EXPECT_TRUE(d1 == d2["a"]);
+}
+
 TEST(Dataset, operator_plus_equal) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});


### PR DESCRIPTION
Fixes #30.

Also adds all comparison operator to work with slices, as well as `operator!=`.