### PR TITLE
Add Python constructor for Variable that makes it usable as a quantity.

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -659,20 +659,21 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::init(&detail::makeVariableDefaultInit), py::arg("tag"),
            py::arg("labels"), py::arg("shape"),
            py::arg("dtype") = py::dtype::of<Empty>())
+      .def(py::init([](const double data, const Unit &unit) {
+             Variable var(Data::Value, {}, {data});
+             var.setUnit(unit);
+             return var;
+           }),
+           py::arg("data"), py::arg("unit") = Unit(units::dimensionless))
       // TODO Need to add overload for std::vector<std::string>, etc., see
       // Dataset.__setitem__
       .def(py::init(&detail::makeVariable), py::arg("tag"), py::arg("labels"),
            py::arg("data"), py::arg("dtype") = py::dtype::of<Empty>())
       .def(py::init<const VariableSlice &>())
       .def("__getitem__", detail::pySlice<Variable>)
-      .def("__copy__",
-           [](Variable &self) {
-             return Variable(self);
-           })
+      .def("__copy__", [](Variable &self) { return Variable(self); })
       .def("__deepcopy__",
-           [](Variable &self, py::dict) {
-             return Variable(self);
-           })
+           [](Variable &self, py::dict) { return Variable(self); })
       .def_property_readonly("tag", &Variable::tag)
       .def_property("name", [](const Variable &self) { return self.name(); },
                     &Variable::setName)
@@ -689,8 +690,9 @@ PYBIND11_MODULE(dataset, m) {
       .def_property("scalar", &as_VariableView::scalar<Variable>,
                     &as_VariableView::set_scalar<Variable>,
                     "The only data point for a 0-dimensional "
-                    "variable. Raises an exception of the variable is "
+                    "variable. Raises an exception if the variable is "
                     "not 0-dimensional.")
+      .def(py::self == py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self + float(), py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
@@ -744,14 +746,9 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("__setitem__", &detail::setVariableSlice)
       .def("__setitem__", &detail::setVariableSliceRange)
-      .def("__copy__",
-           [](VariableSlice &self) {
-             return Variable(self);
-           })
+      .def("__copy__", [](VariableSlice &self) { return Variable(self); })
       .def("__deepcopy__",
-           [](VariableSlice &self, py::dict) {
-             return Variable(self);
-           })
+           [](VariableSlice &self, py::dict) { return Variable(self); })
       .def_property_readonly(
           "numpy", &as_py_array_t_variant<VariableSlice, double, float, int64_t,
                                           int32_t, char, bool>)
@@ -835,14 +832,9 @@ PYBIND11_MODULE(dataset, m) {
           [](DatasetSlice &self, const std::pair<Tag, const std::string> &key) {
             return self(key.first, key.second);
           })
-      .def("__copy__",
-           [](DatasetSlice &self) {
-             return Dataset(self);
-           })
+      .def("__copy__", [](DatasetSlice &self) { return Dataset(self); })
       .def("__deepcopy__",
-           [](DatasetSlice &self, py::dict) {
-             return Dataset(self);
-           })
+           [](DatasetSlice &self, py::dict) { return Dataset(self); })
       .def_property_readonly(
           "subset", [](DatasetSlice &self) { return SubsetHelper(self); })
       .def("__setitem__",
@@ -911,14 +903,9 @@ PYBIND11_MODULE(dataset, m) {
            [](Dataset &self, const std::pair<Tag, const std::string> &key) {
              return self(key.first, key.second);
            })
-      .def("__copy__",
-           [](Dataset &self) {
-             return Dataset(self);
-           })
+      .def("__copy__", [](Dataset &self) { return Dataset(self); })
       .def("__deepcopy__",
-           [](Dataset &self, py::dict) {
-             return Dataset(self);
-           })
+           [](Dataset &self, py::dict) { return Dataset(self); })
       .def_property_readonly("subset",
                              [](Dataset &self) { return SubsetHelper(self); })
       // Careful: The order of overloads is really important here, otherwise

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -32,6 +32,30 @@ class TestVariable(unittest.TestCase):
         var = Variable(Coord.X, [Dim.X], (4,))
         self.assertEqual(var.name, "")
 
+    def test_create_scalar(self):
+        var = Variable(1.2)
+        self.assertEqual(var.scalar, 1.2)
+        self.assertEqual(var.name, '')
+        self.assertEqual(var.dimensions, Dimensions())
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
+        self.assertEqual(var.unit, units.dimensionless)
+
+    def test_create_scalar_quantity(self):
+        var = Variable(1.2, unit=units.m)
+        self.assertEqual(var.scalar, 1.2)
+        self.assertEqual(var.name, '')
+        self.assertEqual(var.dimensions, Dimensions())
+        self.assertEqual(var.numpy.dtype, np.dtype(np.float64))
+        self.assertEqual(var.unit, units.m)
+
+    def test_operation_with_scalar_quantity(self):
+        reference = Variable(Data.Value, [Dim.X], np.arange(4.0) * 1.5)
+        reference.unit = units.kg
+
+        var = Variable(Data.Value, [Dim.X], np.arange(4.0))
+        var *= Variable(1.5, unit=units.kg)
+        self.assertEqual(var, reference)
+
     def test_0D_scalar_access(self):
         var = Variable(Coord.X, [], ())
         self.assertEqual(var.scalar, 0.0)


### PR DESCRIPTION
Fixes #87. Instead of doing a separate quantity implementation, we simply use a 0-D variable. This can then support operations of scalars with dimensionful variables that are part of a dataset.

See the unit test for an example.