### PR TITLE
Avoid std::vector<bool>

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -370,6 +370,7 @@ PYBIND11_MODULE(dataset, m) {
 
   declare_span<double>(m, "double");
   declare_span<float>(m, "float");
+  declare_span<Bool>(m, "bool");
   declare_span<const double>(m, "double_const");
   declare_span<const std::string>(m, "string_const");
   declare_span<const Dim>(m, "Dim_const");
@@ -380,6 +381,7 @@ PYBIND11_MODULE(dataset, m) {
   declare_VariableView<int32_t>(m, "int32");
   declare_VariableView<std::string>(m, "string");
   declare_VariableView<char>(m, "char");
+  declare_VariableView<Bool>(m, "bool");
 
   py::class_<Dimensions>(m, "Dimensions")
       .def(py::init<>())

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -100,8 +100,8 @@ Variable makeVariable(const Tag tag, const std::vector<Dim> &labels,
   const auto dtypeTag = dtype.is(py::dtype::of<Empty>())
                             ? convertDType(data.dtype())
                             : convertDType(dtype);
-  return CallDType<double, float, int64_t, int32_t,
-                   char>::apply<detail::MakeVariable>(dtypeTag, tag, labels,
+  return CallDType<double, float, int64_t, int32_t, char,
+                   bool>::apply<detail::MakeVariable>(dtypeTag, tag, labels,
                                                       data);
 }
 
@@ -114,8 +114,8 @@ Variable makeVariableDefaultInit(const Tag tag, const std::vector<Dim> &labels,
   // py::dtype?
   const auto dtypeTag = dtype.is(py::dtype::of<Empty>()) ? defaultDType(tag)
                                                          : convertDType(dtype);
-  return CallDType<double, float, int64_t, int32_t,
-                   char>::apply<detail::MakeVariableDefaultInit>(dtypeTag, tag,
+  return CallDType<double, float, int64_t, int32_t, char,
+                   bool>::apply<detail::MakeVariableDefaultInit>(dtypeTag, tag,
                                                                  labels, shape);
 }
 
@@ -148,8 +148,8 @@ void insert_ndarray(
   const auto & [ tag, name ] = Key::get(key);
   const auto & [ labels, array ] = data;
   const auto dtypeTag = convertDType(array.dtype());
-  auto var = CallDType<double, float, int64_t, int32_t,
-                       char>::apply<detail::MakeVariable>(dtypeTag, tag, labels,
+  auto var = CallDType<double, float, int64_t, int32_t, char,
+                       bool>::apply<detail::MakeVariable>(dtypeTag, tag, labels,
                                                           array);
   if (!name.empty())
     var.setName(name);
@@ -233,8 +233,8 @@ template <class T, class K>
 void setData(T &self, const K &key, const py::array &data) {
   const auto & [ tag, name ] = Key::get(key);
   const auto slice = self(tag, name);
-  CallDType<double, float, int64_t, int32_t, char>::apply<detail::SetData>(
-      slice.dtype(), slice, data);
+  CallDType<double, float, int64_t, int32_t, char,
+            bool>::apply<detail::SetData>(slice.dtype(), slice, data);
 }
 
 VariableSlice pySlice(VariableSlice &view,
@@ -254,16 +254,16 @@ void setVariableSlice(VariableSlice &self,
                       const std::tuple<Dim, gsl::index> &index,
                       const py::array &data) {
   auto slice = self(std::get<Dim>(index), std::get<gsl::index>(index));
-  CallDType<double, float, int64_t, int32_t, char>::apply<detail::SetData>(
-      slice.dtype(), slice, data);
+  CallDType<double, float, int64_t, int32_t, char,
+            bool>::apply<detail::SetData>(slice.dtype(), slice, data);
 }
 
 void setVariableSliceRange(VariableSlice &self,
                            const std::tuple<Dim, const py::slice> &index,
                            const py::array &data) {
   auto slice = pySlice(self, index);
-  CallDType<double, float, int64_t, int32_t, char>::apply<detail::SetData>(
-      slice.dtype(), slice, data);
+  CallDType<double, float, int64_t, int32_t, char,
+            bool>::apply<detail::SetData>(slice.dtype(), slice, data);
 }
 } // namespace detail
 

--- a/src/bool.h
+++ b/src/bool.h
@@ -1,0 +1,19 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#ifndef BOOL_H
+#define BOOL_H
+
+class Bool {
+public:
+  Bool(const bool value = false) : m_value(value) {}
+  operator const bool &() const { return m_value; }
+  operator bool &() { return m_value; }
+
+private:
+  bool m_value;
+};
+
+#endif // BOOL_H

--- a/src/tags.h
+++ b/src/tags.h
@@ -29,6 +29,7 @@ template <> constexpr DType dtype<int64_t> = DType::Int64;
 template <> constexpr DType dtype<std::string> = DType::String;
 template <> constexpr DType dtype<char> = DType::Char;
 template <> constexpr DType dtype<bool> = DType::Bool;
+template <> constexpr DType dtype<Bool> = DType::Bool;
 
 // Adding new tags
 // ===============

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -680,26 +680,32 @@ void Variable::setDimensions(const Dimensions &dimensions) {
   m_object = m_object->clone(dimensions);
 }
 
-template <class T> const Vector<T> &Variable::cast() const {
-  return dynamic_cast<const DataModel<Vector<T>> &>(*m_object).m_model;
+template <class T> const Vector<underlying_type_t<T>> &Variable::cast() const {
+  return dynamic_cast<const DataModel<Vector<underlying_type_t<T>>> &>(
+             *m_object)
+      .m_model;
 }
 
-template <class T> Vector<T> &Variable::cast() {
-  return dynamic_cast<DataModel<Vector<T>> &>(*m_object).m_model;
+template <class T> Vector<underlying_type_t<T>> &Variable::cast() {
+  return dynamic_cast<DataModel<Vector<underlying_type_t<T>>> &>(*m_object)
+      .m_model;
 }
 
 #define INSTANTIATE(...)                                                       \
   template Variable::Variable(const Tag, const Unit::Id, const Dimensions &,   \
-                              Vector<__VA_ARGS__>);                            \
-  template Vector<__VA_ARGS__> &Variable::cast<__VA_ARGS__>();                 \
-  template const Vector<__VA_ARGS__> &Variable::cast<__VA_ARGS__>() const;
+                              Vector<underlying_type_t<__VA_ARGS__>>);         \
+  template Vector<underlying_type_t<__VA_ARGS__>>                              \
+      &Variable::cast<__VA_ARGS__>();                                          \
+  template const Vector<underlying_type_t<__VA_ARGS__>>                        \
+      &Variable::cast<__VA_ARGS__>() const;
 
 INSTANTIATE(std::string)
 INSTANTIATE(double)
 INSTANTIATE(float)
-INSTANTIATE(char)
-INSTANTIATE(int32_t)
 INSTANTIATE(int64_t)
+INSTANTIATE(int32_t)
+INSTANTIATE(char)
+INSTANTIATE(bool)
 INSTANTIATE(std::pair<int64_t, int64_t>)
 INSTANTIATE(ValueWithDelta<double>)
 #if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
@@ -984,34 +990,40 @@ void VariableSlice::setUnit(const Unit &unit) const {
 }
 
 template <class T>
-const VariableView<const T> ConstVariableSlice::cast() const {
+const VariableView<const underlying_type_t<T>>
+ConstVariableSlice::cast() const {
+  using TT = underlying_type_t<T>;
   if (!m_view)
-    return dynamic_cast<const DataModel<Vector<T>> &>(data()).getView(
+    return dynamic_cast<const DataModel<Vector<TT>> &>(data()).getView(
         dimensions());
   if (m_view->isConstView())
-    return dynamic_cast<const ViewModel<VariableView<const T>> &>(data())
+    return dynamic_cast<const ViewModel<VariableView<const TT>> &>(data())
         .m_model;
   // Make a const view from the mutable one.
-  return {dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model,
+  return {dynamic_cast<const ViewModel<VariableView<TT>> &>(data()).m_model,
           dimensions()};
 }
 
-template <class T> VariableView<T> VariableSlice::cast() const {
+template <class T>
+VariableView<underlying_type_t<T>> VariableSlice::cast() const {
+  using TT = underlying_type_t<T>;
   if (m_view)
-    return dynamic_cast<const ViewModel<VariableView<T>> &>(data()).m_model;
-  return dynamic_cast<DataModel<Vector<T>> &>(data()).getView(dimensions());
+    return dynamic_cast<const ViewModel<VariableView<TT>> &>(data()).m_model;
+  return dynamic_cast<DataModel<Vector<TT>> &>(data()).getView(dimensions());
 }
 
 #define INSTANTIATE_SLICEVIEW(...)                                             \
-  template const VariableView<const __VA_ARGS__>                               \
+  template const VariableView<const underlying_type_t<__VA_ARGS__>>            \
   ConstVariableSlice::cast<__VA_ARGS__>() const;                               \
-  template VariableView<__VA_ARGS__> VariableSlice::cast() const;
+  template VariableView<underlying_type_t<__VA_ARGS__>>                        \
+  VariableSlice::cast<__VA_ARGS__>() const;
 
 INSTANTIATE_SLICEVIEW(double);
 INSTANTIATE_SLICEVIEW(float);
 INSTANTIATE_SLICEVIEW(int64_t);
 INSTANTIATE_SLICEVIEW(int32_t);
 INSTANTIATE_SLICEVIEW(char);
+INSTANTIATE_SLICEVIEW(bool);
 INSTANTIATE_SLICEVIEW(std::string);
 
 ConstVariableSlice Variable::operator()(const Dim dim, const gsl::index begin,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # @author Simon Heybrock
 # Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 # National Laboratory, and European Spallation Source ERIC.
-add_executable ( dataset_test tags_test.cpp dataset_test.cpp md_zip_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp zip_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp )
+add_executable ( dataset_test tags_test.cpp dataset_test.cpp md_zip_view_test.cpp variable_test.cpp variable_view_test.cpp dimensions_test.cpp unit_test.cpp multi_index_test.cpp TableWorkspace_test.cpp Workspace2D_test.cpp EventWorkspace_test.cpp zip_view_test.cpp Run_test.cpp except_test.cpp example_instrument_test.cpp bool_test.cpp )
 target_link_libraries( dataset_test
   LINK_PRIVATE
   Dataset

--- a/test/Workspace2D_test.cpp
+++ b/test/Workspace2D_test.cpp
@@ -212,7 +212,7 @@ TEST(Workspace2D, masking) {
   // Spectra mask.
   // Can be in its own Dataset to support loading, saving, and manipulation.
   Dataset mask;
-  mask.insert(Coord::Mask, {Dim::Spectrum, 3}, Vector<char>{0, 0, 1});
+  mask.insert(Coord::Mask, {Dim::Spectrum, 3}, {false, false, true});
 
   // Add mask to Dataset, not touching data.
   auto d_masked(d);

--- a/test/bool_test.cpp
+++ b/test/bool_test.cpp
@@ -1,0 +1,50 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#include <gtest/gtest.h>
+
+#include "bool.h"
+
+TEST(Bool, size) { EXPECT_EQ(sizeof(Bool), 1ul); }
+
+TEST(Bool, std_vector_initializer_list) {
+  std::vector<Bool> bs{true, false};
+  EXPECT_EQ(bs[0], true);
+  EXPECT_EQ(bs[1], false);
+}
+
+TEST(Bool, avoids_std_vector_specialization) {
+  std::vector<Bool> bytes[9];
+  EXPECT_EQ(&bytes[0] + 8, &bytes[8]);
+
+  // For comparison, the following *may* fail (bool specialization is not
+  // *guaranteed* by the standard, so we cannot actually assert on this).
+  // std::vector<bool> packed[9];
+  // EXPECT_EQ(&packed[0] + 8, &packed[8]);
+}
+
+TEST(Bool, basics) {
+  Bool b;
+  EXPECT_FALSE(b);
+  EXPECT_TRUE(Bool(true));
+  EXPECT_EQ(Bool(false), false);
+  EXPECT_EQ(Bool(true), true);
+  EXPECT_NE(Bool(false), true);
+  EXPECT_NE(Bool(true), false);
+}
+
+TEST(Bool, assign_to_bool) {
+  bool b = Bool(true);
+  EXPECT_TRUE(b);
+  b = Bool(false);
+  EXPECT_FALSE(b);
+}
+
+TEST(Bool, assign_from_bool) {
+  Bool b = true;
+  EXPECT_TRUE(b);
+  b = false;
+  EXPECT_FALSE(b);
+}


### PR DESCRIPTION
Use `std::vector<Bool>` in `Variable` to avoid potential issues with the `std::vector<bool>` specialization, in particular thread-safety issues, see https://en.cppreference.com/w/cpp/container/vector_bool.

This should also match `numpy`'s bool, which is stored as a single byte (not packed).