### PR TITLE
Logscale colorbar and slider values

### DIFF
--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -245,7 +245,7 @@ def plot_image(input_data, axes=None, contours=False, plot=True, logcb=False, cb
 
         title = values[0].name
         if logcb:
-            title = "log(" + title + ")"
+            title = "log\u2081\u2080(" + title + ")"
             z = np.log10(z)
         if values[0].unit != units.dimensionless:
             title += " [{}]".format(values[0].unit)


### PR DESCRIPTION
- Added support for logarithmic colorscale: use `logcb=True`
- You can also change the colormap using `cb='Jet'`
- Finally, the labels of the sliders now represent the actual `z` values rather than the array indices

Try this code as an example:
```Python
d = ds.Dataset()
L = 30
d[ds.Coord.X] = ([ds.Dim.X], np.arange(L).astype(np.float64))
d[ds.Coord.Y] = ([ds.Dim.Y], np.arange(L).astype(np.float64))
d[ds.Coord.Z] = ([ds.Dim.Z], 177.0*np.arange(L).astype(np.float64))
d[ds.Coord.Ei] = ([ds.Dim.Q], 10.0*np.arange(L).astype(np.float64))
a = np.zeros([L,L,L], dtype=np.float64)
b = L/2.0
c = L/4.0
for i in range(L):
    for j in range(L):
        for k in range(L):
            a[i,j,k] = 1.0e3 * np.sin(np.sqrt(((i-b)/c)**2 + ((j-b)/c)**2 + ((k-b)/c)**2))
d[ds.Data.Value, "temperature"] = ([ds.Dim.Z, ds.Dim.Y, ds.Dim.X], a)
ds.plot_sliceviewer(d, logcb=True, axes=[ds.Coord.Y, ds.Coord.Ei], contours=True, cb='Jet')
```
