### PR TITLE
Expose position dtype to python

### DIFF
--- a/python/test/test_dtypes.py
+++ b/python/test/test_dtypes.py
@@ -1,0 +1,17 @@
+import unittest
+
+from dataset import *
+import numpy as np
+
+class TestDTypes(unittest.TestCase):
+    def test_Eigen_Vector3d(self):
+        d = Dataset()
+        d[Coord.Position] = ([Dim.Position], (4,))
+        self.assertEqual(len(d[Coord.Position].data), 4)
+        self.assertEqual(len(d[Coord.Position].data[0]), 3)
+        self.assertEqual(d[Coord.Position].data[0][0], 0.0)
+        d[Coord.Position].data[0][1] = 1.0
+        self.assertEqual(d[Coord.Position].data[0][1], 1.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tags.h
+++ b/src/tags.h
@@ -30,7 +30,8 @@ enum class DType {
   Char,
   Bool,
   SmallVectorDouble8,
-  Dataset
+  Dataset,
+  EigenVector3d
 };
 template <class T> constexpr DType dtype = DType::Unknown;
 template <> constexpr DType dtype<double> = DType::Double;
@@ -45,6 +46,7 @@ template <>
 constexpr DType dtype<boost::container::small_vector<double, 8>> =
     DType::SmallVectorDouble8;
 template <> constexpr DType dtype<Dataset> = DType::Dataset;
+template <> constexpr DType dtype<Eigen::Vector3d> = DType::EigenVector3d;
 
 // Adding new tags
 // ===============

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1095,6 +1095,7 @@ INSTANTIATE_SLICEVIEW(bool);
 INSTANTIATE_SLICEVIEW(std::string);
 INSTANTIATE_SLICEVIEW(boost::container::small_vector<double, 8>);
 INSTANTIATE_SLICEVIEW(Dataset);
+INSTANTIATE_SLICEVIEW(Eigen::Vector3d);
 
 ConstVariableSlice Variable::operator()(const Dim dim, const gsl::index begin,
                                         const gsl::index end) const & {

--- a/src/variable.h
+++ b/src/variable.h
@@ -316,7 +316,9 @@ private:
 template <class T>
 Variable makeVariable(Tag tag, const Dimensions &dimensions) {
   return Variable(tag, defaultUnit(tag), std::move(dimensions),
-                  Vector<underlying_type_t<T>>(dimensions.volume()));
+                  Vector<underlying_type_t<T>>(
+                      dimensions.volume(),
+                      detail::default_init<underlying_type_t<T>>::value()));
 }
 
 template <class T, class T2>


### PR DESCRIPTION
Add Python exports for variables containing `Eigen::Vector3d`.

For now I have not added a `dtype` flag that would allow for specifying `Eigen::Vector3d` as the item type in a `Variable`. The only way to get it is to use `Coord::Position`, which uses `Eigen::Vector3d` as its default `dtype`. We can add the flag later as needed.