### PR TITLE
Improve formatting

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -639,18 +639,16 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self -= py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self *= py::self, py::call_guard<py::gil_scoped_release>())
-      .def("__repr__",
-           [](const DatasetSlice &self) { return dataset::to_string(self); });
+      .def("__repr__", [](const DatasetSlice &self) {
+        return dataset::to_string(self, ".");
+      });
 
   py::class_<Dataset>(m, "Dataset")
       .def(py::init<>())
       .def(py::init<const DatasetSlice &>())
       .def("__len__", &Dataset::size)
       .def("__repr__",
-           [](const Dataset &self) {
-             auto out = dataset::to_string(self, ".");
-             return out;
-           })
+           [](const Dataset &self) { return dataset::to_string(self, "."); })
       .def("__iter__",
            [](Dataset &self) {
              return py::make_iterator(self.begin(), self.end());

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -159,7 +159,7 @@ class TestDataset(unittest.TestCase):
     def test_slice_dataset(self):
         for x in range(2):
             view = self.dataset[Dim.X, x]
-            self.assertRaisesRegex(RuntimeError, 'Dataset slice with 5 variables, could not find variable with tag Coord::X and name ``.', view.__getitem__, Coord.X)
+            self.assertRaisesRegex(RuntimeError, 'could not find variable with tag Coord::X and name ``.', view.__getitem__, Coord.X)
             np.testing.assert_array_equal(view[Coord.Y].numpy, self.reference_y)
             np.testing.assert_array_equal(view[Coord.Z].numpy, self.reference_z)
             np.testing.assert_array_equal(view[Data.Value, "data1"].numpy, self.reference_data1[:,:,x])
@@ -168,7 +168,7 @@ class TestDataset(unittest.TestCase):
         for y in range(3):
             view = self.dataset[Dim.Y, y]
             np.testing.assert_array_equal(view[Coord.X].numpy, self.reference_x)
-            self.assertRaisesRegex(RuntimeError, 'Dataset slice with 5 variables, could not find variable with tag Coord::Y and name ``.', view.__getitem__, Coord.Y)
+            self.assertRaisesRegex(RuntimeError, 'could not find variable with tag Coord::Y and name ``.', view.__getitem__, Coord.Y)
             np.testing.assert_array_equal(view[Coord.Z].numpy, self.reference_z)
             np.testing.assert_array_equal(view[Data.Value, "data1"].numpy, self.reference_data1[:,y,:])
             np.testing.assert_array_equal(view[Data.Value, "data2"].numpy, self.reference_data2[:,y,:])
@@ -177,7 +177,7 @@ class TestDataset(unittest.TestCase):
             view = self.dataset[Dim.Z, z]
             np.testing.assert_array_equal(view[Coord.X].numpy, self.reference_x)
             np.testing.assert_array_equal(view[Coord.Y].numpy, self.reference_y)
-            self.assertRaisesRegex(RuntimeError, 'Dataset slice with 5 variables, could not find variable with tag Coord::Z and name ``.', view.__getitem__, Coord.Z)
+            self.assertRaisesRegex(RuntimeError, 'could not find variable with tag Coord::Z and name ``.', view.__getitem__, Coord.Z)
             np.testing.assert_array_equal(view[Data.Value, "data1"].numpy, self.reference_data1[z,:,:])
             np.testing.assert_array_equal(view[Data.Value, "data2"].numpy, self.reference_data2[z,:,:])
             np.testing.assert_array_equal(view[Data.Value, "data3"].numpy, self.reference_data3[z,:])
@@ -484,7 +484,6 @@ class TestDatasetExamples(unittest.TestCase):
         d[Data.EventPulseTimes, ""].data[1].append(1000)
         # Don't do this, there are no compatiblity checks:
         #for el in zip(d[Data.EventTofs, ""].data, d[Data.EventPulseTimes, ""].data):
-        print("zip start")
         for el, size in zip(d.zip(), [1,1,0,0,0]):
             self.assertEqual(len(el), size)
             for e in el:

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -21,10 +21,6 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertEqual(1, len([var for var in ds_slice if var.is_coord]))
         self.assertEqual(2, len(ds_slice))
 
-    def test_repr(self):
-        ds_slice = self._d["a"]
-        self.assertEqual(repr(ds_slice), "Dataset slice with 2 variables")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -58,15 +58,5 @@ class TestVariable(unittest.TestCase):
         var.name = "data"
         self.assertEqual(var.name, "data")
 
-    def test_repr(self):
-        var = Variable(Coord.X, [Dim.X], np.arange(1))
-        self.assertEqual(repr(var), "Variable(Coord.X, '',( Dim.X ), int64)\n")
-        var = Variable(Data.Value, [Dim.X], np.arange(1))
-        self.assertEqual(repr(var), "Variable(Data.Value, '',( Dim.X ), int64)\n")
-        var = Variable(Coord.SpectrumNumber, [Dim.X], np.arange(1))
-        self.assertEqual(repr(var), "Variable(Coord.SpectrumNumber, '',( Dim.X ), int64)\n")
-        var = Variable(Coord.Mask, [Dim.X], np.arange(1))
-        self.assertEqual(repr(var), "Variable(Coord.Mask, '',( Dim.X ), int64)\n")
-
 if __name__ == '__main__':
     unittest.main()

--- a/src/except.h
+++ b/src/except.h
@@ -20,6 +20,7 @@ class Dimensions;
 class Tag;
 class Unit;
 class Variable;
+class ConstVariableSlice;
 
 namespace dataset {
 std::string to_string(const Dim dim, const std::string &separator = "::");
@@ -29,9 +30,12 @@ std::string to_string(const Tag tag, const std::string &separator = "::");
 std::string to_string(const Unit &unit, const std::string &separator = "::");
 std::string to_string(const Variable &variable,
                       const std::string &separator = "::");
+std::string to_string(const ConstVariableSlice &variable,
+                      const std::string &separator = "::");
 std::string to_string(const Dataset &dataset,
                       const std::string &separator = "::");
-std::string to_string(const ConstDatasetSlice &dataset);
+std::string to_string(const ConstDatasetSlice &dataset,
+                      const std::string &separator = "::");
 
 namespace except {
 


### PR DESCRIPTION
Now looks like this:

```
<Dataset>
Dimensions: {{Dim.Tof, 1000}, {Dim.Spectrum, 100}}
Coordinates:
    (Coord.SpectrumNumber)    int64     [dimensionless]  (Dim.Spectrum)
    (Coord.X)                 double    [m]              (Dim.Spectrum)
    (Coord.Y)                 double    [m]              (Dim.Spectrum)
    (Coord.Z)                 double    [m]              ()
    (Coord.Mask)              bool      [dimensionless]  (Dim.Spectrum)
    (Coord.Tof)               int64     [us]             (Bin-edges: Dim.Tof)
Data:
    (Data.Value, sample1)     double    [dimensionless]  (Dim.Spectrum, Dim.Tof)
    (Data.Variance, sample1)  double    [dimensionless]  (Dim.Spectrum, Dim.Tof)
Attributes:


<DatasetSlice>
Dimensions: {{Dim::Tof, 1000}, {Dim::Spectrum, 80}}
Coordinates:
    (Coord::SpectrumNumber)   int64     [dimensionless]  (Dim::Spectrum)
    (Coord::X)                double    [m]              (Dim::Spectrum)
    (Coord::Y)                double    [m]              (Dim::Spectrum)
    (Coord::Z)                double    [m]              ()
    (Coord::Mask)             bool      [dimensionless]  (Dim::Spectrum)
    (Coord::Tof)              int64     [us]             (Bin-edges: Dim::Tof)
Data:
    (Data::Value, sample1)    double    [dimensionless]  (Dim::Spectrum, Dim::Tof)
    (Data::Variance, sample1)  double    [dimensionless]  (Dim::Spectrum, Dim::Tof)
Attributes:


<VariableSlice>    (Coord.Tof)               int64     [us]             (Dim.Tof)
```

We may want to add output for first and last array elements later?