### PR TITLE
Small UX improvements

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -768,16 +768,21 @@ PYBIND11_MODULE(dataset, m) {
       // 1. Insertion from numpy.ndarray
       .def("__setitem__", detail::insert_ndarray<detail::Key::Tag>)
       .def("__setitem__", detail::insert_ndarray<detail::Key::TagName>)
-      // 2. Insertion attempting forced conversion to array of double. This
+      // 2. Handle integers before case 3. below, which would convert to double.
+      .def("__setitem__", detail::insert_0D<int64_t, detail::Key::Tag>)
+      .def("__setitem__", detail::insert_0D<int64_t, detail::Key::TagName>)
+      .def("__setitem__", detail::insert_1D<int64_t, detail::Key::Tag>)
+      .def("__setitem__", detail::insert_1D<int64_t, detail::Key::TagName>)
+      // 3. Insertion attempting forced conversion to array of double. This
       //    is handled by automatic conversion by pybind11 when using
       //    py::array_t. Handles also scalar data. See also the
       //    py::array::forcecast argument, we need to minimize implicit (and
       //    potentially expensive conversion). If we wanted to avoid some
       //    conversion we need to provide explicit variants for specific types,
-      //    same as or similar to insert_1D in case 3. below.
+      //    same as or similar to insert_1D in case 4. below.
       .def("__setitem__", detail::insert_conv<double, detail::Key::Tag>)
       .def("__setitem__", detail::insert_conv<double, detail::Key::TagName>)
-      // 3. Insertion of numpy-incompatible data. py::array_t does not support
+      // 4. Insertion of numpy-incompatible data. py::array_t does not support
       //    non-POD types like std::string, so we need to handle them
       //    separately.
       .def("__setitem__", detail::insert_0D<std::string, detail::Key::Tag>)
@@ -788,7 +793,7 @@ PYBIND11_MODULE(dataset, m) {
       .def("__setitem__", detail::insert_1D<std::string, detail::Key::TagName>)
       .def("__setitem__", detail::insert_1D<Dataset, detail::Key::Tag>)
       .def("__setitem__", detail::insert_1D<Dataset, detail::Key::TagName>)
-      // 4. Insertion from Variable or Variable slice.
+      // 5. Insertion from Variable or Variable slice.
       .def("__setitem__", detail::insert<Variable, detail::Key::Tag>)
       .def("__setitem__", detail::insert<Variable, detail::Key::TagName>)
       .def("__setitem__", detail::insert<VariableSlice, detail::Key::Tag>)

--- a/python/test/test_xarray_interop.py
+++ b/python/test/test_xarray_interop.py
@@ -9,7 +9,7 @@ class TestXarrayInterop(unittest.TestCase):
         table = ds.Dataset()
         table[ds.Coord.RowLabel] = ([ds.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
         self.assertSequenceEqual(table[ds.Coord.RowLabel].data, ['a', 'bb', 'ccc', 'dddd'])
-        table[ds.Data.Value, "col1"] = ([ds.Dim.Row], [3,2,1,0])
+        table[ds.Data.Value, "col1"] = ([ds.Dim.Row], [3.0,2.0,1.0,0.0])
         table[ds.Data.Value, "col2"] = ([ds.Dim.Row], np.arange(4))
         self.assertEqual(len(table), 3)
 

--- a/src/except.h
+++ b/src/except.h
@@ -12,17 +12,18 @@
 #include <gsl/gsl_util>
 
 #include "dimension.h"
+#include "tags.h"
 #include "unit.h"
 
 class ConstDatasetSlice;
 class Dataset;
 class Dimensions;
-class Tag;
 class Unit;
 class Variable;
 class ConstVariableSlice;
 
 namespace dataset {
+std::string to_string(const DType dtype);
 std::string to_string(const Dim dim, const std::string &separator = "::");
 std::string to_string(const Dimensions &dims,
                       const std::string &separator = "::");
@@ -38,6 +39,10 @@ std::string to_string(const ConstDatasetSlice &dataset,
                       const std::string &separator = "::");
 
 namespace except {
+
+struct TypeError : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 
 struct DimensionError : public std::runtime_error {
   using std::runtime_error::runtime_error;

--- a/test/variable_test.cpp
+++ b/test/variable_test.cpp
@@ -117,6 +117,12 @@ TEST(Variable, operator_equals) {
   EXPECT_FALSE(a == diff4);
 }
 
+TEST(Variable, operator_equals_mismatching_dtype) {
+  auto a = makeVariable<double>(Data::Value, {});
+  auto b = makeVariable<float>(Data::Value, {});
+  EXPECT_NE(a, b);
+}
+
 TEST(Variable, operator_unary_minus) {
   const Variable a(Data::Value, {Dim::X, 2}, {1.1, 2.2});
   auto b = -a;
@@ -198,9 +204,8 @@ TEST(Variable, operator_plus_equal_non_arithmetic_type) {
 TEST(Variable, operator_plus_equal_different_variables_different_element_type) {
   Variable a(Data::Value, {Dim::X, 1}, {1.0});
   auto b = makeVariable<int64_t>(Data::Value, {Dim::X, 1}, {2});
-  EXPECT_THROW_MSG(a += b, std::runtime_error,
-                   "Cannot apply arithmetic operation to Variables: Underlying "
-                   "data types do not match.");
+  EXPECT_THROW_MSG(a += b, dataset::except::TypeError,
+                   "Expected item dtype double, got int64.");
 }
 
 TEST(Variable, operator_plus_equal_different_variables_same_element_type) {


### PR DESCRIPTION
- Throw something sensible instead of `std::bad_cast` -> Exception now gives expected and actual `dtype`.
- Avoid some int -> double conversion.