### PR TITLE
Monitors

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -525,6 +525,7 @@ PYBIND11_MODULE(dataset, m) {
 
   auto attr_tags = m.def_submodule("Attr");
   attr_tags.attr("ExperimentLog") = Tag(Attr::ExperimentLog);
+  attr_tags.attr("Monitor") = Tag(Attr::Monitor);
 
   declare_span<double>(m, "double");
   declare_span<float>(m, "float");

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -492,6 +492,37 @@ class TestDatasetExamples(unittest.TestCase):
                 spec[Data.Value, "sample1"] = np.zeros(1000)
                 spec[Data.Variance, "sample1"] = np.zeros(1000)
 
+    def test_monitors_example(self):
+        d = Dataset()
+
+        d[Coord.SpectrumNumber] = ([Dim.Spectrum], np.arange(1, 101))
+
+        # Add a (common) time-of-flight axis
+        d[Coord.Tof] = ([Dim.Tof], np.arange(9))
+
+        # Add data with uncertainties
+        d[Data.Value, "sample1"] = ([Dim.Spectrum, Dim.Tof], np.random.exponential(size=100*8).reshape([100, 8]))
+        d[Data.Variance, "sample1"] = d[Data.Value, "sample1"]
+
+        # Add event-mode beam-status monitor
+        status = Dataset()
+        status[Data.Tof] = ([Dim.Event], np.random.exponential(size=1000))
+        status[Data.PulseTime] = ([Dim.Event], np.random.exponential(size=1000))
+        d[Coord.Monitor, "beam-status"] = ([], status)
+
+        # Add position-resolved beam-profile monitor
+        profile = Dataset()
+        profile[Coord.X] = ([Dim.X], [-0.02, -0.01, 0.0, 0.01, 0.02])
+        profile[Coord.Y] = ([Dim.Y], [-0.02, -0.01, 0.0, 0.01, 0.02])
+        profile[Data.Value] = ([Dim.Y, Dim.X], (4,4))
+        d[Coord.Monitor, "beam-profile"] = ([], profile)
+
+        # Add histogram-mode transmission monitor
+        transmission = Dataset()
+        transmission[Coord.Energy] = ([Dim.Energy], np.arange(9))
+        transmission[Data.Value] = ([Dim.Energy], np.random.exponential(size=8))
+        d[Coord.Monitor, "transmission"] = ([], ())
+
     def test_zip(self):
         d = Dataset()
         d[Coord.SpectrumNumber] = ([Dim.Position], np.arange(1, 6))

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -515,7 +515,8 @@ class TestDatasetExamples(unittest.TestCase):
         profile[Coord.X] = ([Dim.X], [-0.02, -0.01, 0.0, 0.01, 0.02])
         profile[Coord.Y] = ([Dim.Y], [-0.02, -0.01, 0.0, 0.01, 0.02])
         profile[Data.Value] = ([Dim.Y, Dim.X], (4,4))
-        d[Coord.Monitor, "beam-profile"] = ([], profile)
+        # Monitors can also be attributes, so they are not required to match in operations
+        d[Attr.Monitor, "beam-profile"] = ([], profile)
 
         # Add histogram-mode transmission monitor
         transmission = Dataset()

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -117,6 +117,16 @@ class TestDataset(unittest.TestCase):
         d[Data.Events] = ([Dim.X], (1,))
         self.assertEqual(d[Data.Events].data[0], Dataset())
 
+    def test_nested_0D_empty_item(self):
+        d = Dataset()
+        d[Data.Events] = ([], Dataset())
+        self.assertEqual(d[Data.Events].data[0], Dataset())
+
+    def test_nested_0D_empty_size_tuple(self):
+        d = Dataset()
+        d[Data.Events] = ([], ())
+        self.assertEqual(d[Data.Events].data[0], Dataset())
+
     def test_set_data_nested(self):
         d = Dataset()
         table = Dataset()

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -79,7 +79,7 @@ class TestDataset(unittest.TestCase):
         np.testing.assert_array_equal(d[Data.Value, "data1"].numpy, self.reference_data1)
 
         # Currently implicitly replacing keys in Dataset is not supported. Should it?
-        self.assertRaisesRegex(RuntimeError, "Attempt to insert data with duplicate tag and name.",
+        self.assertRaisesRegex(RuntimeError, "Attempt to insert variable with duplicate tag and name.",
                 d.__setitem__, (Data.Value, "data1"), ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2)))
 
         self.assertRaisesRegex(RuntimeError, "Cannot insert variable into Dataset: Dimensions do not match.",

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -48,10 +48,13 @@ class TestVariable(unittest.TestCase):
         var = Variable(Coord.X, [Dim.X], (4,), dtype=np.dtype(np.int32))
         self.assertEqual(var.numpy.dtype, np.dtype(np.int32))
 
-    def test_coord_set_name_fails(self):
+    def test_coord_set_name(self):
         var = Variable(Coord.X, [Dim.X], np.arange(4))
-        with self.assertRaises(RuntimeError):
-            var.name = "data"
+        # We can set a name for coordinates, but not that operations will typically
+        # not look for a named coordinate. In particular it will not be considered
+        # a "dimension coordinate".
+        var.name = "x"
+        self.assertEqual(var.name, "x")
 
     def test_set_name(self):
         var = Variable(Data.Value, [Dim.X], np.arange(4))

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -61,14 +61,10 @@ VariableSlice Dataset::operator()(const Tag tag, const std::string &name) & {
 }
 
 void Dataset::insert(Variable variable) {
-  if (variable.isCoord() && count(*this, variable.tag()))
-    throw std::runtime_error("Attempt to insert duplicate coordinate.");
-  if (!variable.isCoord()) {
-    for (const auto &item : m_variables)
-      if (item.tag() == variable.tag() && item.name() == variable.name())
-        throw std::runtime_error(
-            "Attempt to insert data with duplicate tag and name.");
-  }
+  for (const auto &item : m_variables)
+    if (item.tag() == variable.tag() && item.name() == variable.name())
+      throw std::runtime_error(
+          "Attempt to insert variable with duplicate tag and name.");
   // TODO special handling for special variables types like
   // Data::Histogram (either prevent adding, or extract into underlying
   // variables).

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -116,7 +116,6 @@ public:
 
   template <class Tag, class... Args>
   void insert(const Tag tag, const Dimensions &dimensions, Args &&... args) {
-    static_assert(is_coord<Tag>, "Non-coordinate variable must have a name.");
     Variable a(tag, std::move(dimensions), std::forward<Args>(args)...);
     insert(std::move(a));
   }
@@ -124,7 +123,6 @@ public:
   template <class Tag, class... Args>
   void insert(const Tag tag, const std::string &name,
               const Dimensions &dimensions, Args &&... args) {
-    static_assert(!is_coord<Tag>, "Coordinate variable cannot have a name.");
     Variable a(tag, std::move(dimensions), std::forward<Args>(args)...);
     a.setName(name);
     insert(std::move(a));
@@ -133,7 +131,6 @@ public:
   template <class Tag, class T>
   void insert(const Tag tag, const Dimensions &dimensions,
               std::initializer_list<T> values) {
-    static_assert(is_coord<Tag>, "Non-coordinate variable must have a name.");
     Variable a(tag, std::move(dimensions), values);
     insert(std::move(a));
   }
@@ -141,7 +138,6 @@ public:
   template <class Tag, class T>
   void insert(const Tag tag, const std::string &name,
               const Dimensions &dimensions, std::initializer_list<T> values) {
-    static_assert(!is_coord<Tag>, "Coordinate variable cannot have a name.");
     Variable a(tag, std::move(dimensions), values);
     a.setName(name);
     insert(std::move(a));
@@ -150,7 +146,6 @@ public:
   // Insert variants with custom type
   template <class T, class Tag, class... Args>
   void insert(const Tag tag, const Dimensions &dimensions, Args &&... args) {
-    static_assert(is_coord<Tag>, "Non-coordinate variable must have a name.");
     auto a = makeVariable<T>(tag, std::move(dimensions),
                              std::forward<Args>(args)...);
     insert(std::move(a));
@@ -159,7 +154,6 @@ public:
   template <class T, class Tag, class... Args>
   void insert(const Tag tag, const std::string &name,
               const Dimensions &dimensions, Args &&... args) {
-    static_assert(!is_coord<Tag>, "Coordinate variable cannot have a name.");
     auto a = makeVariable<T>(tag, std::move(dimensions),
                              std::forward<Args>(args)...);
     a.setName(name);
@@ -169,7 +163,6 @@ public:
   template <class T, class Tag, class T2>
   void insert(const Tag tag, const Dimensions &dimensions,
               std::initializer_list<T2> values) {
-    static_assert(is_coord<Tag>, "Non-coordinate variable must have a name.");
     auto a = makeVariable<T>(tag, std::move(dimensions), values);
     insert(std::move(a));
   }
@@ -177,7 +170,6 @@ public:
   template <class T, class Tag, class T2>
   void insert(const Tag tag, const std::string &name,
               const Dimensions &dimensions, std::initializer_list<T2> values) {
-    static_assert(!is_coord<Tag>, "Coordinate variable cannot have a name.");
     auto a = makeVariable<T>(tag, std::move(dimensions), values);
     a.setName(name);
     insert(std::move(a));

--- a/src/tags.h
+++ b/src/tags.h
@@ -266,8 +266,12 @@ struct AttrDef {
     using type = Dataset;
     static constexpr auto unit = units::dimensionless;
   };
+  struct Monitor {
+    using type = Dataset;
+    static constexpr auto unit = units::dimensionless;
+  };
 
-  using tags = std::tuple<ExperimentLog>;
+  using tags = std::tuple<ExperimentLog, Monitor>;
 };
 
 using Tags = decltype(std::tuple_cat(std::declval<detail::CoordDef::tags>(),
@@ -368,8 +372,10 @@ struct Data {
 
 struct Attr {
   using ExperimentLog_t = detail::TagImpl<detail::AttrDef::ExperimentLog>;
+  using Monitor_t = detail::TagImpl<detail::AttrDef::Monitor>;
 
   static constexpr ExperimentLog_t ExperimentLog{};
+  static constexpr Monitor_t Monitor{};
 };
 
 template <class T>

--- a/src/variable.h
+++ b/src/variable.h
@@ -189,8 +189,6 @@ public:
   void setName(const std::string &name) {
     if (name.empty())
       m_name = nullptr;
-    else if (isCoord())
-      throw std::runtime_error("Coordinate variable cannot have a name.");
     else if (m_name)
       *m_name = name;
     else

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -20,7 +20,7 @@ TEST(Dataset, insert_coords) {
   d.insert(Coord::Tof, {}, {1.1});
   d.insert(Coord::SpectrumNumber, {}, {2});
   EXPECT_THROW_MSG(d.insert(Coord::SpectrumNumber, {}, {2}), std::runtime_error,
-                   "Attempt to insert duplicate coordinate.");
+                   "Attempt to insert variable with duplicate tag and name.");
   ASSERT_EQ(d.size(), 2);
 }
 
@@ -29,7 +29,7 @@ TEST(Dataset, insert_data) {
   d.insert(Data::Value, "name1", {}, {1.1});
   d.insert(Data::Value, "name2", {}, {2});
   EXPECT_THROW_MSG(d.insert(Data::Value, "name2", {}, {2}), std::runtime_error,
-                   "Attempt to insert data with duplicate tag and name.");
+                   "Attempt to insert variable with duplicate tag and name.");
   ASSERT_EQ(d.size(), 2);
 }
 
@@ -88,7 +88,7 @@ TEST(Dataset, insert_edges_first_fail) {
       d.insert(Data::Value, "name2", {Dim::Tof, 1}), std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
   EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 4}), std::runtime_error,
-                   "Attempt to insert duplicate coordinate.");
+                   "Attempt to insert variable with duplicate tag and name.");
 }
 
 TEST(Dataset, insert_edges_fail) {
@@ -189,7 +189,7 @@ TEST(Dataset, merge) {
   merged.merge(d);
   EXPECT_EQ(merged.size(), 3);
   EXPECT_THROW_MSG(merged.merge(d), std::runtime_error,
-                   "Attempt to insert data with duplicate tag and name.");
+                   "Attempt to insert variable with duplicate tag and name.");
 
   Dataset d2;
   d2.insert(Data::Value, "name3", {}, {1.1});


### PR DESCRIPTION
I think I would like to add monitor handling to the examples we will be preparing for the dev. meeting. Not sure how yet, either we can get monitors from Mantid if available and also convert them, or we just add some fake ones, for demo purposes.

Anyway, here is some prep work for this: Add Python example of adding monitors, and add an attribute tag for monitors as well. This also highlighted some overload resolution issue in Pybind11, which is also fixed here.

