### PR TITLE
Units python exports

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -79,7 +79,8 @@ void declare_ItemZipProxy(py::module &m, const std::string &suffix) {
 template <class... Fields>
 void declare_ranges_pair(py::module &m, const std::string &suffix) {
   using Proxy = ranges::v3::common_pair<Fields &...>;
-  py::class_<Proxy> proxy(m, (std::string("ranges_v3_common_pair_") + suffix).c_str());
+  py::class_<Proxy> proxy(
+      m, (std::string("ranges_v3_common_pair_") + suffix).c_str());
   proxy.def("first", [](const Proxy &self) { return std::get<0>(self); })
       .def("second", [](const Proxy &self) { return std::get<1>(self); });
 }
@@ -481,55 +482,27 @@ PYBIND11_MODULE(dataset, m) {
   declare_VariableView<std::string>(m, "string");
   declare_VariableView<char>(m, "char");
   declare_VariableView<Bool>(m, "bool");
-  declare_VariableView<boost::container::small_vector<double, 8>>(m, "SmallVectorDouble8");
+  declare_VariableView<boost::container::small_vector<double, 8>>(
+      m, "SmallVectorDouble8");
   declare_VariableView<Dataset>(m, "Dataset");
 
   py::class_<Unit>(m, "Unit")
       .def(py::init())
-      .def("__repr__", [](const Unit &u) -> std::string {return u.name();})
+      .def("__repr__", [](const Unit &u) -> std::string { return u.name(); })
       .def(py::self + py::self)
       .def(py::self - py::self)
       .def(py::self * py::self)
-      .def(py::self / py::self)
-  ;
+      .def(py::self / py::self);
 
   auto units = m.def_submodule("units");
-  // Unit::unit_t u;
-  // std::visit(
-  //     [&units](auto &&x) {
-  //       units.attr(units::to_string(x).c_str()) = Unit(x);
-  //     },
-  //     u);
-
+  units.attr("dimensionless") = Unit(units::dimensionless);
   units.attr("m") = Unit(units::m);
   units.attr("counts") = Unit(units::counts);
   units.attr("s") = Unit(units::s);
   units.attr("kg") = Unit(units::kg);
-  units.attr("dimensionless_over_m") = Unit(units::dimensionless / units::m);
   units.attr("angstrom") = Unit(units::angstrom);
   units.attr("meV") = Unit(units::meV);
   units.attr("us") = Unit(units::us);
-  units.attr("dimensionless_over_us") = Unit(units::dimensionless / units::us);
-  units.attr("dimensionless_over_s") = Unit(units::dimensionless / units::s);
-  units.attr("counts_over_us") = Unit(units::counts / units::us);
-  // Variances or basic units
-  units.attr("m2") = Unit(units::m*units::m);
-  units.attr("counts2") = Unit(units::counts*units::counts);
-  units.attr("s2") = Unit(units::s*units::s);
-  units.attr("kg2") = Unit(units::kg*units::kg);
-  units.attr("dimensionless_over_m2") = Unit(units::dimensionless / (units::m*units::m));
-  units.attr("angstrom2") = Unit(units::angstrom*units::angstrom);
-  units.attr("meV2") = Unit(units::meV*units::meV);
-  units.attr("us2") = Unit(units::us*units::us);
-  units.attr("dimensionless_over_us2") = Unit(units::dimensionless / (units::us*units::us));
-  units.attr("dimensionless_over_s2") = Unit(units::dimensionless / (units::s*units::s));
-  units.attr("counts_over_us2") = Unit(units::counts*units::counts / (units::us*units::us));
-  // Extra unit combinations
-  units.attr("dimensionless") = Unit(units::dimensionless);
-  units.attr("m4") = Unit(units::m *units::m *units::m *units::m);
-  units.attr("meV_us2_over_m2") = Unit(units::meV *units::us *units::us / (units::m * units::m));
-  units.attr("mev_us2") = Unit(units::meV *units::us *units::us *units::dimensionless);
-
 
   declare_VariableZipProxy(m, "", Access::Key(Data::EventTofs),
                            Access::Key(Data::EventPulseTimes));

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -492,7 +492,9 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::self + py::self)
       .def(py::self - py::self)
       .def(py::self * py::self)
-      .def(py::self / py::self);
+      .def(py::self / py::self)
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 
   auto units = m.def_submodule("units");
   units.attr("dimensionless") = Unit(units::dimensionless);
@@ -538,8 +540,7 @@ PYBIND11_MODULE(dataset, m) {
       .def_property_readonly("tag", &Variable::tag)
       .def_property("name", [](const Variable &self) { return self.name(); },
                     &Variable::setName)
-      .def_property("unit", [](const Variable &self) { return self.unit(); },
-                    &Variable::setUnit)
+      .def_property("unit", &Variable::unit, &Variable::setUnit)
       .def_property_readonly("is_coord", &Variable::isCoord)
       .def_property_readonly("is_data", &Variable::isData)
       .def_property_readonly("is_attr", &Variable::isAttr)

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -370,8 +370,7 @@ std::variant<py::array_t<Ts>...> as_py_array_t_variant(py::object &obj) {
   }
 }
 
-template <class... Ts>
-struct as_VariableViewImpl {
+template <class... Ts> struct as_VariableViewImpl {
   template <class Var>
   static std::variant<std::conditional_t<
       std::is_same_v<Var, Variable>, gsl::span<underlying_type_t<Ts>>,
@@ -401,7 +400,7 @@ struct as_VariableViewImpl {
     default:
       throw std::runtime_error("not implemented for this type.");
     }
-}
+  }
 };
 
 using as_VariableView =
@@ -587,6 +586,7 @@ PYBIND11_MODULE(dataset, m) {
       .def_property_readonly("is_attr", &VariableSlice::isAttr)
       .def_property_readonly("tag", &VariableSlice::tag)
       .def_property_readonly("name", &VariableSlice::name)
+      .def_property("unit", &VariableSlice::unit, &VariableSlice::setUnit)
       .def("__getitem__",
            [](VariableSlice &self, const std::tuple<Dim, gsl::index> &index) {
              return self(std::get<Dim>(index), std::get<gsl::index>(index));
@@ -813,8 +813,7 @@ PYBIND11_MODULE(dataset, m) {
 
   py::implicitly_convertible<DatasetSlice, Dataset>();
 
-
-//-----------------------dataset free functions----------------------------------------
+  //-----------------------dataset free functions-------------------------------
   m.def("split",
         py::overload_cast<const Dataset &, const Dim,
                           const std::vector<gsl::index> &>(&split),
@@ -825,8 +824,9 @@ PYBIND11_MODULE(dataset, m) {
         py::call_guard<py::gil_scoped_release>());
   m.def("rebin", py::overload_cast<const Dataset &, const Variable &>(&rebin),
         py::call_guard<py::gil_scoped_release>());
-  m.def("histogram", py::overload_cast<const Dataset &, const Variable &>(&histogram),
-      py::call_guard<py::gil_scoped_release>());
+  m.def("histogram",
+        py::overload_cast<const Dataset &, const Variable &>(&histogram),
+        py::call_guard<py::gil_scoped_release>());
   m.def(
       "sort",
       py::overload_cast<const Dataset &, const Tag, const std::string &>(&sort),
@@ -841,7 +841,7 @@ PYBIND11_MODULE(dataset, m) {
   m.def("integrate", py::overload_cast<const Dataset &, const Dim>(&integrate),
         py::call_guard<py::gil_scoped_release>());
 
-//-----------------------variable free functions----------------------------------------
+  //-----------------------variable free functions------------------------------
   m.def("split",
         py::overload_cast<const Variable &, const Dim,
                           const std::vector<gsl::index> &>(&split),
@@ -850,9 +850,12 @@ PYBIND11_MODULE(dataset, m) {
         py::overload_cast<const Variable &, const Variable &, const Dim>(
             &concatenate),
         py::call_guard<py::gil_scoped_release>());
-  m.def("rebin", py::overload_cast<const Variable &, const Variable &, const Variable &>(&rebin),
+  m.def("rebin",
+        py::overload_cast<const Variable &, const Variable &, const Variable &>(
+            &rebin),
         py::call_guard<py::gil_scoped_release>());
-  m.def("filter", py::overload_cast<const Variable &, const Variable &>(&filter),
+  m.def("filter",
+        py::overload_cast<const Variable &, const Variable &>(&filter),
         py::call_guard<py::gil_scoped_release>());
   m.def("sum", py::overload_cast<const Variable &, const Dim>(&sum),
         py::call_guard<py::gil_scoped_release>());
@@ -861,6 +864,6 @@ PYBIND11_MODULE(dataset, m) {
   m.def("norm", py::overload_cast<const Variable &>(&norm),
         py::call_guard<py::gil_scoped_release>());
   // find out why py::overload_cast is not working correctly here
-  m.def("sqrt", [](const Variable &self){ return sqrt(self);},
+  m.def("sqrt", [](const Variable &self) { return sqrt(self); },
         py::call_guard<py::gil_scoped_release>());
 }

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -14,6 +14,7 @@
 #include "dataset.h"
 #include "except.h"
 #include "tag_util.h"
+#include "unit.h"
 #include "zip_view.h"
 
 namespace py = pybind11;
@@ -483,6 +484,53 @@ PYBIND11_MODULE(dataset, m) {
   declare_VariableView<boost::container::small_vector<double, 8>>(m, "SmallVectorDouble8");
   declare_VariableView<Dataset>(m, "Dataset");
 
+  py::class_<Unit>(m, "Unit")
+      .def(py::init())
+      .def("__repr__", [](const Unit &u) -> std::string {return u.name();})
+      .def(py::self + py::self)
+      .def(py::self - py::self)
+      .def(py::self * py::self)
+      .def(py::self / py::self)
+  ;
+
+  auto units = m.def_submodule("units");
+  // Unit::unit_t u;
+  // std::visit(
+  //     [&units](auto &&x) {
+  //       units.attr(units::to_string(x).c_str()) = Unit(x);
+  //     },
+  //     u);
+
+  units.attr("m") = Unit(units::m);
+  units.attr("counts") = Unit(units::counts);
+  units.attr("s") = Unit(units::s);
+  units.attr("kg") = Unit(units::kg);
+  units.attr("dimensionless_over_m") = Unit(units::dimensionless / units::m);
+  units.attr("angstrom") = Unit(units::angstrom);
+  units.attr("meV") = Unit(units::meV);
+  units.attr("us") = Unit(units::us);
+  units.attr("dimensionless_over_us") = Unit(units::dimensionless / units::us);
+  units.attr("dimensionless_over_s") = Unit(units::dimensionless / units::s);
+  units.attr("counts_over_us") = Unit(units::counts / units::us);
+  // Variances or basic units
+  units.attr("m2") = Unit(units::m*units::m);
+  units.attr("counts2") = Unit(units::counts*units::counts);
+  units.attr("s2") = Unit(units::s*units::s);
+  units.attr("kg2") = Unit(units::kg*units::kg);
+  units.attr("dimensionless_over_m2") = Unit(units::dimensionless / (units::m*units::m));
+  units.attr("angstrom2") = Unit(units::angstrom*units::angstrom);
+  units.attr("meV2") = Unit(units::meV*units::meV);
+  units.attr("us2") = Unit(units::us*units::us);
+  units.attr("dimensionless_over_us2") = Unit(units::dimensionless / (units::us*units::us));
+  units.attr("dimensionless_over_s2") = Unit(units::dimensionless / (units::s*units::s));
+  units.attr("counts_over_us2") = Unit(units::counts*units::counts / (units::us*units::us));
+  // Extra unit combinations
+  units.attr("dimensionless") = Unit(units::dimensionless);
+  units.attr("m4") = Unit(units::m *units::m *units::m *units::m);
+  units.attr("meV_us2_over_m2") = Unit(units::meV *units::us *units::us / (units::m * units::m));
+  units.attr("mev_us2") = Unit(units::meV *units::us *units::us *units::dimensionless);
+
+
   declare_VariableZipProxy(m, "", Access::Key(Data::EventTofs),
                            Access::Key(Data::EventPulseTimes));
   declare_ItemZipProxy<small_vector, small_vector>(m, "");
@@ -517,6 +565,8 @@ PYBIND11_MODULE(dataset, m) {
       .def_property_readonly("tag", &Variable::tag)
       .def_property("name", [](const Variable &self) { return self.name(); },
                     &Variable::setName)
+      .def_property("unit", [](const Variable &self) { return self.unit(); },
+                    &Variable::setUnit)
       .def_property_readonly("is_coord", &Variable::isCoord)
       .def_property_readonly("is_data", &Variable::isData)
       .def_property_readonly("is_attr", &Variable::isAttr)

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -272,10 +272,10 @@ class TestDataset(unittest.TestCase):
         np.testing.assert_array_equal(dataset[Coord.X].numpy, np.array([3,2,4,1, 3,2]))
         np.testing.assert_array_equal(dataset[Data.Value, "data"].numpy, np.array([0,1,2,3, 0,1]))
 
-    @unittest.skip("Need support for setting unit to `counts` from Python.")
     def test_rebin(self):
         dataset = Dataset()
         dataset[Data.Value, "data"] = ([Dim.X], np.array(10*[1.0]))
+        dataset[Data.Value, "data"].unit = units.counts
         dataset[Coord.X] = ([Dim.X], np.arange(11.0))
         new_coord = Variable(Coord.X, [Dim.X], np.arange(0.0, 11, 2))
         dataset = rebin(dataset, new_coord)
@@ -396,7 +396,6 @@ class TestDatasetExamples(unittest.TestCase):
         dataset['Value:temperature'][10, ...].plot()
         #plt.savefig('test.png')
 
-    @unittest.skip("Need support for setting unit to `counts` from Python.")
     def test_MDHistoWorkspace_example(self):
         L = 30
         d = Dataset()
@@ -415,6 +414,16 @@ class TestDatasetExamples(unittest.TestCase):
 
         # Uncertainties are propagated using grouping mechanism based on name
         square = d * d
+
+        # Add the counts units
+        d[Data.Value, "temperature"].unit = units.counts
+        d[Data.Value, "pressure"].unit = units.counts
+        d[Data.Variance, "temperature"].unit = units.counts * units.counts
+        # The square operation is now prevented because the resulting counts
+        # variance unit (counts^4) is not part of the supported units, i.e. the
+        # result of that operation makes little physical sense.
+        with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of multiplication counts\^2\*counts\^2"):
+            square = d * d
 
         # Rebin the X axis
         d = rebin(d, Variable(Coord.X, [Dim.X], np.arange(0, L+1, 2).astype(np.float64)))
@@ -484,7 +493,6 @@ class TestDatasetExamples(unittest.TestCase):
         d[Data.EventPulseTimes, ""].data[1].append(1000)
         # Don't do this, there are no compatiblity checks:
         #for el in zip(d[Data.EventTofs, ""].data, d[Data.EventPulseTimes, ""].data):
-        print("zip start")
         for el, size in zip(d.zip(), [1,1,0,0,0]):
             self.assertEqual(len(el), size)
             for e in el:

--- a/python/test/test_units.py
+++ b/python/test/test_units.py
@@ -22,10 +22,10 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(repr(var1.unit), "counts us^-1")
         with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of division counts/m"):
             var1.unit = units.counts / units.m
-        var1.unit = ds.units.m / ds.units.m * ds.units.counts
+        var1.unit = units.m / units.m * units.counts
         self.assertEqual(repr(var1.unit), "counts")
-        with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of multiplication counts*m"):
-            var1.unit = ds.units.counts * ds.units.m / ds.units.m
+        with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of multiplication counts\*m"):
+            var1.unit = units.counts * units.m / units.m
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_units.py
+++ b/python/test/test_units.py
@@ -1,0 +1,28 @@
+import unittest
+
+from dataset import *
+import numpy as np
+
+class TestUnits(unittest.TestCase):
+    def test_create_unit(self):
+        u = units.angstrom
+        self.assertEqual(repr(u), "AA")
+
+    def test_variable_unit(self):
+        var1 = Variable(Data.Value, [Dim.X], np.arange(4))
+        var2 = Variable(Coord.X, [Dim.X], np.arange(4))
+        self.assertEqual(repr(var1.unit), "dimensionless")
+        self.assertEqual(repr(var2.unit), "m")
+        u = units.angstrom
+        var1.unit = u
+        self.assertEqual(repr(var1.unit), "AA")
+        var1.unit = units.m * units.m
+        self.assertEqual(repr(var1.unit), "m^2")
+        var1.unit = units.counts / units.us
+        self.assertEqual(repr(var1.unit), "counts us^-1")
+        with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of division counts/m"):
+            var1.unit = units.counts / units.m    
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/test/test_units.py
+++ b/python/test/test_units.py
@@ -21,8 +21,11 @@ class TestUnits(unittest.TestCase):
         var1.unit = units.counts / units.us
         self.assertEqual(repr(var1.unit), "counts us^-1")
         with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of division counts/m"):
-            var1.unit = units.counts / units.m    
-
+            var1.unit = units.counts / units.m
+        var1.unit = ds.units.m / ds.units.m * ds.units.counts
+        self.assertEqual(repr(var1.unit), "counts")
+        with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of multiplication counts*m"):
+            var1.unit = ds.units.counts * ds.units.m / ds.units.m
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_units.py
+++ b/python/test/test_units.py
@@ -11,11 +11,16 @@ class TestUnits(unittest.TestCase):
     def test_variable_unit(self):
         var1 = Variable(Data.Value, [Dim.X], np.arange(4))
         var2 = Variable(Coord.X, [Dim.X], np.arange(4))
-        self.assertEqual(repr(var1.unit), "dimensionless")
-        self.assertEqual(repr(var2.unit), "m")
+        self.assertEqual(var1.unit, units.dimensionless)
         self.assertEqual(var2.unit, units.m)
         self.assertNotEqual(var2.unit, units.counts)
         self.assertTrue(var2.unit != units.counts)
+
+    def test_variable_unit_repr(self):
+        var1 = Variable(Data.Value, [Dim.X], np.arange(4))
+        var2 = Variable(Coord.X, [Dim.X], np.arange(4))
+        self.assertEqual(repr(var1.unit), "dimensionless")
+        self.assertEqual(repr(var2.unit), "m")
         u = units.angstrom
         var1.unit = u
         self.assertEqual(repr(var1.unit), "\u212B")

--- a/python/test/test_units.py
+++ b/python/test/test_units.py
@@ -6,16 +6,19 @@ import numpy as np
 class TestUnits(unittest.TestCase):
     def test_create_unit(self):
         u = units.angstrom
-        self.assertEqual(repr(u), "AA")
+        self.assertEqual(repr(u), "\u212B")
 
     def test_variable_unit(self):
         var1 = Variable(Data.Value, [Dim.X], np.arange(4))
         var2 = Variable(Coord.X, [Dim.X], np.arange(4))
         self.assertEqual(repr(var1.unit), "dimensionless")
         self.assertEqual(repr(var2.unit), "m")
+        self.assertEqual(var2.unit, units.m)
+        self.assertNotEqual(var2.unit, units.counts)
+        self.assertTrue(var2.unit != units.counts)
         u = units.angstrom
         var1.unit = u
-        self.assertEqual(repr(var1.unit), "AA")
+        self.assertEqual(repr(var1.unit), "\u212B")
         var1.unit = units.m * units.m
         self.assertEqual(repr(var1.unit), "m^2")
         var1.unit = units.counts / units.us
@@ -24,6 +27,9 @@ class TestUnits(unittest.TestCase):
             var1.unit = units.counts / units.m
         var1.unit = units.m / units.m * units.counts
         self.assertEqual(repr(var1.unit), "counts")
+        # The statement below fails because (units.counts * units.m) is
+        # performed first and is not part of the currently supported set of
+        # intermediate units.
         with self.assertRaisesRegex(RuntimeError, "Unsupported unit as result of multiplication counts\*m"):
             var1.unit = units.counts * units.m / units.m
 

--- a/src/except.h
+++ b/src/except.h
@@ -91,7 +91,8 @@ template <class T> void unit(const T &object, const Unit &unit) {
 template <class T> void countsOrCountsDensity(const T &object) {
   if (!(units::containsCounts(object.unit()) ||
         units::containsCountsVariance(object.unit())))
-    throw except::UnitError("Expected counts or counts-density.");
+    throw except::UnitError("Expected counts or counts-density, got " +
+                            object.unit().name() + '.');
 }
 } // namespace expect
 } // namespace dataset

--- a/src/unit.h
+++ b/src/unit.h
@@ -77,7 +77,7 @@ BOOST_UNITS_DEFINE_CONVERSION_FACTOR(neutron::tof::tof_base_unit,
 template <>
 struct boost::units::base_unit_info<neutron::tof::wavelength_base_unit> {
   static std::string name() { return "angstroms"; }
-  static std::string symbol() { return "AA"; }
+  static std::string symbol() { return "\u212B"; }
 };
 
 template <>

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -801,11 +801,11 @@ TEST(Dataset, rebin_accepts_only_counts_and_densities) {
 
   d.insert(Data::Value, "", {Dim::Tof, 2}, {10.0, 20.0});
   EXPECT_THROW_MSG(rebin(d, coordNew), dataset::except::UnitError,
-                   "Expected counts or counts-density.");
+                   "Expected counts or counts-density, got dimensionless.");
 
   d(Data::Value, "").setUnit(units::m);
   EXPECT_THROW_MSG(rebin(d, coordNew), dataset::except::UnitError,
-                   "Expected counts or counts-density.");
+                   "Expected counts or counts-density, got m.");
 
   d(Data::Value, "").setUnit(units::counts);
   EXPECT_NO_THROW(rebin(d, coordNew));


### PR DESCRIPTION
This is the first pass at exposing the units to python.
The `Unit` class was simply exposed to python, and a `units` submodule was created, containing the basic units `m`, `s`, `dimensionless` etc... Operations between different units are possible in python, and are handled by the operators of the `Unit` class.

The following Python code
```Python
import numpy as np
import dataset as ds

var1 = ds.Variable(ds.Data.Value, [ds.Dim.X], np.arange(4))
var2 = ds.Variable(ds.Coord.X, [ds.Dim.X], np.arange(4))
var1.name = "SomeNeutronData"

print("var1.name", var1.name)
print("var1.unit", var1.unit)
print("var2.unit", var2.unit)

u = ds.units.angstrom
print("u = ", u)
var1.unit = u
print("var1.unit", var1.unit)

var1.unit = ds.units.m * ds.units.m
print("var1.unit", var1.unit)

var1.unit = ds.units.counts / ds.units.us
print("var1.unit", var1.unit)

var1.unit = ds.units.counts / ds.units.m
print("var1.unit", var1.unit)
```
now produces the following output:
```
var1.name SomeNeutronData
var1.unit dimensionless
var2.unit m
u =  AA
var1.unit AA
var1.unit m^2
var1.unit counts us^-1
Traceback (most recent call last):
  File "python_units.py", line 37, in <module>
    var1.unit = ds.units.counts / ds.units.m
RuntimeError: Unsupported unit as result of division counts/m
```