### PR TITLE
Subset syntax and enhancements

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -717,6 +717,10 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("subset", [](Dataset &self,
                         const std::string &name) { return self.subset(name); })
+      .def("subset",
+           [](Dataset &self, const Tag tag, const std::string &name) {
+             return self.subset(tag, name);
+           })
       // Careful: The order of overloads is really important here, otherwise
       // DatasetSlice matches the overload below for py::array_t. I have not
       // understood all details of this yet though. See also

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -659,6 +659,12 @@ PYBIND11_MODULE(dataset, m) {
           [](DatasetSlice &self, const std::pair<Tag, const std::string> &key) {
             return self(key.first, key.second);
           })
+      .def("subset", [](DatasetSlice &self,
+                        const std::string &name) { return self.subset(name); })
+      .def("subset",
+           [](DatasetSlice &self, const Tag tag, const std::string &name) {
+             return self.subset(tag, name);
+           })
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::Tag>)
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::TagName>)
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -715,8 +715,8 @@ PYBIND11_MODULE(dataset, m) {
            [](Dataset &self, const std::pair<Tag, const std::string> &key) {
              return self(key.first, key.second);
            })
-      .def("__getitem__",
-           [](Dataset &self, const std::string &name) { return self[name]; })
+      .def("subset", [](Dataset &self,
+                        const std::string &name) { return self.subset(name); })
       // Careful: The order of overloads is really important here, otherwise
       // DatasetSlice matches the overload below for py::array_t. I have not
       // understood all details of this yet though. See also

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -38,7 +38,7 @@ class TestDataset(unittest.TestCase):
         self.assertFalse((Data.Value, "data4") in self.dataset)
 
     def test_view_contains(self):
-        view = self.dataset["data2"]
+        view = self.dataset.subset("data2")
         self.assertTrue(Coord.X in view)
         self.assertTrue(Coord.Y in view)
         self.assertTrue(Coord.Z in view)
@@ -149,7 +149,7 @@ class TestDataset(unittest.TestCase):
         np.testing.assert_array_equal(self.dataset[Data.Value, "data3"].numpy, self.reference_data3)
 
     def test_view_subdata(self):
-        view = self.dataset["data1"]
+        view = self.dataset.subset("data1")
         # TODO Need consistent dimensions() implementation for Dataset and its views.
         #self.assertEqual(view.dimensions().size(Dim.X), 2)
         #self.assertEqual(view.dimensions().size(Dim.Y), 3)
@@ -227,7 +227,7 @@ class TestDataset(unittest.TestCase):
 
     def test_slice_numpy_interoperable(self):
         # Dataset subset then view single variable
-        self.dataset['data2'][Data.Value, 'data2'] = np.exp(self.dataset[Data.Value, 'data1'])
+        self.dataset.subset('data2')[Data.Value, 'data2'] = np.exp(self.dataset[Data.Value, 'data1'])
         np.testing.assert_array_equal(self.dataset[Data.Value, "data2"].numpy, np.exp(self.reference_data1))
         # Slice view of dataset then view single variable
         self.dataset[Dim.X, 0][Data.Value, 'data2'] = np.exp(self.dataset[Dim.X, 1][Data.Value, 'data1'])
@@ -392,7 +392,7 @@ class TestDatasetExamples(unittest.TestCase):
         d[Coord.Z] = ([Dim.Z], np.arange(L))
         d[Data.Value, "temperature"] = ([Dim.Z, Dim.Y, Dim.X], np.random.normal(size=L*L*L).reshape([L,L,L]))
 
-        dataset = as_xarray(d['temperature'])
+        dataset = as_xarray(d.subset('temperature'))
         dataset['Value:temperature'][10, ...].plot()
         #plt.savefig('test.png')
 

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -13,7 +13,7 @@ class TestDatasetSlice(unittest.TestCase):
         self._d = d
 
     def test_extract_slice(self):
-        ds_slice = self._d["a"]
+        ds_slice = self._d.subset("a")
         self.assertEqual(type(ds_slice), dataset.DatasetView)
         # We should have just one data variable
         self.assertEqual(1, len([var for var in ds_slice if var.is_data]))

--- a/python/test/test_xarray_interop.py
+++ b/python/test/test_xarray_interop.py
@@ -37,7 +37,7 @@ class TestXarrayInterop(unittest.TestCase):
         table += table
         self.assertSequenceEqual(table[ds.Coord.RowLabel].data, ['a', 'bb', 'bb', 'ccc'])
 
-        dataset = ds.as_xarray(table['col1'])
+        dataset = ds.as_xarray(table.subset('col1'))
         #print(dataset)
         dataset['Value:col1'].plot()
         #plt.savefig('test.png')

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -23,8 +23,17 @@ ConstDatasetSlice Dataset::subset(const std::string &name) const & {
   return ConstDatasetSlice(*this, name);
 }
 
+ConstDatasetSlice Dataset::subset(const Tag tag,
+                                  const std::string &name) const & {
+  return ConstDatasetSlice(*this, tag, name);
+}
+
 DatasetSlice Dataset::subset(const std::string &name) & {
   return DatasetSlice(*this, name);
+}
+
+DatasetSlice Dataset::subset(const Tag tag, const std::string &name) & {
+  return DatasetSlice(*this, tag, name);
 }
 
 ConstDatasetSlice Dataset::operator()(const Dim dim, const gsl::index begin,

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -19,11 +19,11 @@ Dataset::Dataset(const ConstDatasetSlice &view) {
     insert(var);
 }
 
-ConstDatasetSlice Dataset::operator[](const std::string &name) const & {
+ConstDatasetSlice Dataset::subset(const std::string &name) const & {
   return ConstDatasetSlice(*this, name);
 }
 
-DatasetSlice Dataset::operator[](const std::string &name) & {
+DatasetSlice Dataset::subset(const std::string &name) & {
   return DatasetSlice(*this, name);
 }
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -58,7 +58,7 @@ public:
   DatasetSlice subset(const std::string &) && = delete;
   DatasetSlice subset(const Tag, const std::string &) && = delete;
   DatasetSlice subset(const std::string &name) &;
-  DatasetSlice subset(const Tag tag,const std::string &name) &;
+  DatasetSlice subset(const Tag tag, const std::string &name) &;
 
   ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,
                                const gsl::index end = -1) const && = delete;
@@ -312,6 +312,30 @@ private:
 
   friend struct IterAccess;
 
+protected:
+  std::vector<gsl::index> makeIndices(const ConstDatasetSlice &base,
+                                      const std::string &select) const {
+    std::vector<gsl::index> indices;
+    for (const auto i : base.m_indices) {
+      const auto &var = base.m_dataset[i];
+      // TODO Should we also keep attributes? Probably yes?
+      if (var.isCoord() || var.name() == select)
+        indices.push_back(i);
+    }
+    return indices;
+  }
+  std::vector<gsl::index> makeIndices(const ConstDatasetSlice &base,
+                                      const Tag selectTag,
+                                      const std::string &selectName) const {
+    std::vector<gsl::index> indices;
+    for (const auto i : base.m_indices) {
+      const auto &var = base.m_dataset[i];
+      if (var.isCoord() || (var.tag() == selectTag && var.name() == selectName))
+        indices.push_back(i);
+    }
+    return indices;
+  }
+
 public:
   ConstDatasetSlice(const Dataset &dataset) : m_dataset(dataset) {
     // Select everything.
@@ -319,29 +343,27 @@ public:
       m_indices.push_back(i);
   }
 
+  ConstDatasetSlice(const Dataset &dataset, std::vector<gsl::index> indices)
+      : m_dataset(dataset), m_indices(std::move(indices)) {}
+
   ConstDatasetSlice(const Dataset &dataset, const std::string &select)
-      : m_dataset(dataset) {
-    for (gsl::index i = 0; i < dataset.size(); ++i) {
-      const auto &var = dataset[i];
-      // TODO Should we also keep attributes? Probably yes?
-      if (var.isCoord() || var.name() == select)
-        m_indices.push_back(i);
-    }
-  }
+      : ConstDatasetSlice(dataset, makeIndices(dataset, select)) {}
 
   ConstDatasetSlice(const Dataset &dataset, const Tag selectTag,
                     const std::string &selectName)
-      : m_dataset(dataset) {
-    for (gsl::index i = 0; i < dataset.size(); ++i) {
-      const auto &var = dataset[i];
-      if (var.isCoord() || (var.tag() == selectTag && var.name() == selectName))
-        m_indices.push_back(i);
-    }
-  }
+      : ConstDatasetSlice(dataset,
+                          makeIndices(dataset, selectTag, selectName)) {}
 
   ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,
                                const gsl::index end = -1) const {
     return makeSubslice(*this, dim, begin, end);
+  }
+
+  ConstDatasetSlice subset(const std::string &name) const & {
+    return ConstDatasetSlice(m_dataset, makeIndices(*this, name));
+  }
+  ConstDatasetSlice subset(const Tag tag, const std::string &name) const & {
+    return ConstDatasetSlice(m_dataset, makeIndices(*this, tag, name));
   }
 
   bool contains(const Tag tag, const std::string &name = "") const;
@@ -434,6 +456,9 @@ private:
 public:
   DatasetSlice(Dataset &dataset)
       : ConstDatasetSlice(dataset), m_mutableDataset(dataset) {}
+  DatasetSlice(Dataset &dataset, std::vector<gsl::index> indices)
+      : ConstDatasetSlice(dataset, std::move(indices)),
+        m_mutableDataset(dataset) {}
   DatasetSlice(Dataset &dataset, const std::string &select)
       : ConstDatasetSlice(dataset, select), m_mutableDataset(dataset) {}
   DatasetSlice(Dataset &dataset, const Tag selectTag,
@@ -449,6 +474,13 @@ public:
   DatasetSlice operator()(const Dim dim, const gsl::index begin,
                           const gsl::index end = -1) const {
     return makeSubslice(*this, dim, begin, end);
+  }
+
+  DatasetSlice subset(const std::string &name) const & {
+    return DatasetSlice(m_mutableDataset, makeIndices(*this, name));
+  }
+  DatasetSlice subset(const Tag tag, const std::string &name) const & {
+    return DatasetSlice(m_mutableDataset, makeIndices(*this, tag, name));
   }
 
   using ConstDatasetSlice::begin;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -50,10 +50,10 @@ public:
   VariableSlice operator[](const gsl::index i) & {
     return VariableSlice{m_variables[i]};
   }
-  ConstDatasetSlice operator[](const std::string &name) const && = delete;
-  ConstDatasetSlice operator[](const std::string &name) const &;
-  DatasetSlice operator[](const std::string &name) && = delete;
-  DatasetSlice operator[](const std::string &name) &;
+  ConstDatasetSlice subset(const std::string &name) const && = delete;
+  ConstDatasetSlice subset(const std::string &name) const &;
+  DatasetSlice subset(const std::string &name) && = delete;
+  DatasetSlice subset(const std::string &name) &;
   ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,
                                const gsl::index end = -1) const && = delete;
   ConstDatasetSlice operator()(const Dim dim, const gsl::index begin,

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -364,6 +364,46 @@ TEST(Dataset, subset) {
   EXPECT_TRUE(both.contains(Data::Variance, "a"));
 }
 
+TEST(Dataset, subset_of_subset) {
+  Dataset d;
+  d.insert(Coord::X, {});
+  d.insert(Data::Value, "a", {});
+  d.insert(Data::Variance, "a", {});
+  d.insert(Data::Value, "b", {});
+  d.insert(Data::Variance, "b", {});
+
+  const auto value = d.subset(Data::Value, "a");
+  const auto both = d.subset("a");
+
+  const auto value_from_subset = both.subset(Data::Value, "a");
+
+  EXPECT_EQ(value, value_from_subset);
+  EXPECT_EQ(value_from_subset.size(), 2);
+  EXPECT_TRUE(value_from_subset.contains(Coord::X));
+  EXPECT_TRUE(value_from_subset.contains(Data::Value, "a"));
+}
+
+TEST(Dataset, subset_of_full_subset) {
+  Dataset d;
+  d.insert(Coord::X, {});
+  d.insert(Data::Value, "a", {});
+  d.insert(Data::Variance, "a", {});
+  d.insert(Data::Value, "b", {});
+  d.insert(Data::Variance, "b", {});
+
+  const auto both = d.subset("a");
+  const DatasetSlice full(d);
+  EXPECT_EQ(full.size(), 5);
+
+  const auto both_from_subset = full.subset("a");
+
+  EXPECT_EQ(both, both_from_subset);
+  EXPECT_EQ(both_from_subset.size(), 3);
+  EXPECT_TRUE(both_from_subset.contains(Coord::X));
+  EXPECT_TRUE(both_from_subset.contains(Data::Value, "a"));
+  EXPECT_TRUE(both_from_subset.contains(Data::Variance, "a"));
+}
+
 TEST(Dataset, comparison_with_spatial_slice) {
   Dataset d1;
   d1.insert(Data::Value, "a", {Dim::X, 2}, {2, 3});

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -322,7 +322,7 @@ TEST(Dataset, comparison_missing_variable) {
   EXPECT_EQ(d2, d2);
 }
 
-TEST(Dataset, comparison_with_slice) {
+TEST(Dataset, comparison_with_subset) {
   Dataset d1;
   d1.insert(Data::Value, "a", {});
   d1.insert(Data::Variance, "a", {});
@@ -333,6 +333,35 @@ TEST(Dataset, comparison_with_slice) {
   EXPECT_NE(d1, d2);
   EXPECT_EQ(d1, d2.subset("a"));
   EXPECT_EQ(d2.subset("a"), d1);
+}
+
+TEST(Dataset, subset) {
+  Dataset d;
+  d.insert(Coord::X, {});
+  d.insert(Data::Value, "a", {});
+  d.insert(Data::Variance, "a", {});
+  d.insert(Data::Value, "b", {});
+  d.insert(Data::Variance, "b", {});
+
+  const auto no_data = d.subset("");
+  EXPECT_EQ(no_data.size(), 1);
+  EXPECT_TRUE(no_data.contains(Coord::X));
+
+  const auto value = d.subset(Data::Value, "a");
+  EXPECT_EQ(value.size(), 2);
+  EXPECT_TRUE(value.contains(Coord::X));
+  EXPECT_TRUE(value.contains(Data::Value, "a"));
+
+  const auto variance = d.subset(Data::Variance, "a");
+  EXPECT_EQ(variance.size(), 2);
+  EXPECT_TRUE(variance.contains(Coord::X));
+  EXPECT_TRUE(variance.contains(Data::Variance, "a"));
+
+  const auto both = d.subset("a");
+  EXPECT_EQ(both.size(), 3);
+  EXPECT_TRUE(both.contains(Coord::X));
+  EXPECT_TRUE(both.contains(Data::Value, "a"));
+  EXPECT_TRUE(both.contains(Data::Variance, "a"));
 }
 
 TEST(Dataset, comparison_with_spatial_slice) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -331,8 +331,8 @@ TEST(Dataset, comparison_with_slice) {
   d2.insert(Data::Value, "a", {});
   d2.insert(Data::Variance, "a", {});
   EXPECT_NE(d1, d2);
-  EXPECT_EQ(d1, d2["a"]);
-  EXPECT_EQ(d2["a"], d1);
+  EXPECT_EQ(d1, d2.subset("a"));
+  EXPECT_EQ(d2.subset("a"), d1);
 }
 
 TEST(Dataset, comparison_with_spatial_slice) {
@@ -344,17 +344,17 @@ TEST(Dataset, comparison_with_spatial_slice) {
 
   EXPECT_NE(d1, d2);
 
-  EXPECT_NE(d1, d2["a"]);
-  EXPECT_NE(d1, d2["a"](Dim::X, 0, 2));
-  EXPECT_NE(d1, d2["a"](Dim::X, 0));
-  EXPECT_NE(d1, d2["a"](Dim::X, 1));
-  EXPECT_EQ(d1, d2["a"](Dim::X, 1, 3));
+  EXPECT_NE(d1, d2.subset("a"));
+  EXPECT_NE(d1, d2.subset("a")(Dim::X, 0, 2));
+  EXPECT_NE(d1, d2.subset("a")(Dim::X, 0));
+  EXPECT_NE(d1, d2.subset("a")(Dim::X, 1));
+  EXPECT_EQ(d1, d2.subset("a")(Dim::X, 1, 3));
 
-  EXPECT_NE(d2["a"], d1);
-  EXPECT_NE(d2["a"](Dim::X, 0, 2), d1);
-  EXPECT_NE(d2["a"](Dim::X, 0), d1);
-  EXPECT_NE(d2["a"](Dim::X, 1), d1);
-  EXPECT_EQ(d2["a"](Dim::X, 1, 3), d1);
+  EXPECT_NE(d2.subset("a"), d1);
+  EXPECT_NE(d2.subset("a")(Dim::X, 0, 2), d1);
+  EXPECT_NE(d2.subset("a")(Dim::X, 0), d1);
+  EXPECT_NE(d2.subset("a")(Dim::X, 1), d1);
+  EXPECT_EQ(d2.subset("a")(Dim::X, 1, 3), d1);
 }
 
 TEST(Dataset, comparison_two_slices) {
@@ -363,15 +363,15 @@ TEST(Dataset, comparison_two_slices) {
   d.insert(Data::Value, "b", {Dim::X, 4}, {1, 2, 1, 2});
 
   // Data is same but name differs.
-  EXPECT_NE(d["a"](Dim::X, 0, 2), d["b"](Dim::X, 0, 2));
+  EXPECT_NE(d.subset("a")(Dim::X, 0, 2), d.subset("b")(Dim::X, 0, 2));
 
-  EXPECT_EQ(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 0, 2));
-  EXPECT_NE(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 1, 3));
-  EXPECT_NE(d["a"](Dim::X, 0, 2), d["a"](Dim::X, 2, 4));
+  EXPECT_EQ(d.subset("a")(Dim::X, 0, 2), d.subset("a")(Dim::X, 0, 2));
+  EXPECT_NE(d.subset("a")(Dim::X, 0, 2), d.subset("a")(Dim::X, 1, 3));
+  EXPECT_NE(d.subset("a")(Dim::X, 0, 2), d.subset("a")(Dim::X, 2, 4));
 
-  EXPECT_EQ(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 0, 2));
-  EXPECT_NE(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 1, 3));
-  EXPECT_EQ(d["b"](Dim::X, 0, 2), d["b"](Dim::X, 2, 4));
+  EXPECT_EQ(d.subset("b")(Dim::X, 0, 2), d.subset("b")(Dim::X, 0, 2));
+  EXPECT_NE(d.subset("b")(Dim::X, 0, 2), d.subset("b")(Dim::X, 1, 3));
+  EXPECT_EQ(d.subset("b")(Dim::X, 0, 2), d.subset("b")(Dim::X, 2, 4));
 }
 
 TEST(Dataset, operator_plus_equal) {
@@ -1084,8 +1084,8 @@ TEST(DatasetSlice, basics) {
 
   check(viewA, "a");
   check(viewB, "b");
-  check(d["a"], "a");
-  check(d["b"], "b");
+  check(d.subset("a"), "a");
+  check(d.subset("b"), "b");
 }
 
 TEST(DatasetSlice, minus_equals) {
@@ -1097,14 +1097,14 @@ TEST(DatasetSlice, minus_equals) {
   d.insert(Data::Variance, "a", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
   d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}}, 8, 1.0);
 
-  EXPECT_NO_THROW(d -= d["a"]);
+  EXPECT_NO_THROW(d -= d.subset("a"));
 
   EXPECT_EQ(d.get(Data::Value, "a")[0], 0.0);
   EXPECT_EQ(d.get(Data::Value, "b")[0], 1.0);
   EXPECT_EQ(d.get(Data::Variance, "a")[0], 2.0);
   EXPECT_EQ(d.get(Data::Variance, "b")[0], 1.0);
 
-  ASSERT_NO_THROW(d["a"] -= d["b"]);
+  ASSERT_NO_THROW(d.subset("a") -= d.subset("b"));
 
   ASSERT_EQ(d.size(), 6);
   // Note: Variable not renamed when operating with slices.
@@ -1144,7 +1144,7 @@ TEST(DatasetSlice, subset_slice_spatial) {
   d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
 
-  auto view_a_x0 = d["a"](Dim::X, 0);
+  auto view_a_x0 = d.subset("a")(Dim::X, 0);
 
   // Slice with single index (not range) => corresponding dimension coordinate
   // is removed.
@@ -1153,7 +1153,7 @@ TEST(DatasetSlice, subset_slice_spatial) {
   EXPECT_EQ(view_a_x0[1].dimensions(), (Dimensions{Dim::Y, 2}));
   EXPECT_EQ(view_a_x0[2].dimensions(), (Dimensions{Dim::Y, 2}));
 
-  auto view_a_x1 = d["a"](Dim::X, 1);
+  auto view_a_x1 = d.subset("a")(Dim::X, 1);
 
   ASSERT_EQ(view_a_x1.size(), 3);
   EXPECT_EQ(view_a_x1[0].dimensions(), (Dimensions{Dim::Y, 2}));
@@ -1172,8 +1172,8 @@ TEST(DatasetSlice, subset_slice_spatial) {
   // If we slice with a range index the corresponding coordinate (and dimension)
   // is preserved, even if the range has size 1. Thus the operation fails due to
   // coordinate mismatch, as it should.
-  auto view_a_x01 = d["a"](Dim::X, 0, 1);
-  auto view_a_x12 = d["a"](Dim::X, 1, 2);
+  auto view_a_x01 = d.subset("a")(Dim::X, 0, 1);
+  auto view_a_x12 = d.subset("a")(Dim::X, 1, 2);
   EXPECT_THROW_MSG(
       view_a_x12 -= view_a_x01, std::runtime_error,
       "Coordinates of datasets do not match. Cannot perform binary operation.");
@@ -1192,7 +1192,7 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   d.insert(Data::Variance, "b", {{Dim::Y, 2}, {Dim::X, 4}},
            {1, 2, 3, 4, 5, 6, 7, 8});
 
-  auto view_a_x0 = d["a"](Dim::X, 0);
+  auto view_a_x0 = d.subset("a")(Dim::X, 0);
 
   // Slice with single index (not range) => corresponding dimension coordinate
   // is removed.
@@ -1201,7 +1201,7 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   EXPECT_EQ(view_a_x0[1].dimensions(), (Dimensions{Dim::Y, 2}));
   EXPECT_EQ(view_a_x0[2].dimensions(), (Dimensions{Dim::Y, 2}));
 
-  auto view_a_x1 = d["a"](Dim::X, 1);
+  auto view_a_x1 = d.subset("a")(Dim::X, 1);
 
   ASSERT_EQ(view_a_x1.size(), 3);
   EXPECT_EQ(view_a_x1[0].dimensions(), (Dimensions{Dim::Y, 2}));
@@ -1217,8 +1217,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   EXPECT_TRUE(equals(d.get(Data::Value, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
   EXPECT_TRUE(equals(d.get(Data::Variance, "b"), {1, 2, 3, 4, 5, 6, 7, 8}));
 
-  auto view_a_x01 = d["a"](Dim::X, 0, 1);
-  auto view_a_x12 = d["a"](Dim::X, 1, 2);
+  auto view_a_x01 = d.subset("a")(Dim::X, 0, 1);
+  auto view_a_x12 = d.subset("a")(Dim::X, 1, 2);
   ASSERT_EQ(view_a_x01[0].tag(), Coord::X);
   // View extent is 1 so we get 2 edges.
   ASSERT_EQ(view_a_x01.dimensions()[Dim::X], 1);
@@ -1226,8 +1226,8 @@ TEST(DatasetSlice, subset_slice_spatial_with_bin_edges) {
   EXPECT_TRUE(equals(view_a_x01[0].get(Coord::X), {1, 2}));
   EXPECT_TRUE(equals(view_a_x12[0].get(Coord::X), {2, 3}));
 
-  auto view_a_x02 = d["a"](Dim::X, 0, 2);
-  auto view_a_x13 = d["a"](Dim::X, 1, 3);
+  auto view_a_x02 = d.subset("a")(Dim::X, 0, 2);
+  auto view_a_x13 = d.subset("a")(Dim::X, 1, 3);
   ASSERT_EQ(view_a_x02[0].tag(), Coord::X);
   // View extent is 2 so we get 3 edges.
   ASSERT_EQ(view_a_x02.dimensions()[Dim::X], 2);


### PR DESCRIPTION
- Rename overload of `operator()` for `Dataset` to `subset`.
- Add more variants of `subset`.
- Add `subset` for `DatasetSlice`.