### PR TITLE
Subset fix

### DIFF
--- a/src/dataset.h
+++ b/src/dataset.h
@@ -308,23 +308,34 @@ protected:
   std::vector<gsl::index> makeIndices(const ConstDatasetSlice &base,
                                       const std::string &select) const {
     std::vector<gsl::index> indices;
+    bool foundData = false;
     for (const auto i : base.m_indices) {
       const auto &var = base.m_dataset[i];
       // TODO Should we also keep attributes? Probably yes?
-      if (var.isCoord() || var.name() == select)
+      if (var.isCoord() || var.name() == select) {
+        foundData |= var.isData();
         indices.push_back(i);
+      }
     }
+    if (!foundData)
+      throw dataset::except::VariableNotFoundError(base, select);
     return indices;
   }
   std::vector<gsl::index> makeIndices(const ConstDatasetSlice &base,
                                       const Tag selectTag,
                                       const std::string &selectName) const {
     std::vector<gsl::index> indices;
+    bool foundData = false;
     for (const auto i : base.m_indices) {
       const auto &var = base.m_dataset[i];
-      if (var.isCoord() || (var.tag() == selectTag && var.name() == selectName))
+      if (var.isCoord() ||
+          (var.tag() == selectTag && var.name() == selectName)) {
+        foundData |= var.isData();
         indices.push_back(i);
+      }
     }
+    if (!foundData)
+      throw dataset::except::VariableNotFoundError(base, selectTag, selectName);
     return indices;
   }
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -352,10 +352,14 @@ public:
   }
 
   ConstDatasetSlice subset(const std::string &name) const & {
-    return ConstDatasetSlice(m_dataset, makeIndices(*this, name));
+    ConstDatasetSlice ret(m_dataset, makeIndices(*this, name));
+    ret.m_slices = m_slices;
+    return ret;
   }
   ConstDatasetSlice subset(const Tag tag, const std::string &name) const & {
-    return ConstDatasetSlice(m_dataset, makeIndices(*this, tag, name));
+    ConstDatasetSlice ret(m_dataset, makeIndices(*this, tag, name));
+    ret.m_slices = m_slices;
+    return ret;
   }
 
   bool contains(const Tag tag, const std::string &name = "") const;
@@ -469,10 +473,14 @@ public:
   }
 
   DatasetSlice subset(const std::string &name) const & {
-    return DatasetSlice(m_mutableDataset, makeIndices(*this, name));
+    DatasetSlice ret(m_mutableDataset, makeIndices(*this, name));
+    ret.m_slices = m_slices;
+    return ret;
   }
   DatasetSlice subset(const Tag tag, const std::string &name) const & {
-    return DatasetSlice(m_mutableDataset, makeIndices(*this, tag, name));
+    DatasetSlice ret(m_mutableDataset, makeIndices(*this, tag, name));
+    ret.m_slices = m_slices;
+    return ret;
   }
 
   using ConstDatasetSlice::begin;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -360,8 +360,8 @@ public:
 
   bool contains(const Tag tag, const std::string &name = "") const;
 
-  std::map<Dim, gsl::index> dimensions() const {
-    std::map<Dim, gsl::index> dims;
+  Dimensions dimensions() const {
+    Dimensions dims;
     for (gsl::index i = 0; i < m_dataset.dimensions().count(); ++i) {
       const Dim dim = m_dataset.dimensions().label(i);
       gsl::index size = m_dataset.dimensions().size(i);
@@ -373,7 +373,7 @@ public:
             size = std::get<3>(slice) - std::get<2>(slice);
         }
       if (size != -1)
-        dims[dim] = size;
+        dims.add(dim, size);
     }
     return dims;
   }

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -273,11 +273,8 @@ std::string to_string(const Dataset &dataset, const std::string &separator) {
 
 std::string to_string(const ConstDatasetSlice &dataset,
                       const std::string &separator) {
-  // TODO Unify dimensions API for Dataset and ConstDatasetSlice.
-  Dimensions dims;
-  for (const auto[dim, size] : dataset.dimensions())
-    dims.add(dim, size);
-  return do_to_string(dataset, "<DatasetSlice>", dims, separator);
+  return do_to_string(dataset, "<DatasetSlice>", dataset.dimensions(),
+                      separator);
 }
 
 namespace except {

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -313,6 +313,14 @@ VariableNotFoundError::VariableNotFoundError(const ConstDatasetSlice &dataset,
                                              const std::string &name)
     : DatasetError(dataset, "could not find variable with tag " +
                                 to_string(tag) + " and name `" + name + "`.") {}
+VariableNotFoundError::VariableNotFoundError(const Dataset &dataset,
+                                             const std::string &name)
+    : DatasetError(dataset,
+                   "could not find any variable with name " + name + "`.") {}
+VariableNotFoundError::VariableNotFoundError(const ConstDatasetSlice &dataset,
+                                             const std::string &name)
+    : DatasetError(dataset,
+                   "could not find any variable with name " + name + "`.") {}
 
 VariableError::VariableError(const Variable &variable,
                              const std::string &message)

--- a/src/except.h
+++ b/src/except.h
@@ -71,6 +71,9 @@ struct VariableNotFoundError : public DatasetError {
                         const std::string &name);
   VariableNotFoundError(const ConstDatasetSlice &dataset, const Tag tag,
                         const std::string &name);
+  VariableNotFoundError(const Dataset &dataset, const std::string &name);
+  VariableNotFoundError(const ConstDatasetSlice &dataset,
+                        const std::string &name);
 };
 
 struct VariableError : public std::runtime_error {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -343,10 +343,6 @@ TEST(Dataset, subset) {
   d.insert(Data::Value, "b", {});
   d.insert(Data::Variance, "b", {});
 
-  const auto no_data = d.subset("");
-  EXPECT_EQ(no_data.size(), 1);
-  EXPECT_TRUE(no_data.contains(Coord::X));
-
   const auto value = d.subset(Data::Value, "a");
   EXPECT_EQ(value.size(), 2);
   EXPECT_TRUE(value.contains(Coord::X));
@@ -362,6 +358,24 @@ TEST(Dataset, subset) {
   EXPECT_TRUE(both.contains(Coord::X));
   EXPECT_TRUE(both.contains(Data::Value, "a"));
   EXPECT_TRUE(both.contains(Data::Variance, "a"));
+}
+
+TEST(Dataset, subset_no_data_fail) {
+  Dataset d;
+  d.insert(Coord::X, {});
+  d.insert(Data::Value, "a", {});
+  d.insert(Data::Variance, "a", {});
+  d.insert(Data::Value, "b", {});
+  d.insert(Data::Variance, "b", {});
+
+  // Note: This is required to fail, otherwise we silently do nothing if a
+  // subset is used in operations, e.g.,
+  // d.subset("a") += d.subset("c")
+  // TODO DatasetSlice itself *does* support subsets with empty data, we just
+  // need a clearly different way of creating them, i.e., not by accident. One
+  // example could be `dataset.coords()`, a subset that contains all
+  // coordinates.
+  EXPECT_THROW(d.subset(""), dataset::except::VariableNotFoundError);
 }
 
 TEST(Dataset, subset_of_subset) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -404,6 +404,28 @@ TEST(Dataset, subset_of_full_subset) {
   EXPECT_TRUE(both_from_subset.contains(Data::Variance, "a"));
 }
 
+template <class T> void do_subset_of_slice(T &d, bool useTag) {
+  const auto slice = d(Dim::X, 1, 2);
+  const auto subset =
+      useTag ? slice.subset(Data::Value, "a") : slice.subset("a");
+
+  EXPECT_EQ(subset(Coord::X).size(), 1);
+  EXPECT_EQ(subset(Coord::X).template span<double>()[0], 2);
+  EXPECT_EQ(subset.dimensions(), Dimensions({Dim::X, 1}));
+}
+
+TEST(Dataset, subset_of_slice) {
+  Dataset d;
+  d.insert(Coord::X, {Dim::X, 4}, {1, 2, 3, 4});
+  d.insert(Data::Value, "a", {});
+  d.insert(Data::Value, "b", {});
+
+  do_subset_of_slice<Dataset>(d, true);
+  do_subset_of_slice<Dataset>(d, false);
+  do_subset_of_slice<const Dataset>(d, true);
+  do_subset_of_slice<const Dataset>(d, false);
+}
+
 TEST(Dataset, comparison_with_spatial_slice) {
   Dataset d1;
   d1.insert(Data::Value, "a", {Dim::X, 2}, {2, 3});


### PR DESCRIPTION
- `(Dataset)Slice.subset()` was dropping existing spatial slicing. This is fixed here.
- Implicitly fixes #89, since the spatial slicing was lost, formatting the output data was causing the seemingly slow operation.
- Fixes #86.
- Made the return value of `dimensions()` consistent.

