### PR TITLE
Change insertion behavior to match Python dict and C++ std::map.

### DIFF
--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -79,12 +79,15 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(len(d), 1)
         np.testing.assert_array_equal(d[Data.Value, "data1"].numpy, self.reference_data1)
 
-        # Currently implicitly replacing keys in Dataset is not supported. Should it?
-        self.assertRaisesRegex(RuntimeError, "Attempt to insert variable with duplicate tag and name.",
-                d.__setitem__, (Data.Value, "data1"), ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2)))
-
         self.assertRaisesRegex(RuntimeError, "Cannot insert variable into Dataset: Dimensions do not match.",
                 d.__setitem__, (Data.Value, "data2"), ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,2,3)))
+
+    def test_replace(self):
+        d = Dataset()
+        d[Data.Value, "data1"] = ([Dim.Z, Dim.Y, Dim.X], np.zeros(24).reshape(4,3,2))
+        d[Data.Value, "data1"] = ([Dim.Z, Dim.Y, Dim.X], np.arange(24).reshape(4,3,2))
+        self.assertEqual(len(d), 1)
+        np.testing.assert_array_equal(d[Data.Value, "data1"].numpy, self.reference_data1)
 
     def test_insert_variable(self):
         d = Dataset()

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -166,7 +166,7 @@ void Dataset::mergeDimensions(const Dimensions &dims, const Dim coordDim) {
           }
           throw std::runtime_error(
               "Cannot insert variable into Dataset: Variable is a dimension "
-              "coordiante, but the dimension length matches neither as default "
+              "coordinate, but the dimension length matches neither as default "
               "coordinate nor as edge coordinate.");
         } else {
           if (m_dimensions.size(j) == size + 1) {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -68,9 +68,12 @@ void Dataset::insert(Variable variable) {
     auto &old = m_variables[find(variable.tag(), variable.name())];
     for (const auto dim : old.dimensions().labels()) {
       bool found = false;
-      for (const auto &var : m_variables)
+      for (const auto &var : m_variables) {
+        if (var == old)
+          continue;
         if (var.dimensions().contains(dim))
           found = true;
+      }
       if (!found)
         m_dimensions.erase(dim);
     }

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -19,8 +19,8 @@ TEST(Dataset, insert_coords) {
   Dataset d;
   d.insert(Coord::Tof, {}, {1.1});
   d.insert(Coord::SpectrumNumber, {}, {2});
-  EXPECT_THROW_MSG(d.insert(Coord::SpectrumNumber, {}, {2}), std::runtime_error,
-                   "Attempt to insert variable with duplicate tag and name.");
+  ASSERT_EQ(d.size(), 2);
+  EXPECT_NO_THROW(d.insert(Coord::SpectrumNumber, {}, {3}));
   ASSERT_EQ(d.size(), 2);
 }
 
@@ -28,8 +28,8 @@ TEST(Dataset, insert_data) {
   Dataset d;
   d.insert(Data::Value, "name1", {}, {1.1});
   d.insert(Data::Value, "name2", {}, {2});
-  EXPECT_THROW_MSG(d.insert(Data::Value, "name2", {}, {2}), std::runtime_error,
-                   "Attempt to insert variable with duplicate tag and name.");
+  ASSERT_EQ(d.size(), 2);
+  EXPECT_NO_THROW(d.insert(Data::Value, "name2", {}, {3}));
   ASSERT_EQ(d.size(), 2);
 }
 
@@ -88,7 +88,9 @@ TEST(Dataset, insert_edges_first_fail) {
       d.insert(Data::Value, "name2", {Dim::Tof, 1}), std::runtime_error,
       "Cannot insert variable into Dataset: Dimensions do not match.");
   EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 4}), std::runtime_error,
-                   "Attempt to insert variable with duplicate tag and name.");
+                   "Cannot insert variable into Dataset: Variable is a "
+                   "dimension coordinate, but the dimension length matches "
+                   "neither as default coordinate nor as edge coordinate.");
 }
 
 TEST(Dataset, insert_edges_fail) {
@@ -188,8 +190,12 @@ TEST(Dataset, merge) {
   Dataset merged;
   merged.merge(d);
   EXPECT_EQ(merged.size(), 3);
-  EXPECT_THROW_MSG(merged.merge(d), std::runtime_error,
-                   "Attempt to insert variable with duplicate tag and name.");
+
+  Dataset copy(merged);
+
+ // We can merge twice, it is idempotent.
+  EXPECT_NO_THROW(merged.merge(d));
+  EXPECT_EQ(copy, merged);
 
   Dataset d2;
   d2.insert(Data::Value, "name3", {}, {1.1});
@@ -219,8 +225,9 @@ TEST(Dataset, merge_coord_mismatch_fail) {
   d2.insert(Coord::X, {Dim::X, 2}, {1.1, 2.3});
   d2.insert(Data::Value, "data2", {Dim::X, 2});
 
-  EXPECT_THROW_MSG(d1.merge(d2), std::runtime_error,
-                   "Cannot merge: Coordinates do not match.");
+  EXPECT_THROW_MSG(
+      d1.merge(d2), std::runtime_error,
+      "Cannot merge: Variable found in both operands, but does not match.");
 }
 
 TEST(Dataset, const_get) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -39,6 +39,14 @@ TEST(Dataset, insert_variables_with_dimensions) {
   d.insert(Data::Value, "name2", {}, {2});
 }
 
+TEST(Dataset, insert_updated_dimensions_correctly) {
+  Dataset d;
+  d.insert(Data::Value, "name1", {Dim::X, 1});
+  d.insert(Data::Value, "name1", {Dim::Y, 1});
+  ASSERT_EQ(d.size(), 1);
+  ASSERT_EQ(d.dimensions(), Dimensions({Dim::Y, 1}));
+}
+
 TEST(Dataset, insert_variables_different_order) {
   Dimensions xy;
   Dimensions xz;

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -99,11 +99,11 @@ TEST(Dataset, insert_edges_fail) {
   EXPECT_EQ(d.dimensions()[Dim::Tof], 2);
   EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 4}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
-                   "dimension coordiante, but the dimension length matches "
+                   "dimension coordinate, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
   EXPECT_THROW_MSG(d.insert(Coord::Tof, {Dim::Tof, 1}), std::runtime_error,
                    "Cannot insert variable into Dataset: Variable is a "
-                   "dimension coordiante, but the dimension length matches "
+                   "dimension coordinate, but the dimension length matches "
                    "neither as default coordinate nor as edge coordinate.");
 }
 


### PR DESCRIPTION
Access with existing name and tag will no longer fail:
```python
d[Data.Value, "alice"] = ([Dim.Row], [1.0,1.1,1.2])
d[Data.Value, "alice"] = ([Dim.Row], [1.0,1.1,1.3])
```
Previously the second line throw an exception. This was very inconvenient. The new behavior is in line with what you get from a Python `dict` or from `std::map`.