### PR TITLE
Add counts conversions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(INC_FILES
 
 set(SRC_FILES
   convert.cpp 
+  counts.cpp
   dataset.cpp 
   dimensions.cpp
   except.cpp

--- a/src/counts.cpp
+++ b/src/counts.cpp
@@ -1,0 +1,52 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#include "counts.h"
+#include "dataset.h"
+
+namespace counts {
+Dataset toDensity(Dataset d, const Dim dim) {
+  const auto &coord = d(dimensionCoord(dim));
+  if (coord.unit() == Unit::Id::Dimensionless)
+    throw std::runtime_error(
+        "Dimensionless axis cannot be used for conversion to density");
+  auto binWidths = coord(dim, 1, coord.dimensions()[dim]) -
+                   coord(dim, 0, coord.dimensions()[dim] - 1);
+  for(const auto &var : d) {
+    if (var.isData()) {
+      // TODO Should we fail if there are variables that are already
+      // count-densities?
+      if (var.unit() == Unit::Id::Counts) {
+        var /= binWidths;
+      } else if(var.unit() == Unit::Id::CountsVariance) {
+        var /= binWidths * binWidths;
+      }
+    }
+  }
+  return std::move(d);
+}
+
+Dataset fromDensity(Dataset d, const Dim dim) {
+  const auto &coord = d(dimensionCoord(dim));
+  if (coord.unit() == Unit::Id::Dimensionless)
+    throw std::runtime_error(
+        "Dimensionless axis cannot be used for conversion from density");
+  auto binWidths = coord(dim, 1, coord.dimensions()[dim]) -
+                   coord(dim, 0, coord.dimensions()[dim] - 1);
+  for(const auto &var : d) {
+    if (var.isData()) {
+      if (var.unit() == Unit::Id::Counts) {
+        // TODO Already counts, ignore silently? See also toDensity.
+        var /= binWidths;
+      } else if(units::containsCounts(var.unit())) {
+        var *= binWidths;
+      } else if(units::containsCountsVariance(var.unit())) {
+        var *= binWidths * binWidths;
+      }
+    }
+  }
+  return std::move(d);
+}
+} // namespace counts

--- a/src/counts.h
+++ b/src/counts.h
@@ -1,0 +1,18 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#ifndef COUNTS_H
+#define COUNTS_H
+
+#include "dimension.h"
+
+class Dataset;
+
+namespace counts {
+Dataset toDensity(Dataset d, const Dim dim);
+Dataset fromDensity(Dataset d, const Dim dim);
+} // namespace counts
+
+#endif // COUNTS_H

--- a/src/counts.h
+++ b/src/counts.h
@@ -6,13 +6,17 @@
 #ifndef COUNTS_H
 #define COUNTS_H
 
+#include <initializer_list>
+
 #include "dimension.h"
 
 class Dataset;
 
 namespace counts {
 Dataset toDensity(Dataset d, const Dim dim);
+Dataset toDensity(Dataset d, const std::initializer_list<Dim> &dims);
 Dataset fromDensity(Dataset d, const Dim dim);
+Dataset fromDensity(Dataset d, const std::initializer_list<Dim> &dims);
 } // namespace counts
 
 #endif // COUNTS_H

--- a/src/except.h
+++ b/src/except.h
@@ -83,6 +83,9 @@ template <class T> void contains(const T &a, const T &b) {
     throw std::runtime_error("Expected " + to_string(a) + " to contain " +
                              to_string(b) + ".");
 }
+template <class T> void unit(const T &object, const Unit &unit) {
+  expect::equals(object.unit(), unit);
+}
 } // namespace expect
 } // namespace dataset
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -405,6 +405,26 @@ make_coordinate_dimension(const std::tuple<Ts...> &) {
 constexpr auto isDimensionCoord = make_is_dimension_coordinate(detail::Tags{});
 constexpr auto coordDimension = make_coordinate_dimension(detail::Tags{});
 
+inline Tag dimensionCoord(const Dim dim) {
+  switch (dim) {
+  case Dim::X:
+    return Coord::X;
+  case Dim::Y:
+    return Coord::Y;
+  case Dim::Z:
+    return Coord::Z;
+  case Dim::Tof:
+    return Coord::Tof;
+  case Dim::Energy:
+    return Coord::Energy;
+  case Dim::DeltaE:
+    return Coord::DeltaE;
+  default:
+    throw std::runtime_error(
+        "Coordinate for this dimension is not implemented");
+  }
+}
+
 namespace detail {
 template <class... Ts>
 constexpr std::array<Unit::Id, std::tuple_size<detail::Tags>::value>

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "convert.h"
+#include "counts.h"
 #include "dataset.h"
 #include "dimensions.h"
 
@@ -1528,4 +1529,21 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
   ASSERT_TRUE(energy.contains(Coord::Position));
   ASSERT_TRUE(energy.contains(Coord::ComponentInfo));
   ASSERT_TRUE(energy.contains(Coord::Ei));
+}
+
+TEST(Dataset, counts_toDensity_fromDensity) {
+  Dataset d;
+  d.insert(Coord::X, {Dim::X, 4}, {1, 2, 4, 8});
+  d.insert(Data::Value, "", {Dim::X, 3}, {12, 12, 12});
+  d(Data::Value, "").setUnit(Unit::Id::Counts);
+
+  d = counts::toDensity(std::move(d), Dim::X);
+  auto result = d(Data::Value, "");
+  EXPECT_EQ(result.unit(), Unit::Id::CountsPerMeter);
+  EXPECT_TRUE(equals(result.get(Data::Value), {12, 6, 3}));
+
+  d = counts::fromDensity(std::move(d), Dim::X);
+  result = d(Data::Value, "");
+  EXPECT_EQ(result.unit(), Unit::Id::Counts);
+  EXPECT_TRUE(equals(result.get(Data::Value), {12, 12, 12}));
 }


### PR DESCRIPTION
This adds functionality provided in Mantid by the algorithms `ConvertToHistogram` and `ConvertToDistribution`. In contrast to Mantid, we do not use a special flag to track the state of the data, rather this is done using the units system.

The code already supports also a multi-dimensional generalization, e.g., for `counts/(m*m*us)` but there are no tests for that yet --- it would require adding more units, and I would like to postpone that until some other related refactoring is done.