### PR TITLE
Continue unit conversion implementation

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -63,19 +63,10 @@ Dataset tofToEnergy(const Dataset &d) {
     if (varDims.contains(Dim::Tof))
       varDims.relabel(varDims.index(Dim::Tof), Dim::Energy);
     if (var.tag() == Coord::Tof) {
-      // TODO Need to extend the broadcasting capabilities to broadcast to the
-      // union of dimensions of both operands in a binary operation.
-      auto dims = conversionFactor.dimensions();
-      for (const Dim dim : varDims.labels())
-        if (!dims.contains(dim))
-          dims.addInner(dim, varDims[dim]);
-      // TODO Should have a broadcasting assign method?
-      Variable energy(Data::Value, dims, dims.volume(), 1.0);
-      energy *= conversionFactor;
-      // The reshape is just to remap the dimension label, should probably do
-      // this differently.
-      energy /= (var * var).reshape(varDims);
-      converted.insert(Coord::Energy, std::move(energy));
+      // The reshape is to remap the dimension label, should probably be done
+      // differently. Binary op order is to get desired dimension broadcast.
+      Variable inv = 1.0 / (var * var).reshape(varDims);
+      converted.insert(Coord::Energy, std::move(inv) * conversionFactor);
     } else if (var.tag() == Data::Events) {
       throw std::runtime_error(
           "TODO Converting units of event data not implemented yet.");

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -97,6 +97,11 @@ public:
   }
 
   void insert(Variable variable);
+  void insert(const Tag tag, Variable variable) {
+    variable.setTag(tag);
+    variable.setName("");
+    insert(std::move(variable));
+  }
 
   template <class Tag, class... Args>
   void insert(const Tag tag, const Dimensions &dimensions, Args &&... args) {

--- a/src/tags.h
+++ b/src/tags.h
@@ -133,7 +133,7 @@ struct CoordDef {
   };
   struct DeltaE {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Energy;
   };
   struct Ei {
     using type = double;

--- a/src/tags.h
+++ b/src/tags.h
@@ -125,7 +125,7 @@ struct CoordDef {
   };
   struct Tof {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Tof;
   };
   struct Energy {
     using type = double;
@@ -199,7 +199,7 @@ struct CoordDef {
 struct DataDef {
   struct Tof {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Tof;
   };
   struct PulseTime {
     using type = double;
@@ -231,7 +231,7 @@ struct DataDef {
   };
   struct EventTofs {
     using type = boost::container::small_vector<double, 8>;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Tof;
   };
   struct EventPulseTimes {
     using type = boost::container::small_vector<double, 8>;

--- a/src/tags.h
+++ b/src/tags.h
@@ -129,7 +129,7 @@ struct CoordDef {
   };
   struct Energy {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Energy;
   };
   struct DeltaE {
     using type = double;
@@ -137,11 +137,11 @@ struct CoordDef {
   };
   struct Ei {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Energy;
   };
   struct Ef {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = Unit::Id::Energy;
   };
   struct DetectorId {
     using type = int32_t;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -52,7 +52,7 @@ Unit::Unit(const Unit::Id id) {
     m_unit = none / s;
     break;
   case Unit::Id::Energy:
-    m_unit = mev * none;
+    m_unit = meV * none;
     break;
   case Unit::Id::Wavelength:
     m_unit = lambda * none;
@@ -85,7 +85,7 @@ Unit::Id Unit::id() const {
                  [](decltype(counts / m)) { return Unit::Id::CountsPerMeter; },
                  [](decltype(none / m)) { return Unit::Id::InverseLength; },
                  [](decltype(none / s)) { return Unit::Id::InverseTime; },
-                 [](decltype(mev * none)) { return Unit::Id::Energy; },
+                 [](decltype(meV * none)) { return Unit::Id::Energy; },
                  [](decltype(lambda * none)) { return Unit::Id::Wavelength; },
                  [](decltype(s)) { return Unit::Id::Time; },
                  [](decltype(tof * none)) { return Unit::Id::Tof; },

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -141,28 +141,14 @@ Unit operator+(const Unit &a, const Unit &b) {
   return a;
 }
 
-// See https://stackoverflow.com/a/9154394
-using boost::units::sqrt;
-template <class> struct sfinae_true : std::true_type {};
-template <class T>
-static auto test_sqrt(int)
-    -> sfinae_true<decltype(sqrt(1.0 * std::declval<T>()))>;
-template <class> static auto test_sqrt(long) -> std::false_type;
-template <class T> struct sqrt_exists : decltype(test_sqrt<T>(0)) {};
-
 Unit sqrt(const Unit &a) {
   return std::visit(
       [](auto x) -> Unit::unit_t {
-        if constexpr (sqrt_exists<decltype(x)>::value) {
-          typename decltype(sqrt(1.0 * x))::unit_type sqrt_x;
-          if constexpr (isKnownUnit(sqrt_x))
-            return {sqrt_x};
-          std::stringstream msg;
-          msg << "Unsupported unit as result of sqrt, sqrt(" << x << ").";
-          throw std::runtime_error(msg.str());
-        }
+        typename decltype(sqrt(1.0 * x))::unit_type sqrt_x;
+        if constexpr (isKnownUnit(sqrt_x))
+          return {sqrt_x};
         std::stringstream msg;
-        msg << "Square root of unit " << x << " does not exist.";
+        msg << "Unsupported unit as result of sqrt, sqrt(" << x << ").";
         throw std::runtime_error(msg.str());
       },
       a.getUnit());

--- a/src/unit.h
+++ b/src/unit.h
@@ -110,6 +110,14 @@ static neutron::tof::energy meV;
 static neutron::tof::tof tof;
 
 // TODO counts/m is mainly for testing and should maybe be removed.
+// Note the factor `none` in units that otherwise contain only non-SI factors.
+// This is a trick to overcome some subtleties of working with heterogeneous
+// unit systems in boost::units: We are combing SI units with our own, and the
+// two are considered independent unless you convert explicitly. Therefore, in
+// operations like (counts * m) / m, boosts is not cancelling the m as expected
+// --- you get counts * dimensionless. Explicitly putting a factor dimensionless
+// (none) into all our non-SI units avoids special-case handling in all
+// operations (which would attempt to remove the dimensionless factor manually).
 using type = std::variant<
     decltype(none), decltype(m), decltype(m2), decltype(s), decltype(kg),
     decltype(counts * none), decltype(none / m), decltype(lambda * none),
@@ -174,6 +182,7 @@ inline bool operator!=(const Unit &a, const Unit &b) { return !(a == b); }
 Unit operator+(const Unit &a, const Unit &b);
 Unit operator*(const Unit &a, const Unit &b);
 Unit operator/(const Unit &a, const Unit &b);
+Unit sqrt(const Unit &a);
 
 namespace units {
 inline bool containsCounts(const Unit &unit) {

--- a/src/unit.h
+++ b/src/unit.h
@@ -106,16 +106,17 @@ static boost::units::si::time s;
 static boost::units::si::mass kg;
 static neutron::tof::counts counts;
 static neutron::tof::wavelength lambda;
-static neutron::tof::energy mev;
+static neutron::tof::energy meV;
 static neutron::tof::tof tof;
 
 // TODO counts/m is mainly for testing and should maybe be removed.
-using type =
-    std::variant<decltype(none), decltype(m), decltype(m2), decltype(s),
-                 decltype(kg), decltype(counts * none), decltype(none / m),
-                 decltype(lambda * none), decltype(mev * none),
-                 decltype(tof * none), decltype(none / s), decltype(m2 * m2),
-                 decltype(counts * counts * none), decltype(counts / m)>;
+using type = std::variant<
+    decltype(none), decltype(m), decltype(m2), decltype(s), decltype(kg),
+    decltype(counts * none), decltype(none / m), decltype(lambda * none),
+    decltype(meV * none), decltype(tof * none), decltype(tof * tof * none),
+    decltype(none / s), decltype(m2 * m2), decltype(counts * counts * none),
+    decltype(counts / m), decltype(meV * tof * tof / m2),
+    decltype(meV * tof * tof * none)>;
 } // namespace units
 
 class Unit {

--- a/src/unit.h
+++ b/src/unit.h
@@ -122,8 +122,8 @@ using type = std::variant<
     decltype(none), decltype(m), decltype(m2), decltype(s), decltype(kg),
     decltype(counts * none), decltype(none / m), decltype(lambda * none),
     decltype(meV * none), decltype(tof * none), decltype(tof * tof * none),
-    decltype(none / (tof * tof)), decltype(none / s), decltype(m2 * m2),
-    decltype(counts * counts * none), decltype(counts / m),
+    decltype(none / tof), decltype(none / (tof * tof)), decltype(none / s),
+    decltype(m2 * m2), decltype(counts * counts * none), decltype(counts / m),
     decltype(meV * tof * tof / m2), decltype(meV * tof * tof * none)>;
 } // namespace units
 

--- a/src/unit.h
+++ b/src/unit.h
@@ -114,9 +114,9 @@ using type = std::variant<
     decltype(none), decltype(m), decltype(m2), decltype(s), decltype(kg),
     decltype(counts * none), decltype(none / m), decltype(lambda * none),
     decltype(meV * none), decltype(tof * none), decltype(tof * tof * none),
-    decltype(none / s), decltype(m2 * m2), decltype(counts * counts * none),
-    decltype(counts / m), decltype(meV * tof * tof / m2),
-    decltype(meV * tof * tof * none)>;
+    decltype(none / (tof * tof)), decltype(none / s), decltype(m2 * m2),
+    decltype(counts * counts * none), decltype(counts / m),
+    decltype(meV * tof * tof / m2), decltype(meV * tof * tof * none)>;
 } // namespace units
 
 class Unit {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1281,6 +1281,22 @@ Variable norm(const Variable &var) {
   return {var, require<const ArithmeticVariableConcept>(var.data()).norm()};
 }
 
+Variable broadcast(Variable var, const Dimensions &dims) {
+  if (var.dimensions().contains(dims))
+    return std::move(var);
+  auto newDims = var.dimensions();
+  for (const auto label : dims.labels()) {
+    if (newDims.contains(label))
+      dataset::expect::dimensionMatches(newDims, label, dims[label]);
+    else
+      newDims.add(label, dims[label]);
+  }
+  Variable result(var);
+  result.setDimensions(newDims);
+  result.data().copy(var.data(), Dim::Invalid, 0, 0, 1);
+  return result;
+}
+
 template <>
 VariableView<const double> getView<double>(const Variable &var,
                                            const Dimensions &dims) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -8,10 +8,11 @@
 #include "except.h"
 #include "variable_view.h"
 
-template <template <class> class Op, class T> struct ArithmeticHelper {
+template <template <class, class> class Op, class T1, class T2>
+struct ArithmeticHelper {
   template <class InputView, class OutputView>
   static void apply(const OutputView &a, const InputView &b) {
-    std::transform(a.begin(), a.end(), b.begin(), a.begin(), Op<T>());
+    std::transform(a.begin(), a.end(), b.begin(), a.begin(), Op<T1, T2>());
   }
 };
 
@@ -136,6 +137,8 @@ public:
   virtual VariableConcept &operator+=(const VariableConcept &other) = 0;
 };
 
+// This is also used for implementing operations for vector spaces, notably
+// Eigen::Vector3d.
 class ArithmeticVariableConcept : public AddableVariableConcept {
 public:
   static constexpr const char *name = "arithmetic";
@@ -143,6 +146,8 @@ public:
   virtual VariableConcept &operator-=(const VariableConcept &other) = 0;
   virtual VariableConcept &operator*=(const VariableConcept &other) = 0;
   virtual VariableConcept &operator/=(const VariableConcept &other) = 0;
+  /// Returns the absolute value (for scalars) or the norm (for vectors).
+  virtual std::unique_ptr<VariableConcept> norm() const = 0;
 };
 
 class FloatingPointVariableConcept : public ArithmeticVariableConcept {
@@ -170,8 +175,12 @@ struct concept<T, std::enable_if_t<std::is_same<T, Dataset>::value>> {
   using type = AddableVariableConcept;
   using typeT = AddableVariableConceptT<T>;
 };
+template <class T> struct is_vector_space : std::false_type {};
+template <class T, int Rows>
+struct is_vector_space<Eigen::Matrix<T, Rows, 1>> : std::true_type {};
 template <class T>
-struct concept<T, std::enable_if_t<std::is_integral<T>::value>> {
+struct concept<T, std::enable_if_t<std::is_integral<T>::value ||
+                                   is_vector_space<T>::value>> {
   using type = ArithmeticVariableConcept;
   using typeT = ArithmeticVariableConceptT<T>;
 };
@@ -318,47 +327,48 @@ public:
       }
     }
   }
-};
 
-template <class T> class AddableVariableConceptT : public VariableConceptT<T> {
-public:
-  using VariableConceptT<T>::VariableConceptT;
-
-  template <template <class> class Op>
+  template <template <class, class> class Op, class OtherT = T>
   VariableConcept &apply(const VariableConcept &other) {
     const auto &dims = this->dimensions();
     try {
-      const auto &otherT = dynamic_cast<const VariableConceptT<T> &>(other);
-      if (this->getView(dims).overlaps(otherT.getView(dims))) {
-        // If there is an overlap between lhs and rhs we copy the rhs before
-        // applying the operation.
-        const auto &data = otherT.getView(otherT.dimensions());
-        DataModel<Vector<T>> copy(other.dimensions(),
-                                  Vector<T>(data.begin(), data.end()));
-        return apply<Op>(copy);
-      }
+      const auto &otherT =
+          dynamic_cast<const VariableConceptT<OtherT> &>(other);
+      if constexpr (std::is_same_v<T, OtherT>)
+        if (this->getView(dims).overlaps(otherT.getView(dims))) {
+          // If there is an overlap between lhs and rhs we copy the rhs before
+          // applying the operation.
+          const auto &data = otherT.getView(otherT.dimensions());
+          DataModel<Vector<OtherT>> copy(
+              other.dimensions(), Vector<OtherT>(data.begin(), data.end()));
+          return apply<Op, OtherT>(copy);
+        }
 
       if (this->isContiguous() && dims.contains(other.dimensions())) {
         if (other.isContiguous() && dims.isContiguousIn(other.dimensions())) {
-          ArithmeticHelper<Op, T>::apply(this->getSpan(), otherT.getSpan());
+          ArithmeticHelper<Op, T, OtherT>::apply(this->getSpan(),
+                                                 otherT.getSpan());
         } else {
-          ArithmeticHelper<Op, T>::apply(this->getSpan(), otherT.getView(dims));
+          ArithmeticHelper<Op, T, OtherT>::apply(this->getSpan(),
+                                                 otherT.getView(dims));
         }
       } else if (dims.contains(other.dimensions())) {
         if (other.isContiguous() && dims.isContiguousIn(other.dimensions())) {
-          ArithmeticHelper<Op, T>::apply(this->getView(dims), otherT.getSpan());
+          ArithmeticHelper<Op, T, OtherT>::apply(this->getView(dims),
+                                                 otherT.getSpan());
         } else {
-          ArithmeticHelper<Op, T>::apply(this->getView(dims),
-                                         otherT.getView(dims));
+          ArithmeticHelper<Op, T, OtherT>::apply(this->getView(dims),
+                                                 otherT.getView(dims));
         }
       } else {
         // LHS has fewer dimensions than RHS, e.g., for computing sum. Use view.
         if (other.isContiguous() && dims.isContiguousIn(other.dimensions())) {
-          ArithmeticHelper<Op, T>::apply(this->getView(other.dimensions()),
-                                         otherT.getSpan());
+          ArithmeticHelper<Op, T, OtherT>::apply(
+              this->getView(other.dimensions()), otherT.getSpan());
         } else {
-          ArithmeticHelper<Op, T>::apply(this->getView(other.dimensions()),
-                                         otherT.getView(other.dimensions()));
+          ArithmeticHelper<Op, T, OtherT>::apply(
+              this->getView(other.dimensions()),
+              otherT.getView(other.dimensions()));
         }
       }
     } catch (const std::bad_cast &) {
@@ -368,9 +378,53 @@ public:
     }
     return *this;
   }
+};
+
+// For operations with vector spaces we may have operations between a scalar and
+// a vector, so we cannot use std::multiplies, which is available only for
+// arguments of matching types.
+template <class T1, class T2 = T1> struct plus {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+    return lhs + rhs;
+  }
+};
+template <class T1, class T2 = T1> struct minus {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+    return lhs - rhs;
+  }
+};
+template <class T1, class T2 = T1> struct multiplies {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+    return lhs * rhs;
+  }
+};
+template <class T1, class T2 = T1> struct divides {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+    return lhs / rhs;
+  }
+};
+template <class T1, class T2> struct norm_of_second_arg {
+  constexpr T1 operator()(const T1 &, const T2 &rhs) const noexcept {
+    // TODO Should we make a unary ArithmeticHelper::apply?
+    if constexpr (is_vector_space<T2>::value)
+      return rhs.norm();
+    else
+      return abs(rhs);
+  }
+};
+
+template <class T> struct scalar_type { using type = T; };
+template <class T, int Rows> struct scalar_type<Eigen::Matrix<T, Rows, 1>> {
+  using type = T;
+};
+template <class T> using scalar_type_t = typename scalar_type<T>::type;
+
+template <class T> class AddableVariableConceptT : public VariableConceptT<T> {
+public:
+  using VariableConceptT<T>::VariableConceptT;
 
   VariableConcept &operator+=(const VariableConcept &other) override {
-    return apply<std::plus>(other);
+    return this->template apply<plus>(other);
   }
 };
 
@@ -380,20 +434,28 @@ public:
   using AddableVariableConceptT<T>::AddableVariableConceptT;
 
   VariableConcept &operator-=(const VariableConcept &other) override {
-    return this->template apply<std::minus>(other);
+    return this->template apply<minus>(other);
   }
 
   VariableConcept &operator*=(const VariableConcept &other) override {
-    return this->template apply<std::multiplies>(other);
+    return this->template apply<multiplies, scalar_type_t<T>>(other);
   }
 
   VariableConcept &operator/=(const VariableConcept &other) override {
-    return this->template apply<std::divides>(other);
+    return this->template apply<divides, scalar_type_t<T>>(other);
+  }
+
+  std::unique_ptr<VariableConcept> norm() const override {
+    using ScalarT = scalar_type_t<T>;
+    auto norm = std::make_unique<DataModel<Vector<ScalarT>>>(
+        this->dimensions(), Vector<ScalarT>(this->dimensions().volume()));
+    norm->template apply<norm_of_second_arg, T>(*this);
+    return norm;
   }
 };
 
-template <class T> struct ReciprocalTimes {
-  T operator()(const T a, const T b) { return b / a; };
+template <class T1, class T2> struct ReciprocalTimes {
+  T2 operator()(const T1 a, const T2 b) { return b / a; };
 };
 
 template <class T>
@@ -1213,6 +1275,10 @@ Variable mean(const Variable &var, const Dim dim) {
   auto summed = sum(var, dim);
   double scale = 1.0 / static_cast<double>(var.dimensions()[dim]);
   return summed * Variable(Data::Value, {}, {scale});
+}
+
+Variable norm(const Variable &var) {
+  return {var, require<const ArithmeticVariableConcept>(var.data()).norm()};
 }
 
 template <>

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1113,21 +1113,37 @@ Variable ConstVariableSlice::reshape(const Dimensions &dims) const {
 
 // Note: The std::move here is necessary because RVO does not work for variables
 // that are function parameters.
-Variable operator+(Variable a, const Variable &b) { return std::move(a += b); }
-Variable operator-(Variable a, const Variable &b) { return std::move(a -= b); }
-Variable operator*(Variable a, const Variable &b) { return std::move(a *= b); }
-Variable operator/(Variable a, const Variable &b) { return std::move(a /= b); }
+Variable operator+(Variable a, const Variable &b) {
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result += b;
+}
+Variable operator-(Variable a, const Variable &b) {
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result -= b;
+}
+Variable operator*(Variable a, const Variable &b) {
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result *= b;
+}
+Variable operator/(Variable a, const Variable &b) {
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result /= b;
+}
 Variable operator+(Variable a, const ConstVariableSlice &b) {
-  return std::move(a += b);
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result += b;
 }
 Variable operator-(Variable a, const ConstVariableSlice &b) {
-  return std::move(a -= b);
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result -= b;
 }
 Variable operator*(Variable a, const ConstVariableSlice &b) {
-  return std::move(a *= b);
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result *= b;
 }
 Variable operator/(Variable a, const ConstVariableSlice &b) {
-  return std::move(a /= b);
+  auto result = broadcast(std::move(a), b.dimensions());
+  return result /= b;
 }
 Variable operator+(Variable a, const double b) { return std::move(a += b); }
 Variable operator-(Variable a, const double b) { return std::move(a -= b); }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -384,27 +384,27 @@ public:
 // a vector, so we cannot use std::multiplies, which is available only for
 // arguments of matching types.
 template <class T1, class T2 = T1> struct plus {
-  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const {
     return lhs + rhs;
   }
 };
 template <class T1, class T2 = T1> struct minus {
-  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const {
     return lhs - rhs;
   }
 };
 template <class T1, class T2 = T1> struct multiplies {
-  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const {
     return lhs * rhs;
   }
 };
 template <class T1, class T2 = T1> struct divides {
-  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const noexcept {
+  constexpr T1 operator()(const T1 &lhs, const T2 &rhs) const {
     return lhs / rhs;
   }
 };
 template <class T1, class T2> struct norm_of_second_arg {
-  constexpr T1 operator()(const T1 &, const T2 &rhs) const noexcept {
+  constexpr T1 operator()(const T1 &, const T2 &rhs) const {
     // TODO Should we make a unary ArithmeticHelper::apply?
     if constexpr (is_vector_space<T2>::value)
       return rhs.norm();

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1312,7 +1312,10 @@ Variable norm(const Variable &var) {
 }
 
 Variable sqrt(const Variable &var) {
-  return {var, require<const FloatingPointVariableConcept>(var.data()).sqrt()};
+  Variable result(
+      var, require<const FloatingPointVariableConcept>(var.data()).sqrt());
+  result.setUnit(sqrt(var.unit()));
+  return result;
 }
 
 Variable broadcast(Variable var, const Dimensions &dims) {

--- a/src/variable.h
+++ b/src/variable.h
@@ -140,6 +140,9 @@ public:
   // variable slices to functions that do not support slices, but implicit
   // conversion may introduce risks, so there is a trade-of here.
   Variable(const ConstVariableSlice &slice);
+  Variable(const Variable &parent, std::unique_ptr<VariableConcept> data)
+      : m_tag(parent.tag()), m_unit(parent.unit()), m_name(parent.m_name),
+        m_object(std::move(data)) {}
 
   template <class TagT>
   Variable(TagT tag, const Dimensions &dimensions)
@@ -561,6 +564,7 @@ Variable permute(const Variable &var, const Dim dim,
 Variable filter(const Variable &var, const Variable &filter);
 Variable sum(const Variable &var, const Dim dim);
 Variable mean(const Variable &var, const Dim dim);
+Variable norm(const Variable &var);
 
 template <class T>
 VariableView<const T> getView(const Variable &var, const Dimensions &dims);

--- a/src/variable.h
+++ b/src/variable.h
@@ -6,6 +6,8 @@
 #ifndef VARIABLE_H
 #define VARIABLE_H
 
+#include <iostream>
+#include <boost/units/io.hpp>
 #include <string>
 #include <type_traits>
 
@@ -187,10 +189,10 @@ public:
     return *m_name;
   }
   void setName(const std::string &name) {
-    if (isCoord())
-      throw std::runtime_error("Coordinate variable cannot have a name.");
     if (name.empty())
       m_name = nullptr;
+    else if (isCoord())
+      throw std::runtime_error("Coordinate variable cannot have a name.");
     else if (m_name)
       *m_name = name;
     else
@@ -210,6 +212,10 @@ public:
   Variable &operator*=(const Variable &other) &;
   Variable &operator*=(const ConstVariableSlice &other) &;
   Variable &operator*=(const double value) &;
+  template <class T> Variable &operator*=(const T &quantity) & {
+    setUnit(unit() * Unit(typename T::unit_type{}));
+    return *this *= quantity.value();
+  }
   Variable &operator/=(const Variable &other) &;
   Variable &operator/=(const ConstVariableSlice &other) &;
   Variable &operator/=(const double value) &;

--- a/src/variable.h
+++ b/src/variable.h
@@ -571,6 +571,7 @@ Variable filter(const Variable &var, const Variable &filter);
 Variable sum(const Variable &var, const Dim dim);
 Variable mean(const Variable &var, const Dim dim);
 Variable norm(const Variable &var);
+Variable sqrt(const Variable &var);
 Variable broadcast(Variable var, const Dimensions &dims);
 
 template <class T>

--- a/src/variable.h
+++ b/src/variable.h
@@ -559,6 +559,10 @@ Variable operator+(const double a, Variable b);
 Variable operator-(const double a, Variable b);
 Variable operator*(const double a, Variable b);
 Variable operator/(const double a, Variable b);
+template <class T>
+Variable operator*(Variable a, const boost::units::quantity<T> &quantity) {
+  return std::move(a *= quantity);
+}
 
 std::vector<Variable> split(const Variable &var, const Dim dim,
                             const std::vector<gsl::index> &indices);

--- a/src/variable.h
+++ b/src/variable.h
@@ -571,6 +571,7 @@ Variable filter(const Variable &var, const Variable &filter);
 Variable sum(const Variable &var, const Dim dim);
 Variable mean(const Variable &var, const Dim dim);
 Variable norm(const Variable &var);
+Variable broadcast(Variable var, const Dimensions &dims);
 
 template <class T>
 VariableView<const T> getView(const Variable &var, const Dimensions &dims);

--- a/src/variable.h
+++ b/src/variable.h
@@ -6,8 +6,6 @@
 #ifndef VARIABLE_H
 #define VARIABLE_H
 
-#include <iostream>
-#include <boost/units/io.hpp>
 #include <string>
 #include <type_traits>
 

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -556,8 +556,9 @@ TEST(Dataset, operator_times_equal_histogram_data) {
   b.insert(Data::Variance, "name1", {Dim::X, 1}, {4.0});
 
   // Counts (aka "histogram data") times counts not possible.
-  EXPECT_THROW_MSG(a *= a, std::runtime_error,
-                   "Unsupported unit combination in multiplication");
+  EXPECT_THROW_MSG(
+      a *= a, std::runtime_error,
+      "Unsupported unit as result of multiplication counts^2*counts^2");
   // Counts times frequencies (aka "distribution") ok.
   // TODO Works for dimensionless right now, but do we need to handle other
   // cases as well?

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -5,6 +5,8 @@
 /// National Laboratory, and European Spallation Source ERIC.
 #include <gtest/gtest.h>
 
+#include "test_macros.h"
+
 #include "unit.h"
 
 TEST(Unit, construct) { ASSERT_NO_THROW(Unit u{Unit::Id::Dimensionless}); }
@@ -78,4 +80,17 @@ TEST(Unit, conversion_factors) {
                        boost::units::si::constants::codata::e.value().value());
   EXPECT_DOUBLE_EQ(g.value(), 8.0e-6);
   EXPECT_DOUBLE_EQ(h.value(), 9.0e6);
+}
+
+TEST(Unit, sqrt) {
+  Unit a{Unit::Id::Dimensionless};
+  Unit m{Unit::Id::Length};
+  Unit m2{Unit::Id::Area};
+  EXPECT_EQ(sqrt(m2), m);
+}
+
+TEST(Unit, sqrt_fail) {
+  Unit m{Unit::Id::Length};
+  EXPECT_THROW_MSG(sqrt(m), std::runtime_error,
+                   "Unsupported unit as result of sqrt, sqrt(m).");
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -543,6 +543,21 @@ TEST(Variable, mean) {
   EXPECT_TRUE(equals(meanY.get(Data::Value), {2.0, 3.0}));
 }
 
+TEST(Variable, norm_of_scalar) {
+  Variable reference(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1.0, -2.0, -3.0, 4.0});
+  EXPECT_EQ(norm(var), reference);
+}
+
+TEST(Variable, norm_of_vector) {
+  Variable reference(Data::Value, {Dim::X, 3}, {sqrt(2), sqrt(2), 2});
+  auto var = makeVariable<Eigen::Vector3d>(Data::Value, {Dim::X, 3},
+                                           {Eigen::Vector3d{1, 0, -1},
+                                            Eigen::Vector3d{1, 1, 0},
+                                            Eigen::Vector3d{0, 0, -2}});
+  EXPECT_EQ(norm(var), reference);
+}
+
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X, {{Dim::X, 3}});
   ConstVariableSlice view(var);

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -558,6 +558,31 @@ TEST(Variable, norm_of_vector) {
   EXPECT_EQ(norm(var), reference);
 }
 
+TEST(Variable, broadcast) {
+  Variable reference(Data::Value, {{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}},
+                     {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4});
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
+
+  // No change if dimensions exist.
+  EXPECT_EQ(broadcast(var, {Dim::X, 2}), var);
+  EXPECT_EQ(broadcast(var, {Dim::Y, 2}), var);
+  EXPECT_EQ(broadcast(var, {{Dim::Y, 2}, {Dim::X, 2}}), var);
+
+  // No transpose done, should this fail? Failing is not really necessary since
+  // we have labeled dimensions.
+  EXPECT_EQ(broadcast(var, {{Dim::X, 2}, {Dim::Y, 2}}), var);
+
+  EXPECT_EQ(broadcast(var, {Dim::Z, 3}), reference);
+}
+
+TEST(Variable, broadcast_fail) {
+  Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
+  EXPECT_THROW_MSG(broadcast(var, {Dim::X, 3}),
+                   dataset::except::DimensionLengthError,
+                   "Expected dimension to be in {{Dim::Y, 2}, {Dim::X, 2}} , "
+                   "got Dim::X with mismatching length 3.");
+}
+
 TEST(VariableSlice, full_const_view) {
   const Variable var(Coord::X, {{Dim::X, 3}});
   ConstVariableSlice view(var);

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -568,6 +568,14 @@ TEST(Variable, norm_of_vector) {
   EXPECT_EQ(norm(var), reference);
 }
 
+TEST(Variable, sqrt) {
+  // TODO Currently comparisons of variables do not provide special handling of
+  // NaN, so sqrt of negative values will lead variables that are never equal.
+  Variable reference(Data::Value, {Dim::X, 2}, {1, 2});
+  Variable var(Data::Value, {Dim::X, 2}, {1, 4});
+  EXPECT_EQ(sqrt(var), reference);
+}
+
 TEST(Variable, broadcast) {
   Variable reference(Data::Value, {{Dim::Z, 3}, {Dim::Y, 2}, {Dim::X, 2}},
                      {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4});

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -572,7 +572,9 @@ TEST(Variable, sqrt) {
   // TODO Currently comparisons of variables do not provide special handling of
   // NaN, so sqrt of negative values will lead variables that are never equal.
   Variable reference(Data::Value, {Dim::X, 2}, {1, 2});
+  reference.setUnit(Unit::Id::Length);
   Variable var(Data::Value, {Dim::X, 2}, {1, 4});
+  var.setUnit(Unit::Id::Area);
   EXPECT_EQ(sqrt(var), reference);
 }
 

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -250,6 +250,16 @@ TEST(Variable, operator_times_equal_scalar) {
   EXPECT_EQ(a.unit(), Unit::Id::Length);
 }
 
+TEST(Variable, operator_times_can_broadcast) {
+  Variable a(Data::Value, {Dim::X, 2}, {0.5, 1.5});
+  Variable b(Data::Value, {Dim::Y, 2}, {2.0, 3.0});
+
+  auto ab = a * b;
+  Variable reference(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}},
+                     {1.0, 3.0, 1.5, 4.5});
+  EXPECT_EQ(ab, reference);
+}
+
 TEST(Variable, operator_divide_equal) {
   Variable a(Data::Value, {Dim::X, 2}, {2.0, 3.0});
   Variable b(Data::Value, {}, {2.0});
@@ -579,7 +589,7 @@ TEST(Variable, broadcast_fail) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
   EXPECT_THROW_MSG(broadcast(var, {Dim::X, 3}),
                    dataset::except::DimensionLengthError,
-                   "Expected dimension to be in {{Dim::Y, 2}, {Dim::X, 2}} , "
+                   "Expected dimension to be in {{Dim::Y, 2}, {Dim::X, 2}}\n, "
                    "got Dim::X with mismatching length 3.");
 }
 


### PR DESCRIPTION
Based on better unit support, it was now possible to do a better/correct implementation of unit conversion of data. This is still not entirely complete, but there is a number of useful additions:

- Operations between `Variable` and `boost::units::quantity` support a seamless way of working with units.
- Compared to the previous implementation we are not anymore using `zipMD` and a lambda. Instead, slicing is used, which has the advantage of propagating the units correctly, without need for manual intervention.

Bonus (not directly unit-related, but added for making implementation possible):
- `norm` for `Variable`, in particular for `Eigen::Vector3d`. This is an example of how the type-erasure can handle transitions betweens types (the results is `double`).
- `sqrt` for `Variable` (and for units).
- Binary operations for `Variable` can now broadcast. We still (intentionally) do not support this for `+=` (et.c), but only for `+`. Dimensions of the second operand are added as outer dimensions to the first operand. If a specific dimension order is required (such as in the `convert` implementation) this can lead to some awkwardness, since we need do control the operand order to get the desired dimension order.

Missing, for follow up PRs:
- Correct handling of count-densities.
- Conversion of event data.