### PR TITLE
Various issues and additions

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -635,6 +635,8 @@ PYBIND11_MODULE(dataset, m) {
       .def("__len__", &Dimensions::count)
       .def("__contains__", [](const Dimensions &self,
                               const Dim dim) { return self.contains(dim); })
+      .def("__getitem__",
+           py::overload_cast<const Dim>(&Dimensions::operator[], py::const_))
       .def_property_readonly("labels", &Dimensions::labels)
       .def_property_readonly("shape", &Dimensions::shape)
       .def("add", &Dimensions::add)
@@ -781,6 +783,9 @@ PYBIND11_MODULE(dataset, m) {
 
   py::class_<DatasetSlice>(m, "DatasetSlice")
       .def(py::init<Dataset &>())
+      .def_property_readonly(
+          "dimensions",
+          [](const DatasetSlice &self) { return self.dimensions(); })
       .def("__len__", &DatasetSlice::size)
       .def("__iter__",
            [](DatasetSlice &self) {
@@ -831,6 +836,8 @@ PYBIND11_MODULE(dataset, m) {
   py::class_<Dataset>(m, "Dataset")
       .def(py::init<>())
       .def(py::init<const DatasetSlice &>())
+      .def_property_readonly(
+          "dimensions", [](const Dataset &self) { return self.dimensions(); })
       .def("__len__", &Dataset::size)
       .def("__repr__",
            [](const Dataset &self) { return dataset::to_string(self, "."); })
@@ -967,7 +974,6 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self * py::self, py::call_guard<py::gil_scoped_release>())
       .def("merge", &Dataset::merge)
-      .def("dimensions", [](const Dataset &self) { return self.dimensions(); })
       // TODO For now this is just for testing. We need to decide on an API for
       // specifying the keys.
       .def("zip", [](Dataset &self) {

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -14,6 +14,7 @@
 
 #include "convert.h"
 #include "dataset.h"
+#include "events.h"
 #include "except.h"
 #include "tag_util.h"
 #include "tags.h"
@@ -1022,4 +1023,7 @@ PYBIND11_MODULE(dataset, m) {
 
   //-----------------------dimensions free functions----------------------------
   m.def("dimensionCoord", &dimensionCoord);
+
+  auto events = m.def_submodule("events");
+  events.def("sort_by_tof", &events::sortByTof);
 }

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -554,7 +554,7 @@ PYBIND11_MODULE(dataset, m) {
   coord_tags.attr("DetectorId") = Tag(Coord::DetectorId);
   coord_tags.attr("SpectrumNumber") = Tag(Coord::SpectrumNumber);
   coord_tags.attr("DetectorGrouping") = Tag(Coord::DetectorGrouping);
-  coord_tags.attr("RowLabel") = Tag(Coord::RowLabel);
+  coord_tags.attr("Row") = Tag(Coord::Row);
   coord_tags.attr("Polarization") = Tag(Coord::Polarization);
   coord_tags.attr("Temperature") = Tag(Coord::Temperature);
   coord_tags.attr("FuzzyTemperature") = Tag(Coord::FuzzyTemperature);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 set ( PY_FILES
   __init__.py
+  table.py
   xarray_compat.py
   dataset_plotting.py
   )

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,6 +1,7 @@
 from .dataset import *
 from .dataset_plotting import plot, plot_1d, plot_image, plot_sliceviewer
 from .xarray_compat import as_xarray
+from .table import table
 # Following fix for problem described here https://stackoverflow.com/questions/21784641/installation-issue-with-matplotlib-python
 import platform
 if platform.system() == 'Darwin':

--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -17,7 +17,7 @@ except ImportError:
 # Wrapper function to dispatch the input dataset to the appropriate plotting
 # function depending on its dimensions
 def plot(input_data):
-    ndim = len(input_data.dimensions())
+    ndim = len(input_data.dimensions)
     if ndim == 1:
         return plot_1d(input_data)
     elif ndim == 2:
@@ -130,7 +130,7 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, bars=False):
 # variable are returned.
 def plot_image(input_data, contours=False, plot=True):
 
-    ndim = len(input_data.dimensions())
+    ndim = len(input_data.dimensions)
     # TODO: this currently allows for plot_image to be called with a 3D dataset
     # and plot=False, which would lead to an error. We should think of a better
     # way to protect against this.
@@ -216,7 +216,7 @@ def plot_sliceviewer(input_data):
               "on this system")
         return
 
-    ndim = len(input_data.dimensions())
+    ndim = len(input_data.dimensions)
     if (ndim > 2) and (ndim < 5):
 
         # Use the machinery in plot_image to make the slices

--- a/python/examples/dataset_as_table.py
+++ b/python/examples/dataset_as_table.py
@@ -16,7 +16,7 @@ table = Dataset()
 
 #| 
 # Add columns
-table[Coord.RowLabel] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+table[Coord.Row] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
 table[Data.Value, "col1"] = ([Dim.Row], [3,2,1,0])
 table[Data.Value, "col2"] = ([Dim.Row], np.arange(4, dtype=np.float64))
 table[Data.Value, "sum"] = ([Dim.Row], (4,))
@@ -43,12 +43,12 @@ table = concatenate(table[Dim.Row, 0:2], table[Dim.Row, 5:7], Dim.Row)
 # Sort by column
 table = sort(table, Data.Value, "col1")
 # ... or another one
-table = sort(table, Coord.RowLabel)
+table = sort(table, Coord.Row)
 #-------------------------------------
 
 #|
 # Do something for each row (here: cumulative sum)
-for i in range(1, len(table[Coord.RowLabel])):
+for i in range(1, len(table[Coord.Row])):
     table[Dim.Row, i] += table[Dim.Row, i-1]
 
 # Apply numpy function to column, store result as a new column

--- a/python/table.py
+++ b/python/table.py
@@ -1,0 +1,51 @@
+def table(dataset):
+    if len(dataset.dimensions()) != 1:
+        raise RuntimeError("Only 1-D datasets can be rendered as a table")
+    s = str()
+    s += '<table>'
+    s += '<caption>Dataset:</caption>'
+
+    # Header line 1
+    names = { var.name for var in dataset if var.is_data }
+    s += '<tr>'
+    s += '<th colspan="1"></th>'
+    for name in names:
+        s += '<th colspan="2" style="text-align:center;">{}</th>'.format(name)
+    s += '</tr>'
+
+    # Header line 2
+    # TODO tags in correct order, first coords, then data
+    s += '<tr>'
+    coords = [ var for var in dataset if var.is_coord ]
+    for coord in coords:
+        s += '<th>{}</th>'.format(coord.tag)
+
+    datas = []
+    for name in names:
+        datas += [ var for var in dataset.subset[name] if var.is_data ]
+    for data in datas:
+        s += '<th>{}</th>'.format(data.tag)
+    s += '</tr>'
+
+    # Header line 3
+    s += '<tr>'
+    for coord in coords:
+        s += '<th>[{}]</th>'.format(coord.unit)
+    for data in datas:
+        s += '<th>[{}]</th>'.format(data.unit)
+    s += '</tr>'
+
+    # Data lines
+    for i in range(len(coords[0])):
+        s += '<tr>'
+        for coord in coords:
+            s += '<td>{}</td>'.format(coord.data[i])
+        for data in datas:
+            s += '<td>{}</td>'.format(data.data[i])
+        s += '</tr>'
+
+
+    s += '</table>'
+
+    from IPython.display import display, HTML
+    display(HTML(s))

--- a/python/table.py
+++ b/python/table.py
@@ -1,5 +1,5 @@
 def table(dataset):
-    if len(dataset.dimensions()) != 1:
+    if len(dataset.dimensions) != 1:
         raise RuntimeError("Only 1-D datasets can be rendered as a table")
     s = str()
     s += '<table>'

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -38,7 +38,7 @@ class TestDataset(unittest.TestCase):
         self.assertFalse((Data.Value, "data4") in self.dataset)
 
     def test_view_contains(self):
-        view = self.dataset.subset("data2")
+        view = self.dataset.subset["data2"]
         self.assertTrue(Coord.X in view)
         self.assertTrue(Coord.Y in view)
         self.assertTrue(Coord.Z in view)
@@ -171,7 +171,7 @@ class TestDataset(unittest.TestCase):
         np.testing.assert_array_equal(self.dataset[Data.Value, "data3"].numpy, self.reference_data3)
 
     def test_view_subdata(self):
-        view = self.dataset.subset("data1")
+        view = self.dataset.subset["data1"]
         # TODO Need consistent dimensions() implementation for Dataset and its views.
         #self.assertEqual(view.dimensions().size(Dim.X), 2)
         #self.assertEqual(view.dimensions().size(Dim.Y), 3)
@@ -249,7 +249,7 @@ class TestDataset(unittest.TestCase):
 
     def test_slice_numpy_interoperable(self):
         # Dataset subset then view single variable
-        self.dataset.subset('data2')[Data.Value, 'data2'] = np.exp(self.dataset[Data.Value, 'data1'])
+        self.dataset.subset['data2'][Data.Value, 'data2'] = np.exp(self.dataset[Data.Value, 'data1'])
         np.testing.assert_array_equal(self.dataset[Data.Value, "data2"].numpy, np.exp(self.reference_data1))
         # Slice view of dataset then view single variable
         self.dataset[Dim.X, 0][Data.Value, 'data2'] = np.exp(self.dataset[Dim.X, 1][Data.Value, 'data1'])
@@ -414,7 +414,7 @@ class TestDatasetExamples(unittest.TestCase):
         d[Coord.Z] = ([Dim.Z], np.arange(L))
         d[Data.Value, "temperature"] = ([Dim.Z, Dim.Y, Dim.X], np.random.normal(size=L*L*L).reshape([L,L,L]))
 
-        dataset = as_xarray(d.subset('temperature'))
+        dataset = as_xarray(d.subset['temperature'])
         dataset['Value:temperature'][10, ...].plot()
         #plt.savefig('test.png')
 

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -328,13 +328,13 @@ class TestDataset(unittest.TestCase):
 class TestDatasetExamples(unittest.TestCase):
     def test_table_example(self):
         table = Dataset()
-        table[Coord.RowLabel] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
-        self.assertSequenceEqual(table[Coord.RowLabel].data, ['a', 'bb', 'ccc', 'dddd'])
+        table[Coord.Row] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+        self.assertSequenceEqual(table[Coord.Row].data, ['a', 'bb', 'ccc', 'dddd'])
         table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
         table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
         self.assertEqual(len(table), 3)
 
-        table[Data.Value, "sum"] = ([Dim.Row], (len(table[Coord.RowLabel]),))
+        table[Data.Value, "sum"] = ([Dim.Row], (len(table[Coord.Row]),))
 
         for col in table:
             if not col.is_coord and col.name is not "sum":
@@ -351,10 +351,10 @@ class TestDatasetExamples(unittest.TestCase):
         table = sort(table, Data.Value, "col1")
         np.testing.assert_array_equal(table[Data.Value, "col1"].numpy, np.array([1,2,2,3]))
 
-        table = sort(table, Coord.RowLabel)
+        table = sort(table, Coord.Row)
         np.testing.assert_array_equal(table[Data.Value, "col1"].numpy, np.array([3,2,2,1]))
 
-        for i in range(1, len(table[Coord.RowLabel])):
+        for i in range(1, len(table[Coord.Row])):
             table[Dim.Row, i] += table[Dim.Row, i-1]
 
         np.testing.assert_array_equal(table[Data.Value, "col1"].numpy, np.array([3,5,7,8]))
@@ -364,13 +364,13 @@ class TestDatasetExamples(unittest.TestCase):
         np.testing.assert_array_equal(table[Data.Value, "exp1"].numpy, np.exp(np.array([3,5,7,8]))-np.array([3,5,7,8]))
 
         table += table
-        self.assertSequenceEqual(table[Coord.RowLabel].data, ['a', 'bb', 'bb', 'ccc'])
+        self.assertSequenceEqual(table[Coord.Row].data, ['a', 'bb', 'bb', 'ccc'])
 
     def test_table_example_no_assert(self):
         table = Dataset()
 
         # Add columns
-        table[Coord.RowLabel] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+        table[Coord.Row] = ([Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
         table[Data.Value, "col1"] = ([Dim.Row], [3.0,2.0,1.0,0.0])
         table[Data.Value, "col2"] = ([Dim.Row], np.arange(4.0))
         table[Data.Value, "sum"] = ([Dim.Row], (4,))
@@ -389,10 +389,10 @@ class TestDatasetExamples(unittest.TestCase):
         # Sort by column
         table = sort(table, Data.Value, "col1")
         # ... or another one
-        table = sort(table, Coord.RowLabel)
+        table = sort(table, Coord.Row)
 
         # Do something for each row (here: cumulative sum)
-        for i in range(1, len(table[Coord.RowLabel])):
+        for i in range(1, len(table[Coord.Row])):
             table[Dim.Row, i] += table[Dim.Row, i-1]
 
         # Apply numpy function to column, store result as a new column

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -52,19 +52,19 @@ class TestDataset(unittest.TestCase):
         dataset[Data.Value, "data"] = ([Dim.Z, Dim.Y, Dim.X], (1,2,3))
         dataset[Data.Value, "aux"] = ([], ())
         self.assertTrue((Data.Value, "data") in dataset)
-        self.assertEqual(len(dataset.dimensions()), 3)
+        self.assertEqual(len(dataset.dimensions), 3)
         del dataset[Data.Value, "data"]
         self.assertFalse((Data.Value, "data") in dataset)
-        self.assertEqual(len(dataset.dimensions()), 0)
+        self.assertEqual(len(dataset.dimensions), 0)
 
         dataset[Data.Value, "data"] = ([Dim.Z, Dim.Y, Dim.X], (1,2,3))
         dataset[Coord.X] = ([Dim.X], np.arange(3))
         del dataset[Data.Value, "data"]
         self.assertFalse((Data.Value, "data") in dataset)
-        self.assertEqual(len(dataset.dimensions()), 1)
+        self.assertEqual(len(dataset.dimensions), 1)
         del dataset[Coord.X]
         self.assertFalse(Coord.X in dataset)
-        self.assertEqual(len(dataset.dimensions()), 0)
+        self.assertEqual(len(dataset.dimensions), 0)
 
     def test_insert_default_init(self):
         d = Dataset()
@@ -151,9 +151,9 @@ class TestDataset(unittest.TestCase):
         self.assertNotEqual(d[Data.Value, "data1"].data[0], d[Data.Value, "data1"].data[1])
 
     def test_dimensions(self):
-        self.assertEqual(self.dataset.dimensions().size(Dim.X), 2)
-        self.assertEqual(self.dataset.dimensions().size(Dim.Y), 3)
-        self.assertEqual(self.dataset.dimensions().size(Dim.Z), 4)
+        self.assertEqual(self.dataset.dimensions[Dim.X], 2)
+        self.assertEqual(self.dataset.dimensions[Dim.Y], 3)
+        self.assertEqual(self.dataset.dimensions[Dim.Z], 4)
 
     def test_data(self):
         self.assertEqual(len(self.dataset[Coord.X].data), 2)
@@ -173,9 +173,9 @@ class TestDataset(unittest.TestCase):
     def test_view_subdata(self):
         view = self.dataset.subset["data1"]
         # TODO Need consistent dimensions() implementation for Dataset and its views.
-        #self.assertEqual(view.dimensions().size(Dim.X), 2)
-        #self.assertEqual(view.dimensions().size(Dim.Y), 3)
-        #self.assertEqual(view.dimensions().size(Dim.Z), 4)
+        self.assertEqual(view.dimensions[Dim.X], 2)
+        self.assertEqual(view.dimensions[Dim.Y], 3)
+        self.assertEqual(view.dimensions[Dim.Z], 4)
         self.assertEqual(len(view), 4)
 
     def test_slice_dataset(self):

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -13,7 +13,7 @@ class TestDatasetSlice(unittest.TestCase):
         self._d = d
     
     def test_type(self):
-        ds_slice = self._d.subset("a")
+        ds_slice = self._d.subset["a"]
         self.assertEqual(type(ds_slice), dataset.DatasetSlice)
 
     def test_extract_slice(self):
@@ -58,7 +58,7 @@ class TestDatasetSlice(unittest.TestCase):
         # Create slice
         ds_slice = self._d[Dim.X,subset]
         # Test via variable_slice
-        self.assertEquals(len(ds_slice[Coord.X]), len(range(subset.start, subset.stop, subset.step)))
+        self.assertEqual(len(ds_slice[Coord.X]), len(range(subset.start, subset.stop, subset.step)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -17,7 +17,7 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertEqual(type(ds_slice), dataset.DatasetSlice)
 
     def test_extract_slice(self):
-        ds_slice = self._d.subset("a")
+        ds_slice = self._d.subset["a"]
         self.assertEqual(type(ds_slice), dataset.DatasetSlice)
         # We should have just one data variable
         self.assertEqual(1, len([var for var in ds_slice if var.is_data]))

--- a/python/test/test_xarray_interop.py
+++ b/python/test/test_xarray_interop.py
@@ -37,7 +37,7 @@ class TestXarrayInterop(unittest.TestCase):
         table += table
         self.assertSequenceEqual(table[ds.Coord.RowLabel].data, ['a', 'bb', 'bb', 'ccc'])
 
-        dataset = ds.as_xarray(table.subset('col1'))
+        dataset = ds.as_xarray(table.subset['col1'])
         #print(dataset)
         dataset['Value:col1'].plot()
         #plt.savefig('test.png')

--- a/python/test/test_xarray_interop.py
+++ b/python/test/test_xarray_interop.py
@@ -7,8 +7,8 @@ import matplotlib.pyplot as plt
 class TestXarrayInterop(unittest.TestCase):
     def test_table(self):
         table = ds.Dataset()
-        table[ds.Coord.RowLabel] = ([ds.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
-        self.assertSequenceEqual(table[ds.Coord.RowLabel].data, ['a', 'bb', 'ccc', 'dddd'])
+        table[ds.Coord.Row] = ([ds.Dim.Row], ['a', 'bb', 'ccc', 'dddd'])
+        self.assertSequenceEqual(table[ds.Coord.Row].data, ['a', 'bb', 'ccc', 'dddd'])
         table[ds.Data.Value, "col1"] = ([ds.Dim.Row], [3.0,2.0,1.0,0.0])
         table[ds.Data.Value, "col2"] = ([ds.Dim.Row], np.arange(4))
         self.assertEqual(len(table), 3)
@@ -22,10 +22,10 @@ class TestXarrayInterop(unittest.TestCase):
         table = ds.sort(table, ds.Data.Value, "col1")
         np.testing.assert_array_equal(table[ds.Data.Value, "col1"].numpy, np.array([1,2,2,3]))
 
-        table = ds.sort(table, ds.Coord.RowLabel)
+        table = ds.sort(table, ds.Coord.Row)
         np.testing.assert_array_equal(table[ds.Data.Value, "col1"].numpy, np.array([3,2,2,1]))
 
-        for i in range(1, len(table[ds.Coord.RowLabel])):
+        for i in range(1, len(table[ds.Coord.Row])):
             table[ds.Dim.Row, i] += table[ds.Dim.Row, i-1]
 
         np.testing.assert_array_equal(table[ds.Data.Value, "col1"].numpy, np.array([3,5,7,8]))
@@ -35,7 +35,7 @@ class TestXarrayInterop(unittest.TestCase):
         np.testing.assert_array_equal(table[ds.Data.Value, "exp1"].numpy, np.exp(np.array([3,5,7,8]))-np.array([3,5,7,8]))
 
         table += table
-        self.assertSequenceEqual(table[ds.Coord.RowLabel].data, ['a', 'bb', 'bb', 'ccc'])
+        self.assertSequenceEqual(table[ds.Coord.Row].data, ['a', 'bb', 'bb', 'ccc'])
 
         dataset = ds.as_xarray(table.subset['col1'])
         #print(dataset)

--- a/python/test/test_xarray_interop.py
+++ b/python/test/test_xarray_interop.py
@@ -37,6 +37,8 @@ class TestXarrayInterop(unittest.TestCase):
         table += table
         self.assertSequenceEqual(table[ds.Coord.Row].data, ['a', 'bb', 'bb', 'ccc'])
 
+        # xarray cannot deal with non-numeric dimension coordinates
+        del(table[ds.Coord.Row])
         dataset = ds.as_xarray(table.subset['col1'])
         #print(dataset)
         dataset['Value:col1'].plot()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(INC_FILES
   dataset.h 
   dataset_index.h
   dimensions.h 
+  events.h
   except.h
   function_traits.h
   md_zip_view.h 
@@ -29,6 +30,7 @@ set(SRC_FILES
   counts.cpp
   dataset.cpp 
   dimensions.cpp
+  events.cpp
   except.cpp
   md_zip_view.cpp
   unit.cpp

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1,0 +1,31 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#include <algorithm>
+
+#include "dataset.h"
+#include "events.h"
+#include "except.h"
+
+namespace events {
+
+void sortByTof(Dataset &dataset) {
+  for (const auto &var : dataset) {
+    if (var.tag() == Data::Events) {
+      for (auto &el : var.get(Data::Events)) {
+        if (el.size() != 1)
+          throw std::runtime_error(
+              "Sorting for this event type is not implemented yet.");
+        const auto tofs = el.get(Data::Tof);
+        std::sort(tofs.begin(), tofs.end());
+      }
+    } else if (var.tag() == Data::EventTofs) {
+      throw std::runtime_error(
+          "Sorting for this event-storage mode is not implemented yet.");
+    }
+  }
+}
+
+} // namespace events

--- a/src/events.h
+++ b/src/events.h
@@ -1,0 +1,20 @@
+/// @file
+/// SPDX-License-Identifier: GPL-3.0-or-later
+/// @author Simon Heybrock
+/// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+/// National Laboratory, and European Spallation Source ERIC.
+#ifndef EVENTS_H
+#define EVENTS_H
+
+#include <initializer_list>
+#include <vector>
+
+#include "dimension.h"
+
+class Dataset;
+
+namespace events {
+void sortByTof(Dataset &dataset);
+} // namespace events
+
+#endif // EVENTS_H

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -94,8 +94,8 @@ std::string do_to_string(const Tag tag) {
     return "Coord::SpectrumNumber";
   case Coord::DetectorGrouping.value():
     return "Coord::DetectorGrouping";
-  case Coord::RowLabel.value():
-    return "Coord::RowLabel";
+  case Coord::Row.value():
+    return "Coord::Row";
   case Coord::Polarization.value():
     return "Coord::Polarization";
   case Coord::Temperature.value():

--- a/src/tags.h
+++ b/src/tags.h
@@ -174,7 +174,7 @@ struct CoordDef {
     using type = boost::container::small_vector<gsl::index, 1>;
     static constexpr auto unit = units::dimensionless;
   };
-  struct RowLabel {
+  struct Row {
     using type = std::string;
     static constexpr auto unit = units::dimensionless;
   };
@@ -211,7 +211,7 @@ struct CoordDef {
   using tags =
       std::tuple<Monitor, DetectorInfo, ComponentInfo, X, Y, Z, Qx, Qy, Qz, Tof,
                  Energy, DeltaE, Ei, Ef, DetectorId, SpectrumNumber,
-                 DetectorGrouping, RowLabel, Polarization, Temperature,
+                 DetectorGrouping, Row, Polarization, Temperature,
                  FuzzyTemperature, Time, TimeInterval, Mask, Position>;
 };
 
@@ -306,7 +306,7 @@ struct Coord {
   using SpectrumNumber_t = detail::TagImpl<detail::CoordDef::SpectrumNumber>;
   using DetectorGrouping_t =
       detail::TagImpl<detail::CoordDef::DetectorGrouping>;
-  using RowLabel_t = detail::TagImpl<detail::CoordDef::RowLabel>;
+  using Row_t = detail::TagImpl<detail::CoordDef::Row>;
   using Polarization_t = detail::TagImpl<detail::CoordDef::Polarization>;
   using Temperature_t = detail::TagImpl<detail::CoordDef::Temperature>;
   using FuzzyTemperature_t =
@@ -333,7 +333,7 @@ struct Coord {
   static constexpr DetectorId_t DetectorId{};
   static constexpr SpectrumNumber_t SpectrumNumber{};
   static constexpr DetectorGrouping_t DetectorGrouping{};
-  static constexpr RowLabel_t RowLabel{};
+  static constexpr Row_t Row{};
   static constexpr Polarization_t Polarization{};
   static constexpr Temperature_t Temperature{};
   static constexpr FuzzyTemperature_t FuzzyTemperature{};
@@ -405,7 +405,7 @@ template <> constexpr bool is_dimension_coordinate<CoordDef::Qz> = true;
 template <> constexpr bool is_dimension_coordinate<CoordDef::Position> = true;
 template <>
 constexpr bool is_dimension_coordinate<CoordDef::SpectrumNumber> = true;
-template <> constexpr bool is_dimension_coordinate<CoordDef::RowLabel> = true;
+template <> constexpr bool is_dimension_coordinate<CoordDef::Row> = true;
 
 template <class Tag> constexpr Dim coordinate_dimension = Dim::Invalid;
 template <> constexpr Dim coordinate_dimension<CoordDef::Tof> = Dim::Tof;
@@ -421,7 +421,7 @@ template <>
 constexpr Dim coordinate_dimension<CoordDef::Position> = Dim::Position;
 template <>
 constexpr Dim coordinate_dimension<CoordDef::SpectrumNumber> = Dim::Spectrum;
-template <> constexpr Dim coordinate_dimension<CoordDef::RowLabel> = Dim::Row;
+template <> constexpr Dim coordinate_dimension<CoordDef::Row> = Dim::Row;
 } // namespace detail
 
 template <class... Ts>
@@ -456,6 +456,10 @@ inline Tag dimensionCoord(const Dim dim) {
     return Coord::Energy;
   case Dim::DeltaE:
     return Coord::DeltaE;
+  case Dim::Row:
+    return Coord::Row;
+  case Dim::Position:
+    return Coord::Position;
   default:
     throw std::runtime_error(
         "Coordinate for this dimension is not implemented");

--- a/test/TableWorkspace_test.cpp
+++ b/test/TableWorkspace_test.cpp
@@ -24,7 +24,7 @@ std::vector<std::string> asStrings(const Variable &variable) {
 
 TEST(TableWorkspace, basics) {
   Dataset table;
-  table.insert(Coord::RowLabel, {Dim::Row, 3},
+  table.insert(Coord::Row, {Dim::Row, 3},
                Vector<std::string>{"a", "b", "c"});
   table.insert(Data::Value, "", {Dim::Row, 3}, {1.0, -2.0, 3.0});
   table.insert(Data::DeprecatedString, "", {Dim::Row, 3}, 3);
@@ -46,14 +46,14 @@ TEST(TableWorkspace, basics) {
   // Standard shape operations provide basic things required for tables:
   auto mergedTable = concatenate(table, table, Dim::Row);
   Dataset row = table(Dim::Row, 1, 2);
-  EXPECT_EQ(row.get(Coord::RowLabel)[0], "b");
+  EXPECT_EQ(row.get(Coord::Row)[0], "b");
 
   // Slice a range to obtain a new table with a subset of rows.
   Dataset rows = mergedTable(Dim::Row, 1, 4);
-  ASSERT_EQ(rows.get(Coord::RowLabel).size(), 3);
-  EXPECT_EQ(rows.get(Coord::RowLabel)[0], "b");
-  EXPECT_EQ(rows.get(Coord::RowLabel)[1], "c");
-  EXPECT_EQ(rows.get(Coord::RowLabel)[2], "a");
+  ASSERT_EQ(rows.get(Coord::Row).size(), 3);
+  EXPECT_EQ(rows.get(Coord::Row)[0], "b");
+  EXPECT_EQ(rows.get(Coord::Row)[1], "c");
+  EXPECT_EQ(rows.get(Coord::Row)[2], "a");
 
   // Can sort by arbitrary column.
   auto sortedTable = sort(table, Data::Value);


### PR DESCRIPTION
Various additions and issues found during writing examples:

- Free function for sorting events in a dataset.
- Operations with subsets now works (`dataset.subset['name'] += ...`). Note the change from `subset` to a property that was necessary to do this.
- Missing `__setitem__` for slices of datasets.
- Added helper to nicely format 1D datasets in Jupyter as a table.
  ```python
   import dataset as ds
   ds.table(mydataset)
   ```
- Add missing `py::keep_alive` to avoid segmentation faults when iterating "temporaries".