### PR TITLE
Tag cleanup and completion of tag exports

### DIFF
--- a/benchmark/dataset_benchmark.cpp
+++ b/benchmark/dataset_benchmark.cpp
@@ -16,9 +16,9 @@ static void BM_Dataset_get_with_many_columns(benchmark::State &state) {
   Dataset d;
   for (int i = 0; i < state.range(0); ++i)
     d.insert(Data::Value, "name" + std::to_string(i), Dimensions{}, 1);
-  d.insert(Data::Int, "name", Dimensions{}, 1);
+  d.insert(Data::Variance, "name", Dimensions{}, 1);
   for (auto _ : state)
-    d.get(Data::Int);
+    d.get(Data::Variance);
   state.SetItemsProcessed(state.iterations());
 }
 BENCHMARK(BM_Dataset_get_with_many_columns)

--- a/benchmark/md_zip_view_benchmark.cpp
+++ b/benchmark/md_zip_view_benchmark.cpp
@@ -58,13 +58,13 @@ static void BM_MDZipView_multi_column_mixed_dimension(benchmark::State &state) {
   Dataset d;
   Dimensions dims;
   dims.add(Dim::Spectrum, state.range(0));
-  d.insert(Data::Int, "", dims, state.range(0));
+  d.insert(Data::DeprecatedInt, "", dims, state.range(0));
   dims.add(Dim::Tof, 1000);
   d.insert(Data::Value, "", dims, state.range(0) * 1000);
   gsl::index elements = 1000 * state.range(0);
 
   for (auto _ : state) {
-    auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
+    auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::DeprecatedInt));
     auto it = view.begin();
     for (int i = 0; i < elements; ++i) {
       benchmark::DoNotOptimize(it->get(Data::Value));
@@ -133,7 +133,7 @@ static void
 BM_MDZipView_multi_column_mixed_dimension_nested(benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert(Data::Int, "", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::DeprecatedInt, "", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Tof, 1000);
   dims.add(Dim::Spectrum, nSpec);
@@ -142,7 +142,7 @@ BM_MDZipView_multi_column_mixed_dimension_nested(benchmark::State &state) {
 
   for (auto _ : state) {
     auto nested = MDNested(MDWrite(Data::Value), MDWrite(Data::Variance));
-    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::Int));
+    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::DeprecatedInt));
     for (auto &item : view) {
       for (auto &point : item.get(decltype(nested)::type(d))) {
         point.value() -= point.get(Data::Variance);
@@ -162,7 +162,7 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_threaded(
     benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert(Data::Int, "specnums", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::DeprecatedInt, "specnums", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Tof, 1000);
   dims.add(Dim::Spectrum, nSpec);
@@ -171,7 +171,7 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_threaded(
 
   for (auto _ : state) {
     auto nested = MDNested(MDWrite(Data::Value), MDWrite(Data::Variance));
-    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::Int));
+    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::DeprecatedInt));
     const auto end = view.end();
 #pragma omp parallel for num_threads(state.range(1))
     for (auto it = view.begin(); it < end; ++it) {
@@ -194,7 +194,7 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_transpose(
     benchmark::State &state) {
   gsl::index nSpec = state.range(0);
   Dataset d;
-  d.insert(Data::Int, "", {Dim::Spectrum, nSpec}, nSpec);
+  d.insert(Data::DeprecatedInt, "", {Dim::Spectrum, nSpec}, nSpec);
   Dimensions dims;
   dims.add(Dim::Spectrum, nSpec);
   dims.add(Dim::Tof, 1000);
@@ -203,7 +203,7 @@ static void BM_MDZipView_multi_column_mixed_dimension_nested_transpose(
 
   for (auto _ : state) {
     auto nested = MDNested(MDWrite(Data::Value), MDWrite(Data::Variance));
-    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::Int));
+    auto view = zipMD(d, {Dim::Tof}, nested, MDWrite(Data::DeprecatedInt));
     for (auto &item : view) {
       for (auto &point : item.get(decltype(nested)::type(d))) {
         point.value() -= point.get(Data::Variance);

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -403,8 +403,6 @@ PYBIND11_MODULE(dataset, m) {
   data_tags.attr("Value") = Tag(Data::Value);
   data_tags.attr("Variance") = Tag(Data::Variance);
   data_tags.attr("StdDev") = Tag(Data::StdDev);
-  data_tags.attr("Int") = Tag(Data::Int);
-  data_tags.attr("String") = Tag(Data::String);
   data_tags.attr("Events") = Tag(Data::Events);
   data_tags.attr("EventTofs") = Tag(Data::EventTofs);
   data_tags.attr("EventPulseTimes") = Tag(Data::EventPulseTimes);

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -404,7 +404,6 @@ PYBIND11_MODULE(dataset, m) {
   data_tags.attr("Variance") = Tag(Data::Variance);
   data_tags.attr("StdDev") = Tag(Data::StdDev);
   data_tags.attr("Int") = Tag(Data::Int);
-  data_tags.attr("DimensionSize") = Tag(Data::DimensionSize);
   data_tags.attr("String") = Tag(Data::String);
   data_tags.attr("Events") = Tag(Data::Events);
   data_tags.attr("EventTofs") = Tag(Data::EventTofs);

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -343,8 +343,22 @@ as_VariableView_variant(Var &view) {
 
 PYBIND11_MODULE(dataset, m) {
   py::enum_<Dim>(m, "Dim")
+      .value("Component", Dim::Component)
+      .value("DeltaE", Dim::DeltaE)
+      .value("Detector", Dim::Detector)
+      .value("DetectorScan", Dim::DetectorScan)
+      .value("Energy", Dim::Energy)
+      .value("Event", Dim::Event)
+      .value("Invalid", Dim::Invalid)
+      .value("Monitor", Dim::Monitor)
+      .value("Polarization", Dim::Polarization)
+      .value("Position", Dim::Position)
+      .value("Q", Dim::Q)
       .value("Row", Dim::Row)
+      .value("Run", Dim::Run)
       .value("Spectrum", Dim::Spectrum)
+      .value("Temperature", Dim::Temperature)
+      .value("Time", Dim::Time)
       .value("Tof", Dim::Tof)
       .value("X", Dim::X)
       .value("Y", Dim::Y)
@@ -353,18 +367,46 @@ PYBIND11_MODULE(dataset, m) {
   py::class_<Tag>(m, "Tag").def(py::self == py::self);
 
   // Runtime tags are sufficient in Python, not exporting Tag child classes.
-  auto data_tags = m.def_submodule("Data");
-  data_tags.attr("Value") = Tag(Data::Value);
-  data_tags.attr("Variance") = Tag(Data::Variance);
-
   auto coord_tags = m.def_submodule("Coord");
-  coord_tags.attr("Mask") = Tag(Coord::Mask);
+  coord_tags.attr("Monitor") = Tag(Coord::Monitor);
+  coord_tags.attr("DetectorInfo") = Tag(Coord::DetectorInfo);
+  coord_tags.attr("ComponentInfo") = Tag(Coord::ComponentInfo);
   coord_tags.attr("X") = Tag(Coord::X);
   coord_tags.attr("Y") = Tag(Coord::Y);
   coord_tags.attr("Z") = Tag(Coord::Z);
   coord_tags.attr("Tof") = Tag(Coord::Tof);
-  coord_tags.attr("RowLabel") = Tag(Coord::RowLabel);
+  coord_tags.attr("Energy") = Tag(Coord::Energy);
+  coord_tags.attr("DeltaE") = Tag(Coord::DeltaE);
+  coord_tags.attr("Ei") = Tag(Coord::Ei);
+  coord_tags.attr("Ef") = Tag(Coord::Ef);
+  coord_tags.attr("DetectorId") = Tag(Coord::DetectorId);
   coord_tags.attr("SpectrumNumber") = Tag(Coord::SpectrumNumber);
+  coord_tags.attr("DetectorGrouping") = Tag(Coord::DetectorGrouping);
+  coord_tags.attr("RowLabel") = Tag(Coord::RowLabel);
+  coord_tags.attr("Polarization") = Tag(Coord::Polarization);
+  coord_tags.attr("Temperature") = Tag(Coord::Temperature);
+  coord_tags.attr("FuzzyTemperature") = Tag(Coord::FuzzyTemperature);
+  coord_tags.attr("Time") = Tag(Coord::Time);
+  coord_tags.attr("TimeInterval") = Tag(Coord::TimeInterval);
+  coord_tags.attr("Mask") = Tag(Coord::Mask);
+  coord_tags.attr("Position") = Tag(Coord::Position);
+
+  auto data_tags = m.def_submodule("Data");
+  data_tags.attr("Tof") = Tag(Data::Tof);
+  data_tags.attr("PulseTime") = Tag(Data::PulseTime);
+  data_tags.attr("Value") = Tag(Data::Value);
+  data_tags.attr("Variance") = Tag(Data::Variance);
+  data_tags.attr("StdDev") = Tag(Data::StdDev);
+  data_tags.attr("Int") = Tag(Data::Int);
+  data_tags.attr("DimensionSize") = Tag(Data::DimensionSize);
+  data_tags.attr("String") = Tag(Data::String);
+  data_tags.attr("Events") = Tag(Data::Events);
+  data_tags.attr("EventTofs") = Tag(Data::EventTofs);
+  data_tags.attr("EventPulseTimes") = Tag(Data::EventPulseTimes);
+  data_tags.attr("Table") = Tag(Data::Table);
+
+  auto attr_tags = m.def_submodule("Attr");
+  attr_tags.attr("ExperimentLog") = Tag(Attr::ExperimentLog);
 
   declare_span<double>(m, "double");
   declare_span<float>(m, "float");

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -409,7 +409,6 @@ PYBIND11_MODULE(dataset, m) {
   data_tags.attr("Events") = Tag(Data::Events);
   data_tags.attr("EventTofs") = Tag(Data::EventTofs);
   data_tags.attr("EventPulseTimes") = Tag(Data::EventPulseTimes);
-  data_tags.attr("Table") = Tag(Data::Table);
 
   auto attr_tags = m.def_submodule("Attr");
   attr_tags.attr("ExperimentLog") = Tag(Attr::ExperimentLog);

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -112,6 +112,17 @@ class TestDataset(unittest.TestCase):
         d[Data.Value, "data1"] = np.arange(24.0).reshape(4,3,2)
         self.assertEqual(d[Data.Value, "data1"].numpy.dtype, np.int64)
 
+    def test_set_data_nested(self):
+        d = Dataset()
+        table = Dataset()
+        table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
+        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
+        d[Data.Value, "data1"] = ([Dim.X], [table, table])
+        d[Data.Value, "data1"].data[1][Data.Value, "col1"].data[0] = 0.0;
+        self.assertEqual(d[Data.Value, "data1"].data[0], table)
+        self.assertNotEqual(d[Data.Value, "data1"].data[1], table)
+        self.assertNotEqual(d[Data.Value, "data1"].data[0], d[Data.Value, "data1"].data[1])
+
     def test_dimensions(self):
         self.assertEqual(self.dataset.dimensions().size(Dim.X), 2)
         self.assertEqual(self.dataset.dimensions().size(Dim.Y), 3)

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -79,7 +79,7 @@ class TestDataset(unittest.TestCase):
         np.testing.assert_array_equal(d[Data.Value, "data1"].numpy, self.reference_data1)
 
         # Currently implicitly replacing keys in Dataset is not supported. Should it?
-        self.assertRaisesRegex(RuntimeError, "Attempt to insert data of same type with duplicate name.",
+        self.assertRaisesRegex(RuntimeError, "Attempt to insert data with duplicate tag and name.",
                 d.__setitem__, (Data.Value, "data1"), ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2)))
 
         self.assertRaisesRegex(RuntimeError, "Cannot insert variable into Dataset: Dimensions do not match.",

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -51,7 +51,7 @@ void Dataset::insert(Variable variable) {
     for (const auto &item : m_variables)
       if (item.tag() == variable.tag() && item.name() == variable.name())
         throw std::runtime_error(
-            "Attempt to insert data of same type with duplicate name.");
+            "Attempt to insert data with duplicate tag and name.");
   }
   // TODO special handling for special variables types like
   // Data::Histogram (either prevent adding, or extract into underlying

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -9,25 +9,26 @@
 #include <cstdint>
 
 enum class Dim : uint16_t {
-  Invalid,
-  Event,
-  Tof,
-  Energy,
+  Component,
   DeltaE,
-  Spectrum,
-  Monitor,
-  Run,
   Detector,
-  Q,
-  X,
-  Y,
-  Z,
+  DetectorScan,
+  Energy,
+  Event,
+  Invalid,
+  Monitor,
   Polarization,
+  Position,
+  Q,
+  Row,
+  Run,
+  Spectrum,
   Temperature,
   Time,
-  DetectorScan,
-  Component,
-  Row
+  Tof,
+  X,
+  Y,
+  Z
 };
 
 constexpr bool isContinuous(const Dim dim) {

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -77,8 +77,6 @@ std::string to_string(const Tag tag) {
     return "Data::Value";
   case Data::Variance.value():
     return "Data::Variance";
-  case Data::Int.value():
-    return "Data::Int";
   default:
     return "<unknown tag>";
   }

--- a/src/tags.h
+++ b/src/tags.h
@@ -237,14 +237,10 @@ struct DataDef {
     using type = boost::container::small_vector<double, 8>;
     static constexpr auto unit = Unit::Id::Dimensionless;
   };
-  struct Table {
-    using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
-  };
 
   using tags =
       std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, DimensionSize,
-                 String, Events, EventTofs, EventPulseTimes, Table>;
+                 String, Events, EventTofs, EventPulseTimes>;
 };
 
 struct AttrDef {
@@ -331,7 +327,6 @@ struct Data {
   using Events_t = detail::TagImpl<detail::DataDef::Events>;
   using EventTofs_t = detail::TagImpl<detail::DataDef::EventTofs>;
   using EventPulseTimes_t = detail::TagImpl<detail::DataDef::EventPulseTimes>;
-  using Table_t = detail::TagImpl<detail::DataDef::Table>;
 
   static constexpr Tof_t Tof{};
   static constexpr PulseTime_t PulseTime{};
@@ -344,7 +339,6 @@ struct Data {
   static constexpr Events_t Events{};
   static constexpr EventTofs_t EventTofs{};
   static constexpr EventPulseTimes_t EventPulseTimes{};
-  static constexpr Table_t Table{};
 };
 
 struct Attr {

--- a/src/tags.h
+++ b/src/tags.h
@@ -316,6 +316,9 @@ struct Data {
   using Value_t = detail::TagImpl<detail::DataDef::Value>;
   using Variance_t = detail::TagImpl<detail::DataDef::Variance>;
   using StdDev_t = detail::TagImpl<detail::DataDef::StdDev>;
+  // TODO Int and String is deprecated and should be removed, it is curently
+  // only required to maintain tests using MDZipView before it is properly
+  // refactored for multi-name support.
   using Int_t = detail::TagImpl<detail::DataDef::Int>;
   using String_t = detail::TagImpl<detail::DataDef::String>;
   using Events_t = detail::TagImpl<detail::DataDef::Events>;

--- a/src/tags.h
+++ b/src/tags.h
@@ -217,10 +217,6 @@ struct DataDef {
     using type = int64_t;
     static constexpr auto unit = Unit::Id::Dimensionless;
   };
-  struct DimensionSize {
-    using type = gsl::index;
-    static constexpr auto unit = Unit::Id::Dimensionless;
-  };
   struct String {
     using type = std::string;
     static constexpr auto unit = Unit::Id::Dimensionless;
@@ -238,9 +234,8 @@ struct DataDef {
     static constexpr auto unit = Unit::Id::Dimensionless;
   };
 
-  using tags =
-      std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, DimensionSize,
-                 String, Events, EventTofs, EventPulseTimes>;
+  using tags = std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, String,
+                          Events, EventTofs, EventPulseTimes>;
 };
 
 struct AttrDef {
@@ -322,7 +317,6 @@ struct Data {
   using Variance_t = detail::TagImpl<detail::DataDef::Variance>;
   using StdDev_t = detail::TagImpl<detail::DataDef::StdDev>;
   using Int_t = detail::TagImpl<detail::DataDef::Int>;
-  using DimensionSize_t = detail::TagImpl<detail::DataDef::DimensionSize>;
   using String_t = detail::TagImpl<detail::DataDef::String>;
   using Events_t = detail::TagImpl<detail::DataDef::Events>;
   using EventTofs_t = detail::TagImpl<detail::DataDef::EventTofs>;
@@ -334,7 +328,6 @@ struct Data {
   static constexpr Variance_t Variance{};
   static constexpr StdDev_t StdDev{};
   static constexpr Int_t Int{};
-  static constexpr DimensionSize_t DimensionSize{};
   static constexpr String_t String{};
   static constexpr Events_t Events{};
   static constexpr EventTofs_t EventTofs{};

--- a/src/tags.h
+++ b/src/tags.h
@@ -316,11 +316,11 @@ struct Data {
   using Value_t = detail::TagImpl<detail::DataDef::Value>;
   using Variance_t = detail::TagImpl<detail::DataDef::Variance>;
   using StdDev_t = detail::TagImpl<detail::DataDef::StdDev>;
-  // TODO Int and String is deprecated and should be removed, it is curently
+  // TODO Int and String is deprecated and should be removed, it is currently
   // only required to maintain tests using MDZipView before it is properly
   // refactored for multi-name support.
-  using Int_t = detail::TagImpl<detail::DataDef::Int>;
-  using String_t = detail::TagImpl<detail::DataDef::String>;
+  using DeprecatedInt_t = detail::TagImpl<detail::DataDef::Int>;
+  using DeprecatedString_t = detail::TagImpl<detail::DataDef::String>;
   using Events_t = detail::TagImpl<detail::DataDef::Events>;
   using EventTofs_t = detail::TagImpl<detail::DataDef::EventTofs>;
   using EventPulseTimes_t = detail::TagImpl<detail::DataDef::EventPulseTimes>;
@@ -330,8 +330,8 @@ struct Data {
   static constexpr Value_t Value{};
   static constexpr Variance_t Variance{};
   static constexpr StdDev_t StdDev{};
-  static constexpr Int_t Int{};
-  static constexpr String_t String{};
+  static constexpr DeprecatedInt_t DeprecatedInt{};
+  static constexpr DeprecatedString_t DeprecatedString{};
   static constexpr Events_t Events{};
   static constexpr EventTofs_t EventTofs{};
   static constexpr EventPulseTimes_t EventPulseTimes{};

--- a/src/tags.h
+++ b/src/tags.h
@@ -19,7 +19,16 @@
 #include "unit.h"
 #include "value_with_delta.h"
 
-enum class DType { Unknown, Double, Float, Int32, Int64, String, Char };
+enum class DType {
+  Unknown,
+  Double,
+  Float,
+  Int32,
+  Int64,
+  String,
+  Char,
+  Dataset
+};
 template <class T> constexpr DType dtype = DType::Unknown;
 template <> constexpr DType dtype<double> = DType::Double;
 template <> constexpr DType dtype<float> = DType::Float;
@@ -27,6 +36,7 @@ template <> constexpr DType dtype<int32_t> = DType::Int32;
 template <> constexpr DType dtype<int64_t> = DType::Int64;
 template <> constexpr DType dtype<std::string> = DType::String;
 template <> constexpr DType dtype<char> = DType::Char;
+template <> constexpr DType dtype<Dataset> = DType::Dataset;
 
 // Adding new tags
 // ===============

--- a/src/tags.h
+++ b/src/tags.h
@@ -352,6 +352,10 @@ static constexpr bool is_attr =
                std::tuple_size<detail::DataDef::tags>::value;
 template <class T> static constexpr bool is_data = !is_coord<T> && !is_attr<T>;
 
+// TODO Some things *may* be dimension coordinates, but they are not necessarily
+// in all datasets. It depends on which dimensions are present. Does it even
+// make sense to hard-code this? Maybe we require handling everything at
+// runtime?
 namespace detail {
 template <class Tag> constexpr bool is_dimension_coordinate = false;
 template <> constexpr bool is_dimension_coordinate<CoordDef::Tof> = true;
@@ -360,6 +364,7 @@ template <> constexpr bool is_dimension_coordinate<CoordDef::DeltaE> = true;
 template <> constexpr bool is_dimension_coordinate<CoordDef::X> = true;
 template <> constexpr bool is_dimension_coordinate<CoordDef::Y> = true;
 template <> constexpr bool is_dimension_coordinate<CoordDef::Z> = true;
+template <> constexpr bool is_dimension_coordinate<CoordDef::Position> = true;
 template <>
 constexpr bool is_dimension_coordinate<CoordDef::SpectrumNumber> = true;
 template <> constexpr bool is_dimension_coordinate<CoordDef::RowLabel> = true;
@@ -371,6 +376,8 @@ template <> constexpr Dim coordinate_dimension<CoordDef::DeltaE> = Dim::DeltaE;
 template <> constexpr Dim coordinate_dimension<CoordDef::X> = Dim::X;
 template <> constexpr Dim coordinate_dimension<CoordDef::Y> = Dim::Y;
 template <> constexpr Dim coordinate_dimension<CoordDef::Z> = Dim::Z;
+template <>
+constexpr Dim coordinate_dimension<CoordDef::Position> = Dim::Position;
 template <>
 constexpr Dim coordinate_dimension<CoordDef::SpectrumNumber> = Dim::Spectrum;
 template <> constexpr Dim coordinate_dimension<CoordDef::RowLabel> = Dim::Row;

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1014,6 +1014,7 @@ INSTANTIATE_SLICEVIEW(int64_t);
 INSTANTIATE_SLICEVIEW(int32_t);
 INSTANTIATE_SLICEVIEW(char);
 INSTANTIATE_SLICEVIEW(std::string);
+INSTANTIATE_SLICEVIEW(Dataset);
 
 ConstVariableSlice Variable::operator()(const Dim dim, const gsl::index begin,
                                         const gsl::index end) const & {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -771,7 +771,8 @@ template <class T1, class T2> T1 &plus_equals(T1 &variable, const T2 &other) {
   // element types is handled in DataModel::operator+=.
   // Different name is ok for addition.
   dataset::expect::equals(variable.unit(), other.unit());
-  if (variable.tag() != Data::Events && variable.tag() != Data::Table) {
+  // TODO How should attributes be handled?
+  if (variable.dtype() != dtype<Dataset> || variable.isAttr()) {
     dataset::expect::contains(variable.dimensions(), other.dimensions());
     // Note: This will broadcast/transpose the RHS if required. We do not
     // support changing the dimensions of the LHS though!

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -16,7 +16,7 @@ Dataset makeRun() {
   run.insert(Coord::Polarization, {}, {"Spin-Up"});
   run.insert(Coord::FuzzyTemperature, {}, {ValueWithDelta<double>(4.2, 0.1)});
   Dataset comment;
-  comment.insert(Data::String, "", {Dim::Row, 1}, {"first run"});
+  comment.insert(Data::DeprecatedString, "", {Dim::Row, 1}, {"first run"});
   run.insert<Dataset>(Data::Value, "comment", {}, {comment});
   Dataset timeSeriesLog;
   timeSeriesLog.insert(Coord::Time, {Dim::Time, 3}, {0, 1000, 1500});
@@ -42,11 +42,11 @@ TEST(Run, meta_data_propagation) {
   auto run2(run1);
   run2.get(Data::Value, "total_counts")[0] = 1111;
   run2.get(Coord::FuzzyTemperature)[0] = ValueWithDelta<double>(4.15, 0.1);
-  run2.span<Dataset>(Data::Value, "comment")[0].get(Data::String)[0] =
+  run2.span<Dataset>(Data::Value, "comment")[0].get(Data::DeprecatedString)[0] =
       "second run";
   run2.span<Dataset>(Data::Value, "generic_log")[0]
       .span<Dataset>(Data::Value, "root")[0]
-      .insert(Data::String, "user comment", {},
+      .insert(Data::DeprecatedString, "user comment", {},
               {"Spider walked through beam, verify data before publishing."});
 
   Dataset d2;
@@ -80,7 +80,7 @@ TEST(Run, meta_data_propagation) {
 
   // Example of a log entry that is concatenated:
   const auto comments =
-      run.span<Dataset>(Data::Value, "comment")[0].get(Data::String);
+      run.span<Dataset>(Data::Value, "comment")[0].get(Data::DeprecatedString);
   EXPECT_EQ(comments.size(), 2);
   EXPECT_EQ(comments[0], "first run");
   EXPECT_EQ(comments[1], "second run");
@@ -144,7 +144,7 @@ TEST(Run, meta_data_fail_missing) {
   Dataset d2(d1);
 
   auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
-  run2.span<Dataset>(Data::Value, "comment")[0].erase(Data::String);
+  run2.span<Dataset>(Data::Value, "comment")[0].erase(Data::DeprecatedString);
   EXPECT_THROW_MSG(d1 += d2, std::runtime_error,
                    "Cannot add Variable: Nested Dataset dimension must be 1.");
 }

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -27,13 +27,14 @@ TEST(TableWorkspace, basics) {
   table.insert(Coord::RowLabel, {Dim::Row, 3},
                Vector<std::string>{"a", "b", "c"});
   table.insert(Data::Value, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
-  table.insert(Data::String, "", {Dim::Row, 3}, 3);
+  table.insert(Data::DeprecatedString, "", {Dim::Row, 3}, 3);
 
   // Modify table with know columns.
-  auto view = zipMD(table, MDRead(Data::Value), MDWrite(Data::String));
+  auto view =
+      zipMD(table, MDRead(Data::Value), MDWrite(Data::DeprecatedString));
   for (auto &item : view)
     if (item.value() < 0.0)
-      item.get(Data::String) = "why is this negative?";
+      item.get(Data::DeprecatedString) = "why is this negative?";
 
   // Get string representation of arbitrary table, e.g., for visualization.
   EXPECT_EQ(asStrings(table[0]), std::vector<std::string>({"a", "b", "c"}));

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -13,14 +13,11 @@
 // of basic routines.
 std::vector<std::string> asStrings(const Variable &variable) {
   std::vector<std::string> strings;
-  if (variable.tag() == Coord::RowLabel)
-    for (const auto &value : variable.get(Coord::RowLabel))
-      strings.emplace_back(value);
-  if (variable.tag() == Data::Value)
-    for (const auto &value : variable.get(Data::Value))
+  if (variable.dtype() == dtype<double>)
+    for (const auto &value : variable.span<double>())
       strings.emplace_back(std::to_string(value));
-  else if (variable.tag() == Data::String)
-    for (const auto &value : variable.get(Data::String))
+  else if (variable.dtype() == dtype<std::string>)
+    for (const auto &value : variable.span<std::string>())
       strings.emplace_back(value);
   return strings;
 }

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -664,7 +664,7 @@ TEST(Dataset, rebin_failures) {
   EXPECT_THROW_MSG(
       rebin(d, data), std::runtime_error,
       "The provided rebin coordinate is not a coordinate variable.");
-  Variable nonDimCoord(Coord::Position, {Dim::Detector, 2});
+  Variable nonDimCoord(Coord::Mask, {Dim::Detector, 2});
   EXPECT_THROW_MSG(
       rebin(d, nonDimCoord), std::runtime_error,
       "The provided rebin coordinate is not a dimension coordinate.");

--- a/test/md_zip_view_test.cpp
+++ b/test/md_zip_view_test.cpp
@@ -17,33 +17,33 @@
 TEST(MDZipView, construct) {
   Dataset d;
   d.insert(Data::Value, "", {}, {1.1});
-  d.insert(Data::Int, "", {}, {2});
+  d.insert(Data::Variance, "", {}, {2});
   // Empty view forbidden by static_assert:
   // zipMD(d);
   ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Value))));
-  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Int))));
+  ASSERT_NO_THROW(static_cast<void>(zipMD(d, MDRead(Data::Variance))));
   ASSERT_NO_THROW(
-      static_cast<void>(zipMD(d, MDRead(Data::Int), MDRead(Data::Value))));
+      static_cast<void>(zipMD(d, MDRead(Data::Variance), MDRead(Data::Value))));
   ASSERT_THROW(
-      static_cast<void>(zipMD(d, MDRead(Data::Int), MDRead(Data::Variance))),
+      static_cast<void>(zipMD(d, MDRead(Data::Events), MDRead(Data::Variance))),
       std::runtime_error);
 }
 
 TEST(MDZipView, construct_with_const_Dataset) {
   Dataset d;
   d.insert(Data::Value, "", {Dim::X, 1}, {1.1});
-  d.insert(Data::Int, "", {}, {2});
+  d.insert(Data::Variance, "", {}, {2});
   const auto const_d(d);
   EXPECT_NO_THROW(zipMD(const_d, MDRead(Data::Value)));
   EXPECT_NO_THROW(zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value))));
   EXPECT_NO_THROW(zipMD(const_d, {Dim::X}, ConstMDNested(MDRead(Data::Value)),
-                        MDRead(Data::Int)));
+                        MDRead(Data::Variance)));
 }
 
 TEST(MDZipView, iterator) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions{Dim::X, 2}, {1.1, 1.2});
-  d.insert(Data::Int, "", Dimensions{Dim::X, 2}, {2, 3});
+  d.insert(Data::Variance, "", Dimensions{Dim::X, 2}, {2, 3});
   auto view = zipMD(d, MDWrite(Data::Value));
   ASSERT_NO_THROW(view.begin());
   ASSERT_NO_THROW(view.end());
@@ -67,7 +67,7 @@ TEST(MDZipView, iterator) {
 TEST(MDZipView, single_column) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::Tof, 10), 10);
-  d.insert(Data::Int, "", Dimensions(Dim::Tof, 10), 10);
+  d.insert(Data::Variance, "", Dimensions(Dim::Tof, 10), 10);
   auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[3] = 3.2;
@@ -88,37 +88,37 @@ TEST(MDZipView, single_column) {
 TEST(MDZipView, multi_column) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::Tof, 2), 2);
-  d.insert(Data::Int, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Variance, "", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  auto view = zipMD(d, MDRead(Data::Value), MDRead(Data::Int));
+  auto view = zipMD(d, MDRead(Data::Value), MDRead(Data::Variance));
   auto it = view.begin();
   ASSERT_EQ(it->get(Data::Value), 0.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
   it++;
   ASSERT_EQ(it->get(Data::Value), 3.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
 }
 
 TEST(MDZipView, multi_column_mixed_dimension) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::Tof, 2), 2);
-  d.insert(Data::Int, "", {}, 1);
+  d.insert(Data::Variance, "", {}, 1);
   auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Int)));
-  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Int)));
-  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
+  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Variance)));
+  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Variance)));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Variance));
   auto it = view.begin();
   ASSERT_EQ(it->get(Data::Value), 0.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
   it++;
   ASSERT_EQ(it->get(Data::Value), 3.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
 }
 
 TEST(MDZipView, multi_column_transposed) {
@@ -131,22 +131,22 @@ TEST(MDZipView, multi_column_transposed) {
   dimsYX.add(Dim::X, 2);
 
   d.insert(Data::Value, "", dimsXY, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert(Data::Int, "", dimsYX, {1, 3, 5, 2, 4, 6});
+  d.insert(Data::Variance, "", dimsYX, {1, 3, 5, 2, 4, 6});
   // TODO Current dimension check is too strict and fails unless data with
   // transposed dimensions is accessed as const.
-  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Variance));
   auto it = view.begin();
   ASSERT_NE(++it, view.end());
   ASSERT_EQ(it->get(Data::Value), 2.0);
-  ASSERT_EQ(it->get(Data::Int), 2);
+  ASSERT_EQ(it->get(Data::Variance), 2);
   for (const auto &item : view)
-    ASSERT_EQ(item.get(Data::Value), item.get(Data::Int));
+    ASSERT_EQ(item.get(Data::Value), item.get(Data::Variance));
 }
 
 TEST(MDZipView, multi_column_unrelated_dimension) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int, "", Dimensions(Dim::Y, 3), 3);
+  d.insert(Data::Variance, "", Dimensions(Dim::Y, 3), 3);
   auto view = zipMD(d, MDWrite(Data::Value));
   auto it = view.begin();
   ASSERT_TRUE(it < view.end());
@@ -159,8 +159,8 @@ TEST(MDZipView, multi_column_unrelated_dimension) {
 TEST(MDZipView, multi_column_orthogonal_fail) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int, "", Dimensions(Dim::Y, 3), 3);
-  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value), MDRead(Data::Int)),
+  d.insert(Data::Variance, "", Dimensions(Dim::Y, 3), 3);
+  EXPECT_THROW_MSG(zipMD(d, MDRead(Data::Value), MDRead(Data::Variance)),
                    std::runtime_error,
                    "Variables requested for iteration do not span a joint "
                    "space. In case one of the variables represents bin edges "
@@ -172,12 +172,12 @@ TEST(MDZipView, nested_MDZipView) {
   Dataset d;
   d.insert(Data::Value, "", {{Dim::Y, 3}, {Dim::X, 2}},
            {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
-  d.insert(Data::Int, "", {Dim::X, 2}, {10, 20});
+  d.insert(Data::Variance, "", {Dim::X, 2}, {10, 20});
   auto nested = MDNested(MDRead(Data::Value));
   // TODO This is a very bad way of indexing nested views.
   auto Nested = decltype(nested)::type(d);
   ;
-  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int));
+  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Variance));
   ASSERT_EQ(view.size(), 2);
   double base = 0.0;
   for (const auto &item : view) {
@@ -384,7 +384,7 @@ TEST(MDZipView, histogram_using_nested_MDZipView) {
 TEST(MDZipView, single_column_edges) {
   Dataset d;
   d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int, "name2", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Value, "name2", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get(Coord::Tof);
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
@@ -408,7 +408,7 @@ TEST(MDZipView, single_column_edges) {
 TEST(MDZipView, single_column_bins) {
   Dataset d;
   d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int, "name2", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Value, "name2", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get(Coord::Tof);
   ASSERT_EQ(var.size(), 3);
   var[0] = 0.2;
@@ -427,21 +427,22 @@ TEST(MDZipView, single_column_bins) {
 TEST(MDZipView, multi_column_edges) {
   Dataset d;
   d.insert(Coord::Tof, Dimensions(Dim::Tof, 3), 3);
-  d.insert(Data::Int, "", Dimensions(Dim::Tof, 2), 2);
+  d.insert(Data::Value, "", Dimensions(Dim::Tof, 2), 2);
   auto var = d.get(Coord::Tof);
   var[0] = 0.2;
   var[1] = 1.2;
   var[2] = 2.2;
 
   // Cannot simultaneously iterate edges and non-edges, so this throws.
-  EXPECT_THROW_MSG(zipMD(d, MDRead(Coord::Tof), MDRead(Data::Int)),
+  EXPECT_THROW_MSG(zipMD(d, MDRead(Coord::Tof), MDRead(Data::Value)),
                    std::runtime_error,
                    "Variables requested for iteration do not span a joint "
                    "space. In case one of the variables represents bin edges "
                    "direct joint iteration is not possible. Use the Bin<> "
                    "wrapper to iterate over bins defined by edges instead.");
 
-  auto view = zipMD(d, MDRead(Bin<decltype(Coord::Tof)>{}), MDWrite(Data::Int));
+  auto view =
+      zipMD(d, MDRead(Bin<decltype(Coord::Tof)>{}), MDWrite(Data::Value));
   // TODO What are good names for named getters? tofCenter(), etc.?
   const auto &bin = view.begin()->get(Bin<decltype(Coord::Tof)>{});
   EXPECT_EQ(bin.center(), 0.7);
@@ -566,47 +567,48 @@ TEST(MDZipView, derived_standard_deviation) {
 TEST(MDZipView, create_from_labels) {
   Dataset d;
   d.insert(Data::Value, "", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int, "", {}, 1);
+  d.insert(Data::Variance, "", {}, 1);
   auto var = d.get(Data::Value);
   var[0] = 0.2;
   var[1] = 3.2;
 
-  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Int)));
-  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Int)));
-  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Int));
+  ASSERT_ANY_THROW(zipMD(d, MDWrite(Data::Value), MDWrite(Data::Variance)));
+  ASSERT_NO_THROW(zipMD(d, MDWrite(Data::Value), MDRead(Data::Variance)));
+  auto view = zipMD(d, MDWrite(Data::Value), MDRead(Data::Variance));
   auto it = view.begin();
   ASSERT_EQ(it->get(Data::Value), 0.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
   it++;
   ASSERT_EQ(it->get(Data::Value), 3.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
 }
 
 TEST(MDZipView, create_from_labels_with_name) {
   Dataset d;
   d.insert(Data::Value, "name", Dimensions(Dim::X, 2), 2);
-  d.insert(Data::Int, "name", {}, 1);
+  d.insert(Data::Variance, "name", {}, 1);
   auto var = d.get(Data::Value, "name");
   var[0] = 0.2;
   var[1] = 3.2;
 
-  auto view = zipMD(d, MDWrite(Data::Value, "name"), MDRead(Data::Int, "name"));
+  auto view =
+      zipMD(d, MDWrite(Data::Value, "name"), MDRead(Data::Variance, "name"));
   auto it = view.begin();
   ASSERT_EQ(it->get(Data::Value), 0.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
   it++;
   ASSERT_EQ(it->get(Data::Value), 3.2);
-  ASSERT_EQ(it->get(Data::Int), 0);
+  ASSERT_EQ(it->get(Data::Variance), 0);
 }
 
 TEST(MDZipView, create_from_labels_nested) {
   Dataset d;
   d.insert(Data::Value, "", {{Dim::Y, 3}, {Dim::X, 2}}, {1, 2, 3, 4, 5, 6});
-  d.insert(Data::Int, "", {Dim::X, 2}, {10, 20});
+  d.insert(Data::Variance, "", {Dim::X, 2}, {10, 20});
 
   auto nested = MDNested(MDRead(Data::Value));
   auto Nested = decltype(nested)::type(d);
-  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Int));
+  auto view = zipMD(d, {Dim::Y}, nested, MDRead(Data::Variance));
 
   ASSERT_EQ(view.size(), 2);
   double base = 0.0;

--- a/test/tags_test.cpp
+++ b/test/tags_test.cpp
@@ -12,5 +12,6 @@ TEST(Tags, isDimensionCoord) {
   EXPECT_TRUE(isDimensionCoord[Coord::X.value()]);
   EXPECT_TRUE(isDimensionCoord[Coord::Y.value()]);
   EXPECT_TRUE(isDimensionCoord[Coord::Z.value()]);
-  EXPECT_FALSE(isDimensionCoord[Coord::Position.value()]);
+  EXPECT_TRUE(isDimensionCoord[Coord::Position.value()]);
+  EXPECT_FALSE(isDimensionCoord[Coord::Mask.value()]);
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -189,14 +189,15 @@ TEST(Variable, operator_plus_equal_different_unit) {
 }
 
 TEST(Variable, operator_plus_equal_non_arithmetic_type) {
-  Variable a(Data::String, {Dim::X, 1}, {std::string("test")});
+  auto a = makeVariable<std::string>(Data::Value, {Dim::X, 1},
+                                     {std::string("test")});
   EXPECT_THROW_MSG(a += a, std::runtime_error,
                    "Cannot apply operation, requires addable type.");
 }
 
 TEST(Variable, operator_plus_equal_different_variables_different_element_type) {
   Variable a(Data::Value, {Dim::X, 1}, {1.0});
-  Variable b(Data::Int, {Dim::X, 1}, {2});
+  auto b = makeVariable<int64_t>(Data::Value, {Dim::X, 1}, {2});
   EXPECT_THROW_MSG(a += b, std::runtime_error,
                    "Cannot apply arithmetic operation to Variables: Underlying "
                    "data types do not match.");


### PR DESCRIPTION
- Remove data tags that encoded a data type --- the new way to achieve this is to use a custom `dtype` instead. Tags are not for types, but for conceptual grouping.
- Add Python exports for all dimensions and tags.

Also fixes #39. Nested datasets can be added as follows:

```python
        d = Dataset()
        table = Dataset()
        table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
        table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
        d[Data.Value, "data1"] = ([Dim.X], [table, table])
```