### PR TITLE
Python additions

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -823,6 +823,7 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self * py::self, py::call_guard<py::gil_scoped_release>())
+      .def("merge", &Dataset::merge)
       .def("dimensions", [](const Dataset &self) { return self.dimensions(); })
       // TODO For now this is just for testing. We need to decide on an API for
       // specifying the keys.

--- a/python/compat/mantid.py
+++ b/python/compat/mantid.py
@@ -30,19 +30,21 @@ def ConvertWorkspace2DToDataset(ws):
     convert_instrument(d, ws)
     initPosSpectrumNo(d, nHist, ws)
 
+    # TODO More cases?
+    tag = ds.Coord.DeltaE if ws.getAxis(0).getUnit().unitID() == 'DeltaE' else ds.Coord.Tof
+    dim = ds.Dim.DeltaE if ws.getAxis(0).getUnit().unitID() == 'DeltaE' else ds.Dim.Tof
     if cb:
-        d[ds.Coord.Tof] = ([ds.Dim.Tof], ws.readX(0))
+        d[tag] = ([dim], ws.readX(0))
     else:
-        d[ds.Coord.Tof] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readX(0))))
+        d[tag] = ([ds.Dim.Position, dim], (ws.getNumberHistograms(), len(ws.readX(0))))
         for i in range(ws.getNumberHistograms()):
-            d[ds.Coord.Tof][ds.Dim.Position, i] = ws.readX(i);
+            d[tag][ds.Dim.Position, i] = ws.readX(i);
 
 
-    d[ds.Data.Value] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readY(0))))
-    d[ds.Data.Variance] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readE(0))))
+    d[ds.Data.Value] = ([ds.Dim.Position, dim], (ws.getNumberHistograms(), len(ws.readY(0))))
+    d[ds.Data.Variance] = ([ds.Dim.Position, dim], (ws.getNumberHistograms(), len(ws.readE(0))))
 
     # TODO Use unit information in workspace, if available.
-    d[ds.Coord.Tof].unit = ds.units.us
     d[ds.Data.Value].unit = ds.units.counts
     d[ds.Data.Variance].unit = ds.units.counts * ds.units.counts
 

--- a/python/compat/mantid.py
+++ b/python/compat/mantid.py
@@ -1,32 +1,44 @@
 import dataset as ds
 
-def initPosSpectrunNo(d, nHist, ws): 
+def get_pos(pos):
+    return [pos.X(), pos.Y(), pos.Z()]
+
+def convert_instrument(dataset, ws):
+    compInfo = ds.Dataset()
+    compInfo[ds.Coord.Position] = ([ds.Dim.Component], (2,))
+    # Current assumption: 0 is source, 1 is sample
+    samplePos = ws.componentInfo().samplePosition()
+    sourcePos = ws.componentInfo().sourcePosition()
+    compInfo[ds.Coord.Position].data[0] = get_pos(samplePos)
+    compInfo[ds.Coord.Position].data[1] = get_pos(sourcePos)
+    dataset[ds.Coord.ComponentInfo] = ([], compInfo)
+
+def initPosSpectrumNo(d, nHist, ws):
     d[ds.Coord.Position] = ([ds.Dim.Position], (nHist,))
     d[ds.Coord.SpectrumNumber] = ([ds.Dim.Position], (nHist,))
-    
+
     for j, pos in enumerate(d[ds.Coord.Position].data):
-        pos[0] = ws.spectrumInfo().position(j).X()
-        pos[1] = ws.spectrumInfo().position(j).Y()
-        pos[2] = ws.spectrumInfo().position(j).Z()
-    
+        pos = get_pos(ws.spectrumInfo().position(j))
+
     for j, specNum in enumerate(d[ds.Coord.SpectrumNumber].data):
         specNum = ws.getSpectrum(j).getSpectrumNo()
-        
+
 def ConvertWorkspace2DToDataset(ws):
     d = ds.Dataset()
     cb = ws.isCommonBins()
     nHist = ws.getNumberHistograms()
-    initPosSpectrunNo(d, nHist, ws)
-        
+    convert_instrument(d, ws)
+    initPosSpectrumNo(d, nHist, ws)
+
     if cb:
-        d[ds.Coord.Tof] = ([ds.Dim.Tof], ws.readX(0))        
+        d[ds.Coord.Tof] = ([ds.Dim.Tof], ws.readX(0))
     else:
         d[ds.Coord.Tof] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readX(0))))
         for i in range(ws.getNumberHistograms()):
             d[ds.Coord.Tof][ds.Dim.Position, i] = ws.readX(i);
-        
-    
-    d[ds.Data.Value] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readY(0))))     
+
+
+    d[ds.Data.Value] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readY(0))))
     d[ds.Data.Variance] = ([ds.Dim.Position, ds.Dim.Tof], (ws.getNumberHistograms(), len(ws.readE(0))))
 
     # TODO Use unit information in workspace, if available.
@@ -37,19 +49,20 @@ def ConvertWorkspace2DToDataset(ws):
     for i in range(ws.getNumberHistograms()):
         d[ds.Data.Value][ds.Dim.Position, i] = ws.readY(i)
         d[ds.Data.Variance][ds.Dim.Position, i] = ws.readE(i)*ws.readE(i)
-        
+
     return d
 
 def ConvertEventWorkspaceToDataset(ws):
     d = ds.Dataset()
     nHist = ws.getNumberHistograms()
-    initPosSpectrunNo(d, nHist, ws)        
-    
-    d[ds.Data.Events] = ([ds.Dim.Position], (nHist,))    
+    convert_instrument(d, ws)
+    initPosSpectrumNo(d, nHist, ws)
+
+    d[ds.Data.Events] = ([ds.Dim.Position], (nHist,))
     for i, e in enumerate(d[ds.Data.Events].data):
         e[ds.Data.Tof] = ([ds.Dim.Event], ws.getSpectrum(i).getTofs())
         pt = ws.getSpectrum(i).getPulseTimes()
-        e[ds.Data.PulseTime] = ([ds.Dim.Event], [p.total_nanoseconds() for p in pt])        
+        e[ds.Data.PulseTime] = ([ds.Dim.Event], [p.total_nanoseconds() for p in pt])
     return d
 
 def to_dataset(ws):

--- a/python/compat/test/mantid_test.py
+++ b/python/compat/test/mantid_test.py
@@ -11,8 +11,8 @@ class TestMantidConversion(unittest.TestCase):
     def test_Workspace2D(self):
         # This is from the Mantid system-test data
         filename = 'CNCS_51936_event.nxs'
-        ws = mantid.LoadEventNexus(filename)
-        ws = mantid.Rebin(ws, -0.001, PreserveEvents=False)
+        eventWS = mantid.LoadEventNexus(filename)
+        ws = mantid.Rebin(eventWS, -0.001, PreserveEvents=False)
         d = mantidcompat.to_dataset(ws)
         #dataset = as_xarray(d[Dim.Position, 1000:2000])
         #dataset['Value'].plot()
@@ -22,13 +22,13 @@ class TestMantidConversion(unittest.TestCase):
     def test_EventWorkspace(self):
         # This is from the Mantid system-test data
         filename = 'CNCS_51936_event.nxs'
-        ews = mantid.LoadEventNexus(filename)
-        ws = mantid.Rebin(ews, -0.001, PreserveEvents=False)
+        eventWS = mantid.LoadEventNexus(filename)
+        ws = mantid.Rebin(eventWS, -0.001, PreserveEvents=False)
 
         binned_mantid = mantidcompat.to_dataset(ws)
 
         tof = Variable(binned_mantid[Coord.Tof])
-        d = mantidcompat.to_dataset(ews)
+        d = mantidcompat.to_dataset(eventWS)
         binned = histogram(d, tof)
 
         delta = sum(binned_mantid - binned, Dim.Position)
@@ -44,3 +44,31 @@ class TestMantidConversion(unittest.TestCase):
         #ds = as_xarray(sum(binned_mantid, Dim.Position))
         #ds['Value'].plot()
         #plt.savefig('binned_mantid.png')
+
+    def test_unit_conversion(self):
+        # This is from the Mantid system-test data
+        filename = 'CNCS_51936_event.nxs'
+        eventWS = mantid.LoadEventNexus(filename)
+        ws = mantid.Rebin(eventWS, -0.001, PreserveEvents=False)
+        ws = mantid.ConvertUnits(InputWorkspace=ws, Target='DeltaE', EMode='Direct', EFixed=3.3056)
+
+        converted_mantid = mantidcompat.to_dataset(ws)
+
+        tof = Variable(converted_mantid[Coord.Tof])
+        d = mantidcompat.to_dataset(eventWS)
+        d[Coord.Ei] = ([], 3.3059)
+        d.merge(histogram(d, tof))
+        del(d[Data.Events])
+        converted = convert(d, Dim.Tof, Dim.DeltaE)
+
+        delta = sum(converted_mantid - converted, Dim.Position)
+
+        ds = as_xarray(delta)
+        ds['Value'].plot()
+
+        ds = as_xarray(sum(converted, Dim.Position))
+        ds['Value'].plot()
+
+        ds = as_xarray(sum(converted_mantid, Dim.Position))
+        ds['Value'].plot()
+        plt.savefig('converted.png')

--- a/python/compat/test/mantid_test.py
+++ b/python/compat/test/mantid_test.py
@@ -50,11 +50,13 @@ class TestMantidConversion(unittest.TestCase):
         filename = 'CNCS_51936_event.nxs'
         eventWS = mantid.LoadEventNexus(filename)
         ws = mantid.Rebin(eventWS, -0.001, PreserveEvents=False)
+        tmp = mantidcompat.to_dataset(ws)
+        tof = Variable(tmp[Coord.Tof])
         ws = mantid.ConvertUnits(InputWorkspace=ws, Target='DeltaE', EMode='Direct', EFixed=3.3056)
 
         converted_mantid = mantidcompat.to_dataset(ws)
+        converted_mantid[Coord.Ei] = ([], 3.3059)
 
-        tof = Variable(converted_mantid[Coord.Tof])
         d = mantidcompat.to_dataset(eventWS)
         d[Coord.Ei] = ([], 3.3059)
         d.merge(histogram(d, tof))
@@ -72,3 +74,6 @@ class TestMantidConversion(unittest.TestCase):
         ds = as_xarray(sum(converted_mantid, Dim.Position))
         ds['Value'].plot()
         plt.savefig('converted.png')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/compat/test/mantid_test.py
+++ b/python/compat/test/mantid_test.py
@@ -57,7 +57,7 @@ class TestMantidConversion(unittest.TestCase):
         converted_mantid = mantidcompat.to_dataset(ws)
         converted_mantid[Coord.Ei] = ([], 3.3059)
 
-        d = mantidcompat.to_dataset(eventWS)
+        d = mantidcompat.to_dataset(eventWS, drop_pulse_times=True)
         d[Coord.Ei] = ([], 3.3059)
         d.merge(histogram(d, tof))
         del(d[Data.Events])

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -253,10 +253,7 @@ T1 &binary_op_equals(Op op, T1 &dataset, const T2 &other) {
         // Coordinate variables must match
         // Strictly speaking we should allow "equivalent" coordinates, i.e.,
         // match only after projecting out any constant dimensions.
-        if (!(var1 == var2))
-          throw std::runtime_error(
-              "Coordinates of datasets do not match. Cannot "
-              "perform binary operation.");
+        dataset::expect::variablesMatch(var1, var2);
         // TODO We could improve sharing here magically, but whether this is
         // beneficial would depend on the shared reference count in var1 and
         // var2: var1 = var2;
@@ -344,9 +341,7 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
     auto var1 = dataset[index];
     if (var1.isCoord()) {
       // Coordinate variables must match
-      if (!(var1 == var2))
-        throw std::runtime_error(
-            "Coordinates of datasets do not match. Cannot perform addition");
+      dataset::expect::variablesMatch(var1, var2);
     } else if (var1.isData()) {
       // Data variables are added
       if (var2.tag() == Data::Value) {

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -295,10 +295,10 @@ DimensionLengthError::DimensionLengthError(const Dimensions &expected,
                      ".") {}
 
 DatasetError::DatasetError(const Dataset &dataset, const std::string &message)
-    : std::runtime_error(to_string(dataset) + ", " + message) {}
+    : std::runtime_error(to_string(dataset) + message) {}
 DatasetError::DatasetError(const ConstDatasetSlice &dataset,
                            const std::string &message)
-    : std::runtime_error(to_string(dataset) + ", " + message) {}
+    : std::runtime_error(to_string(dataset) + message) {}
 
 VariableNotFoundError::VariableNotFoundError(const Dataset &dataset,
                                              const Tag tag,
@@ -310,6 +310,13 @@ VariableNotFoundError::VariableNotFoundError(const ConstDatasetSlice &dataset,
                                              const std::string &name)
     : DatasetError(dataset, "could not find variable with tag " +
                                 to_string(tag) + " and name `" + name + "`.") {}
+
+VariableError::VariableError(const Variable &variable,
+                             const std::string &message)
+    : std::runtime_error(to_string(variable) + message) {}
+VariableError::VariableError(const ConstVariableSlice &variable,
+                             const std::string &message)
+    : std::runtime_error(to_string(variable) + message) {}
 
 UnitMismatchError::UnitMismatchError(const Unit &a, const Unit &b)
     : UnitError("Expected " + to_string(a) + " to be equal to " + to_string(b) +

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -60,30 +60,58 @@ std::string do_to_string(const Dim dim) {
 
 std::string do_to_string(const Tag tag) {
   switch (tag.value()) {
-  case Coord::Tof.value():
-    return "Coord::Tof";
-  case Coord::Energy.value():
-    return "Coord::Energy";
-  case Coord::DeltaE.value():
-    return "Coord::DeltaE";
+  case Coord::Monitor.value():
+    return "Coord::Monitor";
+  case Coord::DetectorInfo.value():
+    return "Coord::DetectorInfo";
+  case Coord::ComponentInfo.value():
+    return "Coord::ComponentInfo";
   case Coord::X.value():
     return "Coord::X";
   case Coord::Y.value():
     return "Coord::Y";
   case Coord::Z.value():
     return "Coord::Z";
+  case Coord::Tof.value():
+    return "Coord::Tof";
+  case Coord::Energy.value():
+    return "Coord::Energy";
+  case Coord::DeltaE.value():
+    return "Coord::DeltaE";
+  case Coord::Ei.value():
+    return "Coord::Ei";
+  case Coord::Ef.value():
+    return "Coord::Ef";
+  case Coord::DetectorId.value():
+    return "Coord::DetectorId";
   case Coord::SpectrumNumber.value():
     return "Coord::SpectrumNumber";
+  case Coord::DetectorGrouping.value():
+    return "Coord::DetectorGrouping";
+  case Coord::RowLabel.value():
+    return "Coord::RowLabel";
+  case Coord::Polarization.value():
+    return "Coord::Polarization";
+  case Coord::Temperature.value():
+    return "Coord::Temperature";
+  case Coord::Time.value():
+    return "Coord::Time";
   case Coord::Mask.value():
     return "Coord::Mask";
   case Coord::Position.value():
     return "Coord::Position";
-  case Coord::DetectorGrouping.value():
-    return "Coord::DetectorGrouping";
+  case Data::Events.value():
+    return "Data::Events";
   case Data::Value.value():
     return "Data::Value";
   case Data::Variance.value():
     return "Data::Variance";
+  case Data::Tof.value():
+    return "Data::Tof";
+  case Data::PulseTime.value():
+    return "Data::PulseTime";
+  case Attr::ExperimentLog.value():
+    return "Attr::ExperimentLog";
   default:
     return "<unknown tag>";
   }

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -124,7 +124,7 @@ namespace dataset {
 
 std::string to_string(const Dimensions &dims, const std::string &separator) {
   if (dims.empty())
-    return "{}";
+    return "{}\n";
   std::string s = "{{";
   for (int32_t i = 0; i < dims.ndim(); ++i)
     s += to_string(dims.labels()[i], separator) + ", " +

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -115,7 +115,7 @@ std::string to_string(const DType dtype) {
   case DType::Char:
     return "char";
   case DType::Dataset:
-    return "dataset";
+    return "Dataset";
   case DType::Float:
     return "float";
   case DType::Double:
@@ -124,6 +124,8 @@ std::string to_string(const DType dtype) {
     return "int32";
   case DType::Int64:
     return "int64";
+  case DType::EigenVector3d:
+    return "Eigen::Vector3d";
   case DType::Unknown:
     return "unknown";
   default:

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -124,13 +124,13 @@ namespace dataset {
 
 std::string to_string(const Dimensions &dims, const std::string &separator) {
   if (dims.empty())
-    return "{}\n";
+    return "{}";
   std::string s = "{{";
   for (int32_t i = 0; i < dims.ndim(); ++i)
     s += to_string(dims.labels()[i], separator) + ", " +
          std::to_string(dims.shape()[i]) + "}, {";
   s.resize(s.size() - 3);
-  s += "}\n";
+  s += "}";
   return s;
 }
 
@@ -241,7 +241,7 @@ std::string do_to_string(const D &dataset, const std::string &id,
                          const Dimensions &dims, const std::string &separator) {
   std::stringstream s;
   s << id + '\n';
-  s << "Dimensions: " << to_string(dims, separator);
+  s << "Dimensions: " << to_string(dims, separator) << '\n';
   s << "Coordinates:\n";
   for (const auto &var : dataset) {
     if (var.isCoord())

--- a/src/except.h
+++ b/src/except.h
@@ -68,6 +68,17 @@ struct VariableNotFoundError : public DatasetError {
                         const std::string &name);
 };
 
+struct VariableError : public std::runtime_error {
+  VariableError(const Variable &variable, const std::string &message);
+  VariableError(const ConstVariableSlice &variable, const std::string &message);
+};
+
+struct VariableMismatchError : public VariableError {
+  template <class A, class B>
+  VariableMismatchError(const A &a, const B &b)
+      : VariableError(a, "expected to match\n" + dataset::to_string(b)) {}
+};
+
 struct UnitError : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
@@ -79,6 +90,10 @@ struct UnitMismatchError : public UnitError {
 } // namespace except
 
 namespace expect {
+template <class A, class B> void variablesMatch(const A &a, const B &b) {
+  if (a != b)
+    throw except::VariableMismatchError(a, b);
+}
 void dimensionMatches(const Dimensions &dims, const Dim dim,
                       const gsl::index length);
 void equals(const Unit &a, const Unit &b);

--- a/test/Run_test.cpp
+++ b/test/Run_test.cpp
@@ -121,9 +121,8 @@ TEST(Run, meta_data_fail_coord_mismatch) {
 
   auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
   run2.get(Coord::Polarization)[0] = "Spin-Down";
-  EXPECT_THROW_MSG(
-      d1 += d2, std::runtime_error,
-      "Coordinates of datasets do not match. Cannot perform binary operation.");
+  EXPECT_THROW_MSG_SUBSTR(d1 += d2, dataset::except::VariableMismatchError,
+                          "expected to match");
 }
 
 TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
@@ -133,9 +132,8 @@ TEST(Run, meta_data_fail_fuzzy_coord_mismatch) {
 
   auto &run2 = d2.get(Attr::ExperimentLog, "sample_log")[0];
   run2.get(Coord::FuzzyTemperature)[0] = ValueWithDelta<double>(4.0, 0.1);
-  EXPECT_THROW_MSG(
-      d1 += d2, std::runtime_error,
-      "Coordinates of datasets do not match. Cannot perform binary operation.");
+  EXPECT_THROW_MSG_SUBSTR(d1 += d2, dataset::except::VariableMismatchError,
+                          "expected to match");
 }
 
 TEST(Run, meta_data_fail_missing) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -615,10 +615,10 @@ TEST(Dataset, slice) {
   }
   EXPECT_THROW_MSG(
       d(Dim::Z, 0), std::runtime_error,
-      "Expected dimension to be in {{Dim::Y, 3}, {Dim::X, 2}}\n, got Dim::Z.");
+      "Expected dimension to be in {{Dim::Y, 3}, {Dim::X, 2}}, got Dim::Z.");
   EXPECT_THROW_MSG(
       d(Dim::Z, 1), std::runtime_error,
-      "Expected dimension to be in {{Dim::Y, 3}, {Dim::X, 2}}\n, got Dim::Z.");
+      "Expected dimension to be in {{Dim::Y, 3}, {Dim::X, 2}}, got Dim::Z.");
 }
 
 TEST(Dataset, concatenate_constant_dimension_broken) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -1174,9 +1174,9 @@ TEST(DatasetSlice, subset_slice_spatial) {
   // coordinate mismatch, as it should.
   auto view_a_x01 = d["a"](Dim::X, 0, 1);
   auto view_a_x12 = d["a"](Dim::X, 1, 2);
-  EXPECT_THROW_MSG(
-      view_a_x12 -= view_a_x01, std::runtime_error,
-      "Coordinates of datasets do not match. Cannot perform binary operation.");
+  EXPECT_THROW_MSG_SUBSTR(view_a_x12 -= view_a_x01,
+                          dataset::except::VariableMismatchError,
+                          "expected to match");
 }
 
 TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
@@ -1238,12 +1238,12 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
   // coordinate mismatch, as it should.
-  EXPECT_THROW_MSG(
-      view_a_x12 -= view_a_x01, std::runtime_error,
-      "Coordinates of datasets do not match. Cannot perform binary operation.");
-  EXPECT_THROW_MSG(
-      view_a_x13 -= view_a_x02, std::runtime_error,
-      "Coordinates of datasets do not match. Cannot perform binary operation.");
+  EXPECT_THROW_MSG_SUBSTR(view_a_x12 -= view_a_x01,
+                          dataset::except::VariableMismatchError,
+                          "expected to match");
+  EXPECT_THROW_MSG_SUBSTR(view_a_x13 -= view_a_x02,
+                          dataset::except::VariableMismatchError,
+                          "expected to match");
 }
 
 TEST(Dataset, unary_minus) {

--- a/test/except_test.cpp
+++ b/test/except_test.cpp
@@ -15,14 +15,14 @@ TEST(DimensionMismatchError, what) {
   dataset::except::DimensionMismatchError error(dims, Dimensions{});
   EXPECT_EQ(
       error.what(),
-      std::string("Expected dimensions {{Dim::X, 1}, {Dim::Y, 2}}\n, got {}."));
+      std::string("Expected dimensions {{Dim::X, 1}, {Dim::Y, 2}}, got {}."));
 }
 
 TEST(DimensionNotFoundError, what) {
   Dimensions dims{{Dim::X, 1}, {Dim::Y, 2}};
   dataset::except::DimensionNotFoundError error(dims, Dim::Z);
   EXPECT_EQ(error.what(), std::string("Expected dimension to be in {{Dim::X, "
-                                      "1}, {Dim::Y, 2}}\n, got Dim::Z."));
+                                      "1}, {Dim::Y, 2}}, got Dim::Z."));
 }
 
 TEST(DimensionLengthError, what) {
@@ -30,7 +30,7 @@ TEST(DimensionLengthError, what) {
   dataset::except::DimensionLengthError error(dims, Dim::Y, 3);
   EXPECT_EQ(error.what(),
             std::string("Expected dimension to be in {{Dim::X, 1}, {Dim::Y, "
-                        "2}}\n, got Dim::Y with mismatching length 3."));
+                        "2}}, got Dim::Y with mismatching length 3."));
 }
 
 TEST(Dimensions, to_string) {

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -176,7 +176,7 @@ TEST(Variable, operator_plus_equal_different_dimensions) {
 
   Variable different_dimensions(Data::Value, {Dim::Y, 2}, {1.1, 2.2});
   EXPECT_THROW_MSG(a += different_dimensions, std::runtime_error,
-                   "Expected {{Dim::X, 2}}\n to contain {{Dim::Y, 2}}\n.");
+                   "Expected {{Dim::X, 2}} to contain {{Dim::Y, 2}}.");
 }
 
 TEST(Variable, operator_plus_equal_different_unit) {
@@ -600,7 +600,7 @@ TEST(Variable, broadcast_fail) {
   Variable var(Data::Value, {{Dim::Y, 2}, {Dim::X, 2}}, {1, 2, 3, 4});
   EXPECT_THROW_MSG(broadcast(var, {Dim::X, 3}),
                    dataset::except::DimensionLengthError,
-                   "Expected dimension to be in {{Dim::Y, 2}, {Dim::X, 2}}\n, "
+                   "Expected dimension to be in {{Dim::Y, 2}, {Dim::X, 2}}, "
                    "got Dim::X with mismatching length 3.");
 }
 
@@ -656,8 +656,8 @@ TEST(VariableSlice, minus_equals_failures) {
   Variable var(Data::Value, {{Dim::X, 2}, {Dim::Y, 2}}, {1.0, 2.0, 3.0, 4.0});
 
   EXPECT_THROW_MSG(var -= var(Dim::X, 0, 1), std::runtime_error,
-                   "Expected {{Dim::X, 2}, {Dim::Y, 2}}\n to contain {{Dim::X, "
-                   "1}, {Dim::Y, 2}}\n.");
+                   "Expected {{Dim::X, 2}, {Dim::Y, 2}} to contain {{Dim::X, "
+                   "1}, {Dim::Y, 2}}.");
 }
 
 TEST(VariableSlice, self_overlapping_view_operation) {


### PR DESCRIPTION
Several smaller things fixed, encountered during playing with data converted from Mantid:

- Converting pulse times from Mantid format is extremely slow, added option to drop them (10x speedup in conversion).
- Conversion of source and sample positions, needed for applying unit conversions.
- Try to set some sensible units in converters.
- Fix several cases of incomplete formatting, exception messages, ...