### PR TITLE
Remove unit IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ install:
   # C++17
   - sudo apt-get install -qq g++-7
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
-  - sudo apt install libboost-dev
+  - sudo add-apt-repository ppa:mhier/libboost-latest
+  - sudo apt update
+  - sudo apt install libboost1.67-dev
   - sudo apt install libomp-dev
   - sudo apt install python3-pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   # C++17
   - sudo apt-get install -qq g++-7
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
-  - sudo add-apt-repository ppa:mhier/libboost-latest
+  - sudo add-apt-repository -y ppa:mhier/libboost-latest
   - sudo apt update
   - sudo apt install libboost1.67-dev
   - sudo apt install libomp-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 set ( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake" )
 
 find_package (OpenMP 3.1 REQUIRED)
-find_package (Boost 1.58 REQUIRED)
+find_package (Boost 1.67 REQUIRED)
 
 include( Eigen )
 include( gsl )

--- a/DataSetDocker/Dockerfile
+++ b/DataSetDocker/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update && \
     apt-get install -y cmake && \
     apt-get install -y g++ && \
     apt-get install -y mercurial && \
-    apt-get install -y libboost-dev && \
-
+    add-apt-repository ppa:mhier/libboost-latest && \
+    apt update && \
+    apt-get install -y libboost1.67-dev && \
     rm -rf /var/lib/apt/lists/*
 
 USER $NB_UID

--- a/DataSetDocker/Dockerfile
+++ b/DataSetDocker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     apt-get install -y cmake && \
     apt-get install -y g++ && \
     apt-get install -y mercurial && \
+    apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:mhier/libboost-latest && \
     apt update && \
     apt-get install -y libboost1.67-dev && \

--- a/DataSetDocker/Dockerfile
+++ b/DataSetDocker/Dockerfile
@@ -66,8 +66,6 @@ USER root
 
 RUN cd /tmp/dataset/build && \
     make install 
-
-RUN sudo apt-get purge --auto-remove -y libboost-dev 
    
 USER $NB_UID
 

--- a/DataSetDocker/Dockerfile
+++ b/DataSetDocker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y cmake && \
     apt-get install -y g++ && \
     apt-get install -y mercurial && \
-    add-apt-repository ppa:mhier/libboost-latest && \
+    add-apt-repository -y ppa:mhier/libboost-latest && \
     apt update && \
     apt-get install -y libboost1.67-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/DataSetDocker/ReadMe.md
+++ b/DataSetDocker/ReadMe.md
@@ -1,3 +1,15 @@
+# Installing and configuring docker
+
+## Ubuntu 18.04
+
+```
+sudo apt install docker.io
+sudo usermod -aG docker $(whoami)
+# Now logout and login again for the permission changes to take effect
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
 # To build the image:
 
 From the directory containing Dockerfile launch:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ This a prototype for the `Dataset` library.
 
 ## Build instructions
 
+### Prerequisites
+
+We require a minimum of `boost1.67`.
+
+#### Ubuntu 18.04
+On Ubuntu 18.04 the maximum available is `boost1.65`.
+A newer version can be installed as follows:
+
+```
+sudo add-apt-repository ppa:mhier/libboost-latest
+sudo apt update
+sudo apt remove libboost1.65-dev
+sudo apt install libboost1.67-dev
+```
+
+#### OSX
+* You will need to be running High Sierra 10.13. Lower version have incompatible libc++ implementations.
+* You will need to be using [LLVM Clang](https://releases.llvm.org/download.html) version 6 or greater. Current latest XCode 10.1, does not support all language features used. Note that pybind11's use of `std::variant` presents the current issues for `Apple LLVM 10.0.0`. Pybind11 automatically picks up on the CMAKE_CXX_STANDARD 17 applied in the dataset configuration and presumes to use `std::variant`.
+* You will need to `brew install libomp`.
+
+### Getting the code and building
+
 ```
 git submodule init
 git submodule update
@@ -15,11 +37,6 @@ cd build
 cmake ..
 make
 ```
-
-### OSX
-* You will need to be running High Sierra 10.13. Lower version have incompatible libc++ implementations.
-* You will need to be using [LLVM Clang](https://releases.llvm.org/download.html) version 6 or greater. Current latest XCode 10.1, does not support all language features used. Note that pybind11's use of `std::variant` presents the current issues for `Apple LLVM 10.0.0`. Pybind11 automatically picks up on the CMAKE_CXX_STANDARD 17 applied in the dataset configuration and presumes to use `std::variant`.  
-* You will need to `brew install libomp` 
 
 ## Usage of the Python exports
 

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -34,13 +34,11 @@ class TestVariable(unittest.TestCase):
         self.assertTrue(var_data.is_data)
 
     def test_create_dtype(self):
-        print("start")
         var = Variable(Coord.X, [Dim.X], np.arange(4))
         var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.int32))
         var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.float64))
         var = Variable(Coord.X, [Dim.X], np.arange(4).astype(np.float32))
         #var = Variable(Coord.X, [Dim.X], ['a', 'bb', 'ccc', 'dddd'])
-        print("end")
         var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float64))
         self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
         var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.float32))

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -24,8 +24,7 @@ Variable getSpecPos(const Dataset &d) {
 }
 
 const auto tof_to_s =
-    boost::units::quantity<boost::units::si::time>(1.0 * units::tof) /
-    units::tof;
+    boost::units::quantity<boost::units::si::time>(1.0 * units::us) / units::us;
 const auto J_to_meV =
     units::meV /
     boost::units::quantity<boost::units::si::energy>(1.0 * units::meV);

--- a/src/counts.cpp
+++ b/src/counts.cpp
@@ -13,7 +13,7 @@ auto getBinWidths(const Dataset &d, const std::initializer_list<Dim> &dims) {
   std::vector<Variable> binWidths;
   for (const auto dim : dims) {
     const auto &coord = d(dimensionCoord(dim));
-    if (coord.unit() == Unit::Id::Dimensionless)
+    if (coord.unit() == units::dimensionless)
       throw std::runtime_error("Dimensionless axis cannot be used for "
                                "conversion from or to density");
     binWidths.emplace_back(coord(dim, 1, coord.dimensions()[dim]) -
@@ -30,13 +30,13 @@ Dataset toDensity(Dataset d, const std::initializer_list<Dim> &dims) {
   const auto binWidths = getBinWidths(d, dims);
   for (const auto &var : d) {
     if (var.isData()) {
-      if (var.unit() == Unit::Id::Counts) {
+      if (var.unit() == units::counts) {
         for (const auto &binWidth : binWidths)
           var /= binWidth;
-      } else if (var.unit() == Unit::Id::CountsVariance) {
+      } else if (var.unit() == units::counts * units::counts) {
         for (const auto &binWidth : binWidths)
           var /= binWidth * binWidth;
-      } else if (units::containsCounts(Unit::Id::Counts)) {
+      } else if (units::containsCounts(var.unit())) {
         // This error implies that conversion to multi-dimensional densities
         // must be done in one step, e.g., counts -> counts/(m*m*s). We cannot
         // do counts -> counts/m -> counts/(m*m) -> counts/(m*m*s) since the
@@ -62,18 +62,18 @@ Dataset fromDensity(Dataset d, const std::initializer_list<Dim> &dims) {
   const auto binWidths = getBinWidths(d, dims);
   for (const auto &var : d) {
     if (var.isData()) {
-      if (var.unit() == Unit::Id::Counts) {
+      if (var.unit() == units::counts) {
         throw std::runtime_error("Cannot convert counts-variable from density, "
                                  "it looks like it has already been "
                                  "converted.");
       } else if (units::containsCounts(var.unit())) {
         for (const auto &binWidth : binWidths)
           var *= binWidth;
-        dataset::expect::unit(var, Unit::Id::Counts);
+        dataset::expect::unit(var, units::counts);
       } else if (units::containsCountsVariance(var.unit())) {
         for (const auto &binWidth : binWidths)
           var *= binWidth * binWidth;
-        dataset::expect::unit(var, Unit::Id::CountsVariance);
+        dataset::expect::unit(var, units::counts * units::counts);
       }
     }
   }

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -3,11 +3,12 @@
 /// @author Simon Heybrock
 /// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
 /// National Laboratory, and European Spallation Source ERIC.
+#include <regex>
+
 #include "except.h"
 #include "dataset.h"
 #include "dimensions.h"
 #include "tags.h"
-#include <regex>
 
 namespace {
 std::string do_to_string(const Dim dim) {
@@ -87,14 +88,7 @@ std::string do_to_string(const Tag tag) {
 }
 
 std::string do_to_string(const Unit &unit) {
-  switch (unit.id()) {
-  case Unit::Id::Dimensionless:
-    return "Unit::Dimensionless";
-  case Unit::Id::Length:
-    return "Unit::Length";
-  default:
-    return "<unknown unit>";
-  }
+  return unit.name();
 }
 } // namespace
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -99,95 +99,95 @@ namespace detail {
 struct CoordDef {
   struct Monitor {
     using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   // TODO Should we name this `Detectors` and `Components` instead, or find some
   // more generic terms?
   struct DetectorInfo {
     using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct ComponentInfo {
     using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct X {
     using type = double;
-    static constexpr auto unit = Unit::Id::Length;
+    static constexpr auto unit = units::m;
   };
   struct Y {
     using type = double;
-    static constexpr auto unit = Unit::Id::Length;
+    static constexpr auto unit = units::m;
   };
   struct Z {
     using type = double;
-    static constexpr auto unit = Unit::Id::Length;
+    static constexpr auto unit = units::m;
   };
   struct Tof {
     using type = double;
-    static constexpr auto unit = Unit::Id::Tof;
+    static constexpr auto unit = units::us;
   };
   struct Energy {
     using type = double;
-    static constexpr auto unit = Unit::Id::Energy;
+    static constexpr auto unit = units::meV;
   };
   struct DeltaE {
     using type = double;
-    static constexpr auto unit = Unit::Id::Energy;
+    static constexpr auto unit = units::meV;
   };
   struct Ei {
     using type = double;
-    static constexpr auto unit = Unit::Id::Energy;
+    static constexpr auto unit = units::meV;
   };
   struct Ef {
     using type = double;
-    static constexpr auto unit = Unit::Id::Energy;
+    static constexpr auto unit = units::meV;
   };
   struct DetectorId {
     using type = int32_t;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct SpectrumNumber {
     using type = int32_t;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct DetectorGrouping {
     // Dummy for now, or sufficient like this?
     using type = boost::container::small_vector<gsl::index, 1>;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct RowLabel {
     using type = std::string;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Polarization {
     // Dummy for now
     using type = std::string;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Temperature {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Time {
     using type = int64_t;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct TimeInterval {
     using type = std::pair<int64_t, int64_t>;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Mask {
     using type = bool;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct FuzzyTemperature {
     using type = ValueWithDelta<double>;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Position : public detail::ReturnByValueIfConstPolicy {
     using type = Eigen::Vector3d;
-    static constexpr auto unit = Unit::Id::Length;
+    static constexpr auto unit = units::m;
   };
 
   using tags = std::tuple<Monitor, DetectorInfo, ComponentInfo, X, Y, Z, Tof,
@@ -199,43 +199,43 @@ struct CoordDef {
 struct DataDef {
   struct Tof {
     using type = double;
-    static constexpr auto unit = Unit::Id::Tof;
+    static constexpr auto unit = units::us;
   };
   struct PulseTime {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Value {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Variance {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct StdDev : public detail::ReturnByValuePolicy {
     using type = double;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Int {
     using type = int64_t;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct String {
     using type = std::string;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct Events {
     using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
   struct EventTofs {
     using type = boost::container::small_vector<double, 8>;
-    static constexpr auto unit = Unit::Id::Tof;
+    static constexpr auto unit = units::us;
   };
   struct EventPulseTimes {
     using type = boost::container::small_vector<double, 8>;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
 
   using tags = std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, String,
@@ -245,7 +245,7 @@ struct DataDef {
 struct AttrDef {
   struct ExperimentLog {
     using type = Dataset;
-    static constexpr auto unit = Unit::Id::Dimensionless;
+    static constexpr auto unit = units::dimensionless;
   };
 
   using tags = std::tuple<ExperimentLog>;
@@ -427,21 +427,21 @@ inline Tag dimensionCoord(const Dim dim) {
 
 namespace detail {
 template <class... Ts>
-constexpr std::array<Unit::Id, std::tuple_size<detail::Tags>::value>
+std::array<Unit, std::tuple_size<detail::Tags>::value>
 make_unit_table(const std::tuple<Ts...> &) {
-  return {Ts::unit...};
+  return {Unit(Ts::unit)...};
 }
 template <class... Ts>
 constexpr std::array<DType, std::tuple_size<detail::Tags>::value>
 make_dtype_table(const std::tuple<Ts...> &) {
   return {dtype<typename Ts::type>...};
 }
-constexpr auto unit_table = make_unit_table(detail::Tags{});
+static const auto unit_table = make_unit_table(detail::Tags{});
 constexpr auto dtype_table = make_dtype_table(detail::Tags{});
 } // namespace detail
 
 /// Return the default unit for a runtime tag.
-constexpr auto defaultUnit(const Tag tag) {
+inline auto defaultUnit(const Tag tag) {
   return detail::unit_table[tag.value()];
 }
 /// Return the default dtype for a runtime tag.

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -33,6 +33,22 @@ std::string Unit::name() const {
       m_unit);
 }
 
+bool operator==(const Unit &a, const Unit &b) { return a() == b(); }
+bool operator!=(const Unit &a, const Unit &b) { return !(a == b); }
+
+Unit operator+(const Unit &a, const Unit &b) {
+  if (a == b)
+    return a;
+  throw std::runtime_error("Cannot add " + a.name() + " and " + b.name() + ".");
+}
+
+Unit operator-(const Unit &a, const Unit &b) {
+  if (a == b)
+    return a;
+  throw std::runtime_error("Cannot subtract " + a.name() + " and " + b.name() +
+                           ".");
+}
+
 // Mutliplying two units together using std::visit to run through the contents
 // of the std::variant
 Unit operator*(const Unit &a, const Unit &b) {
@@ -48,11 +64,9 @@ Unit operator*(const Unit &a, const Unit &b) {
         msg << "Unsupported unit as result of multiplication " << x << "*" << y;
         throw std::runtime_error(msg.str());
       },
-      a.getUnit(), b.getUnit()));
+      a(), b()));
 }
 
-// Dividing two units together using std::visit to run through the contents
-// of the std::variant
 Unit operator/(const Unit &a, const Unit &b) {
   return Unit(std::visit(
       [](auto x, auto y) -> Unit::unit_t {
@@ -63,13 +77,7 @@ Unit operator/(const Unit &a, const Unit &b) {
         msg << "Unsupported unit as result of division " << x << "/" << y;
         throw std::runtime_error(msg.str());
       },
-      a.getUnit(), b.getUnit()));
-}
-
-Unit operator+(const Unit &a, const Unit &b) {
-  if (a != b)
-    throw std::runtime_error("Cannot add different units");
-  return a;
+      a(), b()));
 }
 
 Unit sqrt(const Unit &a) {
@@ -82,5 +90,18 @@ Unit sqrt(const Unit &a) {
         msg << "Unsupported unit as result of sqrt, sqrt(" << x << ").";
         throw std::runtime_error(msg.str());
       },
-      a.getUnit()));
+      a()));
 }
+
+namespace units {
+bool containsCounts(const Unit &unit) {
+  if ((unit == units::counts) || unit == units::counts / units::m)
+    return true;
+  return false;
+}
+bool containsCountsVariance(const Unit &unit) {
+  if (unit == units::counts * units::counts)
+    return true;
+  return false;
+}
+} // namespace units

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -59,7 +59,7 @@ Unit operator*(const Unit &a, const Unit &b) {
         // a constant expression
         auto z{x * y};
         if constexpr (isKnownUnit(z))
-          return {z};
+          return z;
         throw std::runtime_error(
             "Unsupported unit as result of multiplication " +
             units::to_string(x) + "*" + units::to_string(y));
@@ -72,7 +72,7 @@ Unit operator/(const Unit &a, const Unit &b) {
       [](auto x, auto y) -> Unit::unit_t {
         auto z{x / y};
         if constexpr (isKnownUnit(z))
-          return {z};
+          return z;
         throw std::runtime_error("Unsupported unit as result of division " +
                                  units::to_string(x) + "/" +
                                  units::to_string(y));
@@ -85,7 +85,7 @@ Unit sqrt(const Unit &a) {
       [](auto x) -> Unit::unit_t {
         typename decltype(sqrt(1.0 * x))::unit_type sqrt_x;
         if constexpr (isKnownUnit(sqrt_x))
-          return {sqrt_x};
+          return sqrt_x;
         throw std::runtime_error("Unsupported unit as result of sqrt, sqrt(" +
                                  units::to_string(x) + ").");
       },

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -29,7 +29,7 @@ template <class T> constexpr bool isKnownUnit(const T &) {
 Unit::Unit(const Unit::Id id) {
   switch (id) {
   case Unit::Id::Dimensionless:
-    m_unit = none;
+    m_unit = dimensionless;
     break;
   case Unit::Id::Length:
     m_unit = m;
@@ -41,31 +41,31 @@ Unit::Unit(const Unit::Id id) {
     m_unit = m2 * m2;
     break;
   case Unit::Id::Counts:
-    m_unit = counts * none;
+    m_unit = counts * dimensionless;
     break;
   case Unit::Id::CountsVariance:
-    m_unit = counts * counts * none;
+    m_unit = counts * counts * dimensionless;
     break;
   case Unit::Id::CountsPerMeter:
     m_unit = counts / m;
     break;
   case Unit::Id::InverseLength:
-    m_unit = none / m;
+    m_unit = dimensionless / m;
     break;
   case Unit::Id::InverseTime:
-    m_unit = none / s;
+    m_unit = dimensionless / s;
     break;
   case Unit::Id::Energy:
-    m_unit = meV * none;
+    m_unit = meV * dimensionless;
     break;
   case Unit::Id::Wavelength:
-    m_unit = lambda * none;
+    m_unit = lambda * dimensionless;
     break;
   case Unit::Id::Time:
     m_unit = s;
     break;
   case Unit::Id::Tof:
-    m_unit = tof * none;
+    m_unit = tof * dimensionless;
     break;
   case Unit::Id::Mass:
     m_unit = kg;
@@ -78,27 +78,28 @@ Unit::Unit(const Unit::Id id) {
 /// Get the Id corresponding to the underlying unit
 Unit::Id Unit::id() const {
   return std::visit(
-      overloaded{[](decltype(none)) { return Unit::Id::Dimensionless; },
-                 [](decltype(m)) { return Unit::Id::Length; },
-                 [](decltype(m2)) { return Unit::Id::Area; },
-                 [](decltype(m2 * m2)) { return Unit::Id::AreaVariance; },
-                 [](decltype(counts * none)) { return Unit::Id::Counts; },
-                 [](decltype(counts * counts * none)) {
-                   return Unit::Id::CountsVariance;
-                 },
-                 [](decltype(counts / m)) { return Unit::Id::CountsPerMeter; },
-                 [](decltype(none / m)) { return Unit::Id::InverseLength; },
-                 [](decltype(none / s)) { return Unit::Id::InverseTime; },
-                 [](decltype(meV * none)) { return Unit::Id::Energy; },
-                 [](decltype(lambda * none)) { return Unit::Id::Wavelength; },
-                 [](decltype(s)) { return Unit::Id::Time; },
-                 [](decltype(tof * none)) { return Unit::Id::Tof; },
-                 [](decltype(kg)) { return Unit::Id::Mass; },
-                 [](auto unit) -> Unit::Id {
-                   std::stringstream msg;
-                   msg << "Unsupported unit " << unit;
-                   throw std::runtime_error(msg.str());
-                 }},
+      overloaded{
+          [](decltype(dimensionless)) { return Unit::Id::Dimensionless; },
+          [](decltype(m)) { return Unit::Id::Length; },
+          [](decltype(m2)) { return Unit::Id::Area; },
+          [](decltype(m2 * m2)) { return Unit::Id::AreaVariance; },
+          [](decltype(counts * dimensionless)) { return Unit::Id::Counts; },
+          [](decltype(counts * counts * dimensionless)) {
+            return Unit::Id::CountsVariance;
+          },
+          [](decltype(counts / m)) { return Unit::Id::CountsPerMeter; },
+          [](decltype(dimensionless / m)) { return Unit::Id::InverseLength; },
+          [](decltype(dimensionless / s)) { return Unit::Id::InverseTime; },
+          [](decltype(meV * dimensionless)) { return Unit::Id::Energy; },
+          [](decltype(lambda * dimensionless)) { return Unit::Id::Wavelength; },
+          [](decltype(s)) { return Unit::Id::Time; },
+          [](decltype(tof * dimensionless)) { return Unit::Id::Tof; },
+          [](decltype(kg)) { return Unit::Id::Mass; },
+          [](auto unit) -> Unit::Id {
+            std::stringstream msg;
+            msg << "Unsupported unit " << unit;
+            throw std::runtime_error(msg.str());
+          }},
       m_unit);
 }
 

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -35,10 +35,10 @@ Unit::Unit(const Unit::Id id) {
     m_unit = m;
     break;
   case Unit::Id::Area:
-    m_unit = m*m;
+    m_unit = m * m;
     break;
   case Unit::Id::AreaVariance:
-    m_unit = m*m * m*m;
+    m_unit = m * m * m * m;
     break;
   case Unit::Id::Counts:
     m_unit = counts * dimensionless;
@@ -59,13 +59,13 @@ Unit::Unit(const Unit::Id id) {
     m_unit = meV * dimensionless;
     break;
   case Unit::Id::Wavelength:
-    m_unit = lambda * dimensionless;
+    m_unit = angstrom * dimensionless;
     break;
   case Unit::Id::Time:
     m_unit = s;
     break;
   case Unit::Id::Tof:
-    m_unit = tof * dimensionless;
+    m_unit = us * dimensionless;
     break;
   case Unit::Id::Mass:
     m_unit = kg;
@@ -91,9 +91,11 @@ Unit::Id Unit::id() const {
           [](decltype(dimensionless / m)) { return Unit::Id::InverseLength; },
           [](decltype(dimensionless / s)) { return Unit::Id::InverseTime; },
           [](decltype(meV * dimensionless)) { return Unit::Id::Energy; },
-          [](decltype(lambda * dimensionless)) { return Unit::Id::Wavelength; },
+          [](decltype(angstrom * dimensionless)) {
+            return Unit::Id::Wavelength;
+          },
           [](decltype(s)) { return Unit::Id::Time; },
-          [](decltype(tof * dimensionless)) { return Unit::Id::Tof; },
+          [](decltype(us * dimensionless)) { return Unit::Id::Tof; },
           [](decltype(kg)) { return Unit::Id::Mass; },
           [](auto unit) -> Unit::Id {
             std::stringstream msg;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -94,12 +94,13 @@ Unit sqrt(const Unit &a) {
 
 namespace units {
 bool containsCounts(const Unit &unit) {
-  if ((unit == units::counts) || unit == units::counts / units::m)
+  if ((unit == units::counts) || unit == units::counts / units::us)
     return true;
   return false;
 }
 bool containsCountsVariance(const Unit &unit) {
-  if (unit == units::counts * units::counts)
+  if (unit == units::counts * units::counts ||
+      unit == (units::counts / units::us) * (units::counts / units::us))
     return true;
   return false;
 }

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -35,10 +35,10 @@ Unit::Unit(const Unit::Id id) {
     m_unit = m;
     break;
   case Unit::Id::Area:
-    m_unit = m2;
+    m_unit = m*m;
     break;
   case Unit::Id::AreaVariance:
-    m_unit = m2 * m2;
+    m_unit = m*m * m*m;
     break;
   case Unit::Id::Counts:
     m_unit = counts * dimensionless;
@@ -81,8 +81,8 @@ Unit::Id Unit::id() const {
       overloaded{
           [](decltype(dimensionless)) { return Unit::Id::Dimensionless; },
           [](decltype(m)) { return Unit::Id::Length; },
-          [](decltype(m2)) { return Unit::Id::Area; },
-          [](decltype(m2 * m2)) { return Unit::Id::AreaVariance; },
+          [](decltype(m * m)) { return Unit::Id::Area; },
+          [](decltype(m * m * m * m)) { return Unit::Id::AreaVariance; },
           [](decltype(counts * dimensionless)) { return Unit::Id::Counts; },
           [](decltype(counts * counts * dimensionless)) {
             return Unit::Id::CountsVariance;

--- a/src/unit.h
+++ b/src/unit.h
@@ -99,7 +99,7 @@ template <> struct boost::units::base_unit_info<neutron::tof::tof_base_unit> {
 // Define some helper variables to make the declaration of the set of allowed
 // units more succinct
 namespace units {
-static boost::units::si::dimensionless none;
+static boost::units::si::dimensionless dimensionless;
 static boost::units::si::length m;
 static boost::units::si::area m2;
 static boost::units::si::time s;
@@ -110,21 +110,21 @@ static neutron::tof::energy meV;
 static neutron::tof::tof tof;
 
 // TODO counts/m is mainly for testing and should maybe be removed.
-// Note the factor `none` in units that otherwise contain only non-SI factors.
+// Note the factor `dimensionless` in units that otherwise contain only non-SI factors.
 // This is a trick to overcome some subtleties of working with heterogeneous
 // unit systems in boost::units: We are combing SI units with our own, and the
 // two are considered independent unless you convert explicitly. Therefore, in
 // operations like (counts * m) / m, boosts is not cancelling the m as expected
 // --- you get counts * dimensionless. Explicitly putting a factor dimensionless
-// (none) into all our non-SI units avoids special-case handling in all
+// (dimensionless) into all our non-SI units avoids special-case handling in all
 // operations (which would attempt to remove the dimensionless factor manually).
 using type = std::variant<
-    decltype(none), decltype(m), decltype(m2), decltype(s), decltype(kg),
-    decltype(counts * none), decltype(none / m), decltype(lambda * none),
-    decltype(meV * none), decltype(tof * none), decltype(tof * tof * none),
-    decltype(none / tof), decltype(none / (tof * tof)), decltype(none / s),
-    decltype(m2 * m2), decltype(counts * counts * none), decltype(counts / m),
-    decltype(meV * tof * tof / m2), decltype(meV * tof * tof * none)>;
+    decltype(dimensionless), decltype(m), decltype(m2), decltype(s), decltype(kg),
+    decltype(counts * dimensionless), decltype(dimensionless / m), decltype(lambda * dimensionless),
+    decltype(meV * dimensionless), decltype(tof * dimensionless), decltype(tof * tof * dimensionless),
+    decltype(dimensionless / tof), decltype(dimensionless / (tof * tof)), decltype(dimensionless / s),
+    decltype(m2 * m2), decltype(counts * counts * dimensionless), decltype(counts / m),
+    decltype(meV * tof * tof / m2), decltype(meV * tof * tof * dimensionless)>;
 } // namespace units
 
 class Unit {
@@ -175,7 +175,7 @@ private:
 };
 
 inline bool operator==(const Unit &a, const Unit &b) {
-  return a.id() == b.id();
+  return a.getUnit() == b.getUnit();
 }
 inline bool operator!=(const Unit &a, const Unit &b) { return !(a == b); }
 

--- a/src/unit.h
+++ b/src/unit.h
@@ -101,7 +101,6 @@ template <> struct boost::units::base_unit_info<neutron::tof::tof_base_unit> {
 namespace units {
 static boost::units::si::dimensionless dimensionless;
 static boost::units::si::length m;
-static boost::units::si::area m2;
 static boost::units::si::time s;
 static boost::units::si::mass kg;
 static neutron::tof::counts counts;
@@ -119,12 +118,15 @@ static neutron::tof::tof tof;
 // (dimensionless) into all our non-SI units avoids special-case handling in all
 // operations (which would attempt to remove the dimensionless factor manually).
 using type = std::variant<
-    decltype(dimensionless), decltype(m), decltype(m2), decltype(s), decltype(kg),
-    decltype(counts * dimensionless), decltype(dimensionless / m), decltype(lambda * dimensionless),
-    decltype(meV * dimensionless), decltype(tof * dimensionless), decltype(tof * tof * dimensionless),
-    decltype(dimensionless / tof), decltype(dimensionless / (tof * tof)), decltype(dimensionless / s),
-    decltype(m2 * m2), decltype(counts * counts * dimensionless), decltype(counts / m),
-    decltype(meV * tof * tof / m2), decltype(meV * tof * tof * dimensionless)>;
+    decltype(dimensionless), decltype(m), decltype(m * m), decltype(s),
+    decltype(kg), decltype(counts * dimensionless), decltype(dimensionless / m),
+    decltype(lambda * dimensionless), decltype(meV * dimensionless),
+    decltype(tof * dimensionless), decltype(tof * tof * dimensionless),
+    decltype(dimensionless / tof), decltype(dimensionless / (tof * tof)),
+    decltype(dimensionless / s), decltype(m * m * m * m),
+    decltype(counts * counts * dimensionless), decltype(counts / m),
+    decltype(meV * tof * tof / (m * m)),
+    decltype(meV * tof * tof * dimensionless)>;
 } // namespace units
 
 class Unit {

--- a/src/unit.h
+++ b/src/unit.h
@@ -130,12 +130,11 @@ make_unit(const std::tuple<Ts...> &, const std::tuple<Extra...> &) {
   return {};
 }
 
-// TODO counts/m is mainly for testing and should maybe be removed.
 using type = decltype(detail::make_unit(
     std::make_tuple(m, counts, s, kg, dimensionless / m, angstrom, meV, us,
-                    dimensionless / us, dimensionless / s),
-    std::make_tuple(dimensionless, counts / m, m *m *m *m,
-                    meV *us *us / (m * m), meV *us *us *dimensionless)));
+                    dimensionless / us, dimensionless / s, counts / us),
+    std::make_tuple(dimensionless, m *m *m *m, meV *us *us / (m * m),
+                    meV *us *us *dimensionless)));
 } // namespace detail
 } // namespace units
 

--- a/src/unit.h
+++ b/src/unit.h
@@ -104,29 +104,29 @@ static boost::units::si::length m;
 static boost::units::si::time s;
 static boost::units::si::mass kg;
 static neutron::tof::counts counts;
-static neutron::tof::wavelength lambda;
+static neutron::tof::wavelength angstrom;
 static neutron::tof::energy meV;
-static neutron::tof::tof tof;
+static neutron::tof::tof us;
 
 // TODO counts/m is mainly for testing and should maybe be removed.
-// Note the factor `dimensionless` in units that otherwise contain only non-SI factors.
-// This is a trick to overcome some subtleties of working with heterogeneous
-// unit systems in boost::units: We are combing SI units with our own, and the
-// two are considered independent unless you convert explicitly. Therefore, in
-// operations like (counts * m) / m, boosts is not cancelling the m as expected
+// Note the factor `dimensionless` in units that otherwise contain only non-SI
+// factors. This is a trick to overcome some subtleties of working with
+// heterogeneous unit systems in boost::units: We are combing SI units with our
+// own, and the two are considered independent unless you convert explicitly.
+// Therefore, in operations like (counts * m) / m, boosts is not cancelling the
+// m as expected
 // --- you get counts * dimensionless. Explicitly putting a factor dimensionless
 // (dimensionless) into all our non-SI units avoids special-case handling in all
 // operations (which would attempt to remove the dimensionless factor manually).
 using type = std::variant<
     decltype(dimensionless), decltype(m), decltype(m * m), decltype(s),
     decltype(kg), decltype(counts * dimensionless), decltype(dimensionless / m),
-    decltype(lambda * dimensionless), decltype(meV * dimensionless),
-    decltype(tof * dimensionless), decltype(tof * tof * dimensionless),
-    decltype(dimensionless / tof), decltype(dimensionless / (tof * tof)),
+    decltype(angstrom * dimensionless), decltype(meV * dimensionless),
+    decltype(us * dimensionless), decltype(us * us * dimensionless),
+    decltype(dimensionless / us), decltype(dimensionless / (us * us)),
     decltype(dimensionless / s), decltype(m * m * m * m),
     decltype(counts * counts * dimensionless), decltype(counts / m),
-    decltype(meV * tof * tof / (m * m)),
-    decltype(meV * tof * tof * dimensionless)>;
+    decltype(meV * us * us / (m * m)), decltype(meV * us * us * dimensionless)>;
 } // namespace units
 
 class Unit {

--- a/src/unit.h
+++ b/src/unit.h
@@ -96,19 +96,12 @@ template <> struct boost::units::base_unit_info<neutron::tof::tof_base_unit> {
   static std::string symbol() { return "us"; }
 };
 
-// Define some helper variables to make the declaration of the set of allowed
-// units more succinct
+// Helper variables to make the declaration units more succinct.
 namespace units {
-static boost::units::si::dimensionless dimensionless;
-static boost::units::si::length m;
-static boost::units::si::time s;
-static boost::units::si::mass kg;
-static neutron::tof::counts counts;
-static neutron::tof::wavelength angstrom;
-static neutron::tof::energy meV;
-static neutron::tof::tof us;
-
-// TODO counts/m is mainly for testing and should maybe be removed.
+static constexpr boost::units::si::dimensionless dimensionless;
+static constexpr boost::units::si::length m;
+static constexpr boost::units::si::time s;
+static constexpr boost::units::si::mass kg;
 // Note the factor `dimensionless` in units that otherwise contain only non-SI
 // factors. This is a trick to overcome some subtleties of working with
 // heterogeneous unit systems in boost::units: We are combing SI units with our
@@ -118,58 +111,46 @@ static neutron::tof::tof us;
 // --- you get counts * dimensionless. Explicitly putting a factor dimensionless
 // (dimensionless) into all our non-SI units avoids special-case handling in all
 // operations (which would attempt to remove the dimensionless factor manually).
-using type = std::variant<
-    decltype(dimensionless), decltype(m), decltype(m * m), decltype(s),
-    decltype(kg), decltype(counts * dimensionless), decltype(dimensionless / m),
-    decltype(angstrom * dimensionless), decltype(meV * dimensionless),
-    decltype(us * dimensionless), decltype(us * us * dimensionless),
-    decltype(dimensionless / us), decltype(dimensionless / (us * us)),
-    decltype(dimensionless / s), decltype(m * m * m * m),
-    decltype(counts * counts * dimensionless), decltype(counts / m),
-    decltype(meV * us * us / (m * m)), decltype(meV * us * us * dimensionless)>;
+static constexpr decltype(neutron::tof::counts{} * dimensionless) counts;
+static constexpr decltype(neutron::tof::wavelength{} * dimensionless) angstrom;
+static constexpr decltype(neutron::tof::energy{} * dimensionless) meV;
+static constexpr decltype(neutron::tof::tof{} * dimensionless) us;
+
+// Define a std::variant which will hold the set of allowed units. Any unit that
+// does not exist in the variant will either fail to compile or throw a
+// std::runtime_error during operations such as multiplication or division.
+namespace detail {
+template <class... Ts, class... Extra>
+std::variant<Ts...,
+             decltype(std::declval<std::remove_cv_t<Ts>>() *
+                      std::declval<std::remove_cv_t<Ts>>())...,
+             std::remove_cv_t<Extra>...>
+make_unit(const std::tuple<Ts...> &, const std::tuple<Extra...> &) {
+  return {};
+}
+} // namespace detail
+
+// TODO counts/m is mainly for testing and should maybe be removed.
+using type = decltype(detail::make_unit(
+    std::make_tuple(m, counts, s, kg, dimensionless / m, angstrom, meV, us,
+                    dimensionless / us, dimensionless / s),
+    std::make_tuple(dimensionless, counts / m, m *m *m *m,
+                    meV *us *us / (m * m), meV *us *us *dimensionless)));
 } // namespace units
 
 class Unit {
 public:
-  // Define a std::variant which will hold the set of allowed units.
-  // Any unit that does not exist in the variant will either fail to compile or
-  // throw a std::runtime_error during operations such as multiplication or
-  // division.
-  //
-  // TODO: maybe it is possible to create a helper that will automatically
-  // generate the squares for variance?
-  // The following was attempted but did not succeed:
-  //  template <class... Ts> struct unit_and_variance {
-  //  using type =
-  //    std::variant<Ts..., decltype(std::declval<Ts>()*std::declval<Ts>())...>;
-  //  };
   using unit_t = units::type;
 
-  enum class Id : uint16_t {
-    Dimensionless,
-    Length,
-    Area,
-    AreaVariance,
-    Counts,
-    CountsVariance,
-    CountsPerMeter,
-    InverseLength,
-    InverseTime,
-    Energy,
-    Wavelength,
-    Time,
-    Tof,
-    Mass
-  };
+  constexpr Unit() = default;
   // TODO should this be explicit?
-  Unit() = default;
-  // TODO: should we have a templated constructor here?
-  // e.g.: template <class T> Unit(T &&unit) : m_unit(std::forward<T>(unit)) {}
-  Unit(const Unit::Id id);
-  Unit(const unit_t unit) : m_unit(unit) {}
+  template <class Dim, class System, class Enable>
+  Unit(boost::units::unit<Dim, System, Enable> unit) : m_unit(unit) {}
+  explicit Unit(const unit_t &unit) : m_unit(unit) {}
 
-  Unit::Id id() const;
-  const Unit::unit_t &getUnit() const { return m_unit; }
+  constexpr const Unit::unit_t &getUnit() const noexcept { return m_unit; }
+
+  std::string name() const;
 
 private:
   unit_t m_unit;
@@ -188,12 +169,12 @@ Unit sqrt(const Unit &a);
 
 namespace units {
 inline bool containsCounts(const Unit &unit) {
-  if (unit == Unit::Id::Counts || unit == Unit::Id::CountsPerMeter)
+  if ((unit == units::counts) || unit == units::counts / units::m)
     return true;
   return false;
 }
 inline bool containsCountsVariance(const Unit &unit) {
-  if (unit == Unit::Id::CountsVariance)
+  if (unit == units::counts * units::counts)
     return true;
   return false;
 }

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -741,8 +741,8 @@ Variable::Variable(const ConstVariableSlice &slice)
 }
 
 template <class T>
-Variable::Variable(const Tag tag, const Unit::Id unit,
-                   const Dimensions &dimensions, T object)
+Variable::Variable(const Tag tag, const Unit unit, const Dimensions &dimensions,
+                   T object)
     : m_tag(tag), m_unit{unit},
       m_object(std::make_unique<DataModel<T>>(std::move(dimensions),
                                               std::move(object))) {}
@@ -768,7 +768,7 @@ template <class T> Vector<underlying_type_t<T>> &Variable::cast() {
 }
 
 #define INSTANTIATE(...)                                                       \
-  template Variable::Variable(const Tag, const Unit::Id, const Dimensions &,   \
+  template Variable::Variable(const Tag, const Unit, const Dimensions &,       \
                               Vector<underlying_type_t<__VA_ARGS__>>);         \
   template Vector<underlying_type_t<__VA_ARGS__>>                              \
       &Variable::cast<__VA_ARGS__>();                                          \
@@ -932,7 +932,7 @@ Variable &Variable::operator*=(const ConstVariableSlice &other) & {
 }
 Variable &Variable::operator*=(const double value) & {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return times_equals(*this, other);
 }
 
@@ -954,7 +954,7 @@ Variable &Variable::operator/=(const ConstVariableSlice &other) & {
 }
 Variable &Variable::operator/=(const double value) & {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return divide_equals(*this, other);
 }
 
@@ -983,7 +983,7 @@ VariableSlice VariableSlice::operator+=(const ConstVariableSlice &other) const {
 }
 VariableSlice VariableSlice::operator+=(const double value) const {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return plus_equals(*this, other);
 }
 
@@ -995,7 +995,7 @@ VariableSlice VariableSlice::operator-=(const ConstVariableSlice &other) const {
 }
 VariableSlice VariableSlice::operator-=(const double value) const {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return minus_equals(*this, other);
 }
 
@@ -1007,7 +1007,7 @@ VariableSlice VariableSlice::operator*=(const ConstVariableSlice &other) const {
 }
 VariableSlice VariableSlice::operator*=(const double value) const {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return times_equals(*this, other);
 }
 
@@ -1019,7 +1019,7 @@ VariableSlice VariableSlice::operator/=(const ConstVariableSlice &other) const {
 }
 VariableSlice VariableSlice::operator/=(const double value) const {
   Variable other(Data::Value, {}, {value});
-  other.setUnit(Unit::Id::Dimensionless);
+  other.setUnit(units::dimensionless);
   return divide_equals(*this, other);
 }
 
@@ -1167,7 +1167,7 @@ Variable operator+(const double a, Variable b) { return std::move(b += a); }
 Variable operator-(const double a, Variable b) { return -(b -= a); }
 Variable operator*(const double a, Variable b) { return std::move(b *= a); }
 Variable operator/(const double a, Variable b) {
-  b.setUnit(Unit::Id::Dimensionless / b.unit());
+  b.setUnit(Unit(units::dimensionless) / b.unit());
   require<FloatingPointVariableConcept>(b.data()).reciprocal_times(a);
   return std::move(b);
 }

--- a/src/variable.h
+++ b/src/variable.h
@@ -176,7 +176,7 @@ public:
   }
 
   template <class T>
-  Variable(const Tag tag, const Unit::Id unit, const Dimensions &dimensions,
+  Variable(const Tag tag, const Unit unit, const Dimensions &dimensions,
            T object);
 
   const std::string &name() const && = delete;

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -527,14 +527,15 @@ TEST(Dataset, operator_times_equal_with_units) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});
   Variable values(Data::Value, Dimensions({{Dim::X, 1}}), {3.0});
-  values.setUnit(Unit::Id::Length);
+  values.setUnit(units::m);
   Variable variances(Data::Variance, Dimensions({{Dim::X, 1}}), {2.0});
-  variances.setUnit(Unit::Id::Area);
+  variances.setUnit(units::m * units::m);
   a.insert(values);
   a.insert(variances);
   a *= a;
-  EXPECT_EQ(a(Data::Value).unit(), Unit::Id::Area);
-  EXPECT_EQ(a(Data::Variance).unit(), Unit::Id::AreaVariance);
+  EXPECT_EQ(a(Data::Value).unit(), units::m * units::m);
+  EXPECT_EQ(a(Data::Variance).unit(),
+            units::m * units::m * units::m * units::m);
   EXPECT_EQ(a.get(Data::Variance)[0], 36.0);
 }
 
@@ -543,10 +544,10 @@ TEST(Dataset, operator_times_equal_histogram_data) {
   a.insert(Coord::X, {Dim::X, 1}, {0.1});
   Variable values(Data::Value, Dimensions({{Dim::X, 1}}), {3.0});
   values.setName("name1");
-  values.setUnit(Unit::Id::Counts);
+  values.setUnit(units::counts);
   Variable variances(Data::Variance, Dimensions({{Dim::X, 1}}), {2.0});
   variances.setName("name1");
-  variances.setUnit(Unit::Id::CountsVariance);
+  variances.setUnit(units::counts * units::counts);
   a.insert(values);
   a.insert(variances);
 
@@ -1536,15 +1537,15 @@ TEST(Dataset, counts_toDensity_fromDensity) {
   Dataset d;
   d.insert(Coord::X, {Dim::X, 4}, {1, 2, 4, 8});
   d.insert(Data::Value, "", {Dim::X, 3}, {12, 12, 12});
-  d(Data::Value, "").setUnit(Unit::Id::Counts);
+  d(Data::Value, "").setUnit(units::counts);
 
   d = counts::toDensity(std::move(d), Dim::X);
   auto result = d(Data::Value, "");
-  EXPECT_EQ(result.unit(), Unit::Id::CountsPerMeter);
+  EXPECT_EQ(result.unit(), units::counts / units::m);
   EXPECT_TRUE(equals(result.get(Data::Value), {12, 6, 3}));
 
   d = counts::fromDensity(std::move(d), Dim::X);
   result = d(Data::Value, "");
-  EXPECT_EQ(result.unit(), Unit::Id::Counts);
+  EXPECT_EQ(result.unit(), units::counts);
   EXPECT_TRUE(equals(result.get(Data::Value), {12, 12, 12}));
 }

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -1534,16 +1534,16 @@ TEST(Dataset, convert_direct_inelastic_multi_Ei) {
 
 TEST(Dataset, counts_toDensity_fromDensity) {
   Dataset d;
-  d.insert(Coord::X, {Dim::X, 4}, {1, 2, 4, 8});
-  d.insert(Data::Value, "", {Dim::X, 3}, {12, 12, 12});
+  d.insert(Coord::Tof, {Dim::Tof, 4}, {1, 2, 4, 8});
+  d.insert(Data::Value, "", {Dim::Tof, 3}, {12, 12, 12});
   d(Data::Value, "").setUnit(units::counts);
 
-  d = counts::toDensity(std::move(d), Dim::X);
+  d = counts::toDensity(std::move(d), Dim::Tof);
   auto result = d(Data::Value, "");
-  EXPECT_EQ(result.unit(), units::counts / units::m);
+  EXPECT_EQ(result.unit(), units::counts / units::us);
   EXPECT_TRUE(equals(result.get(Data::Value), {12, 6, 3}));
 
-  d = counts::fromDensity(std::move(d), Dim::X);
+  d = counts::fromDensity(std::move(d), Dim::Tof);
   result = d(Data::Value, "");
   EXPECT_EQ(result.unit(), units::counts);
   EXPECT_TRUE(equals(result.get(Data::Value), {12, 12, 12}));

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -9,19 +9,19 @@
 
 #include "unit.h"
 
-TEST(Unit, construct) { ASSERT_NO_THROW(Unit u{Unit::Id::Dimensionless}); }
+TEST(Unit, construct) { ASSERT_NO_THROW(Unit u{units::dimensionless}); }
 
 TEST(Unit, compare) {
-  Unit u1{Unit::Id::Dimensionless};
-  Unit u2{Unit::Id::Length};
+  Unit u1{units::dimensionless};
+  Unit u2{units::m};
   ASSERT_TRUE(u1 == u1);
   ASSERT_TRUE(u1 != u2);
 }
 
 TEST(Unit, add) {
-  Unit a{Unit::Id::Dimensionless};
-  Unit b{Unit::Id::Length};
-  Unit c{Unit::Id::Area};
+  Unit a{units::dimensionless};
+  Unit b{units::m};
+  Unit c{units::m * units::m};
   EXPECT_EQ(a + a, a);
   EXPECT_EQ(b + b, b);
   EXPECT_EQ(c + c, c);
@@ -34,9 +34,9 @@ TEST(Unit, add) {
 }
 
 TEST(Unit, multiply) {
-  Unit a{Unit::Id::Dimensionless};
-  Unit b{Unit::Id::Length};
-  Unit c{Unit::Id::Area};
+  Unit a{units::dimensionless};
+  Unit b{units::m};
+  Unit c{units::m * units::m};
   EXPECT_EQ(a * a, a);
   EXPECT_EQ(a * b, b);
   EXPECT_EQ(b * a, b);
@@ -45,13 +45,13 @@ TEST(Unit, multiply) {
   EXPECT_EQ(b * b, c);
   EXPECT_ANY_THROW(b * c);
   EXPECT_ANY_THROW(c * b);
-  EXPECT_EQ(c * c, Unit::Id::AreaVariance);
+  EXPECT_EQ(c * c, units::m * units::m * units::m * units::m);
 }
 
 TEST(Unit, multiply_counts) {
-  Unit counts{Unit::Id::Counts};
-  Unit none{Unit::Id::Dimensionless};
-  EXPECT_EQ(counts * counts, Unit::Id::CountsVariance);
+  Unit counts{units::counts};
+  Unit none{units::dimensionless};
+  EXPECT_EQ(counts * counts, units::counts * units::counts);
   EXPECT_EQ(counts * none, counts);
   EXPECT_EQ(none * counts, counts);
 }
@@ -83,14 +83,14 @@ TEST(Unit, conversion_factors) {
 }
 
 TEST(Unit, sqrt) {
-  Unit a{Unit::Id::Dimensionless};
-  Unit m{Unit::Id::Length};
-  Unit m2{Unit::Id::Area};
+  Unit a{units::dimensionless};
+  Unit m{units::m};
+  Unit m2{units::m * units::m};
   EXPECT_EQ(sqrt(m2), m);
 }
 
 TEST(Unit, sqrt_fail) {
-  Unit m{Unit::Id::Length};
+  Unit m{units::m};
   EXPECT_THROW_MSG(sqrt(m), std::runtime_error,
                    "Unsupported unit as result of sqrt, sqrt(m).");
 }

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -106,7 +106,7 @@ TEST(Variable, operator_equals) {
   auto diff3(a);
   diff3.setName("test");
   auto diff4(a);
-  diff4.setUnit(Unit::Id::Length);
+  diff4.setUnit(units::m);
   EXPECT_EQ(a, a);
   EXPECT_EQ(a, a_copy);
   EXPECT_EQ(a, b);
@@ -183,9 +183,9 @@ TEST(Variable, operator_plus_equal_different_unit) {
   Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
 
   auto different_unit(a);
-  different_unit.setUnit(Unit::Id::Length);
+  different_unit.setUnit(units::m);
   EXPECT_THROW_MSG(a += different_unit, dataset::except::UnitMismatchError,
-                   "Expected Unit::Dimensionless to be equal to Unit::Length.");
+                   "Expected dimensionless to be equal to m.");
 }
 
 TEST(Variable, operator_plus_equal_non_arithmetic_type) {
@@ -233,21 +233,21 @@ TEST(Variable, operator_plus_equal_custom_type) {
 TEST(Variable, operator_times_equal) {
   Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a *= a);
   EXPECT_EQ(a.get(Coord::X)[0], 4.0);
   EXPECT_EQ(a.get(Coord::X)[1], 9.0);
-  EXPECT_EQ(a.unit(), Unit::Id::Area);
+  EXPECT_EQ(a.unit(), units::m * units::m);
 }
 
 TEST(Variable, operator_times_equal_scalar) {
   Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a *= 2.0);
   EXPECT_EQ(a.get(Coord::X)[0], 4.0);
   EXPECT_EQ(a.get(Coord::X)[1], 6.0);
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
 }
 
 TEST(Variable, operator_times_can_broadcast) {
@@ -263,32 +263,32 @@ TEST(Variable, operator_times_can_broadcast) {
 TEST(Variable, operator_divide_equal) {
   Variable a(Data::Value, {Dim::X, 2}, {2.0, 3.0});
   Variable b(Data::Value, {}, {2.0});
-  b.setUnit(Unit::Id::Length);
+  b.setUnit(units::m);
 
   EXPECT_NO_THROW(a /= b);
   EXPECT_EQ(a.get(Data::Value)[0], 1.0);
   EXPECT_EQ(a.get(Data::Value)[1], 1.5);
-  EXPECT_EQ(a.unit(), Unit::Id::InverseLength);
+  EXPECT_EQ(a.unit(), units::dimensionless / units::m);
 }
 
 TEST(Variable, operator_divide_equal_self) {
   Variable a(Coord::X, {Dim::X, 2}, {2.0, 3.0});
 
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a /= a);
   EXPECT_EQ(a.get(Coord::X)[0], 1.0);
   EXPECT_EQ(a.get(Coord::X)[1], 1.0);
-  EXPECT_EQ(a.unit(), Unit::Id::Dimensionless);
+  EXPECT_EQ(a.unit(), units::dimensionless);
 }
 
 TEST(Variable, operator_divide_equal_scalar) {
   Variable a(Coord::X, {Dim::X, 2}, {2.0, 4.0});
 
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
   EXPECT_NO_THROW(a /= 2.0);
   EXPECT_EQ(a.get(Coord::X)[0], 1.0);
   EXPECT_EQ(a.get(Coord::X)[1], 2.0);
-  EXPECT_EQ(a.unit(), Unit::Id::Length);
+  EXPECT_EQ(a.unit(), units::m);
 }
 
 TEST(Variable, setSlice) {
@@ -440,11 +440,11 @@ TEST(Variable, concatenate) {
   Dimensions dims(Dim::Tof, 1);
   Variable a(Data::Value, dims, {1.0});
   Variable b(Data::Value, dims, {2.0});
-  a.setUnit(Unit::Id::Length);
-  b.setUnit(Unit::Id::Length);
+  a.setUnit(units::m);
+  b.setUnit(units::m);
   auto ab = concatenate(a, b, Dim::Tof);
   ASSERT_EQ(ab.size(), 2);
-  EXPECT_EQ(ab.unit(), Unit(Unit::Id::Length));
+  EXPECT_EQ(ab.unit(), Unit(units::m));
   const auto &data = ab.get(Data::Value);
   EXPECT_EQ(data[0], 1.0);
   EXPECT_EQ(data[1], 2.0);
@@ -515,10 +515,10 @@ TEST(Variable, concatenate_unit_fail) {
   Variable a(Data::Value, dims, {1.0});
   auto b(a);
   EXPECT_NO_THROW(concatenate(a, b, Dim::X));
-  a.setUnit(Unit::Id::Length);
+  a.setUnit(units::m);
   EXPECT_THROW_MSG(concatenate(a, b, Dim::X), std::runtime_error,
                    "Cannot concatenate Variables: Units do not match.");
-  b.setUnit(Unit::Id::Length);
+  b.setUnit(units::m);
   EXPECT_NO_THROW(concatenate(a, b, Dim::X));
 }
 
@@ -572,9 +572,9 @@ TEST(Variable, sqrt) {
   // TODO Currently comparisons of variables do not provide special handling of
   // NaN, so sqrt of negative values will lead variables that are never equal.
   Variable reference(Data::Value, {Dim::X, 2}, {1, 2});
-  reference.setUnit(Unit::Id::Length);
+  reference.setUnit(units::m);
   Variable var(Data::Value, {Dim::X, 2}, {1, 4});
-  var.setUnit(Unit::Id::Area);
+  var.setUnit(units::m * units::m);
   EXPECT_EQ(sqrt(var), reference);
 }
 


### PR DESCRIPTION
Unit ID are not necessary any more, since a cleaner solution is possible now.

Note that it was necessary to up the boost requirement to 1.67.

Note: This is based on #50, exclude those commits for review.

