### PR TITLE
Fix *= operator to match rules for other binary operators

### DIFF
--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -273,12 +273,7 @@ class TestDataset(unittest.TestCase):
 
         self._apply_test_op(operator.iadd, a, b, data)
         self._apply_test_op(operator.isub, a, b, data)
-        # TODO problem described above need inplace operators
-        # Only demonstrate behaviour where variable names are sames across operands
-        b = Dataset()
-        b[Data.Value, "i"] = ([Dim.X], np.arange(10, dtype='float64'))
-        
-        self._apply_test_op(operator.imul, a, b, data, lh_var_name="i", rh_var_name="i")
+        self._apply_test_op(operator.imul, a, b, data)
 
 
     def test_plus_equals_slice(self):

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -80,10 +80,7 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data + data))
         c = a - b
         # Variables "a" and "b" added despite different names
-        self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data + data))
-
-
-        #TODO. resolve issues with times_equals and binary_op_equals preventing implementation of * and / variants
+        self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data - data))
 
         c = a + 2.0
         self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data + 2.0))
@@ -99,8 +96,7 @@ class TestDatasetSlice(unittest.TestCase):
         self._apply_test_op(operator.iadd, a, b, data)
         self._apply_test_op(operator.isub, a, b, data)
         # problem described above need inplace operators
-        #self._apply_test_op(operator.imul, a, b, data)
-        #self._apply_test_op(operator.itruediv, a, b, data)
+        self._apply_test_op(operator.imul, a, b, data)
         
 
 if __name__ == '__main__':

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -360,7 +360,7 @@ void multiply_slices(DatasetSlice &lhs_slice,
   if (rhs_var.tag() == Data::Variance) {
     if (!lhs_slice.contains(Data::Value, lhs_var.name()) ||
         !rhs_slice.contains(Data::Value, rhs_var.name())) {
-      throw std::runtime_error("Cannot multiply datasets that contain a "
+      throw std::runtime_error("Cannot operate on datasets that contain a "
                                "variance but no corresponding value.");
     }
   }
@@ -413,9 +413,9 @@ void multiply_slices(DatasetSlice &lhs_slice,
 } // namespace
 template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
   std::set<std::string> lhs_names;
-  for (const auto &lhs_var : other)
-    if (lhs_var.isData())
-      lhs_names.insert(lhs_var.name());
+  for (const auto &rhs_var : other)
+    if (rhs_var.isData())
+      lhs_names.insert(rhs_var.name());
 
   // See operator+= for additional comments.
   for (const auto &rhs_var : other) {
@@ -438,7 +438,7 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
       if (rhs_var.isData() && lhs_names.size() == 1) {
         // Only a single (named) variable in RHS, operate on all.
         // Not a coordinate, apply from all.
-        // op([a, b], [a]) = [op(a, a), op(b, a)] is legal
+        // op([a, b], [c]) = [op(a, c), op(b, c)] is legal
         auto rhs_slice = other.subset(rhs_var.name());
 
         gsl::index count = 0;

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -340,6 +340,7 @@ void multiply_slices(DatasetSlice &slice1, const ConstDatasetSlice &slice2,
                                "variance but no corresponding value.");
     }
   }
+  // Data variables are added
   if (var2.tag() == Data::Value) {
     if (dataset.contains(Data::Variance, var2.name())) {
       auto error1 = slice1(Data::Variance, var1.name());
@@ -347,16 +348,15 @@ void multiply_slices(DatasetSlice &slice1, const ConstDatasetSlice &slice2,
       if ((var1.dimensions() == var2.dimensions()) &&
           (var1.dimensions() == error1.dimensions()) &&
           (var1.dimensions() == error2.dimensions())) {
-        // Optimization if all dimensions match, avoiding allocation
-        // of temporaries and redundant streaming from memory of large
-        // array.
+        // Optimization if all dimensions match, avoiding allocation of
+        // temporaries and redundant streaming from memory of large array.
         error1.setUnit(var2.unit() * var2.unit() * error1.unit() +
                        var1.unit() * var1.unit() * error2.unit());
         var1.setUnit(var1.unit() * var2.unit());
 
-        // TODO We are working with VariableSlice here, so get<>
-        // returns a view, not a span, i.e., it is less efficient. May
-        // need to do this differently for optimal performance.
+        // TODO We are working with VariableSlice here, so get<> returns a
+        // view, not a span, i.e., it is less efficient. May need to do
+        // this differently for optimal performance.
         auto v1 = var1.template span<double>();
         const auto v2 = var2.template span<double>();
         auto e1 = error1.template span<double>();
@@ -365,19 +365,24 @@ void multiply_slices(DatasetSlice &slice1, const ConstDatasetSlice &slice2,
         aligned::multiply(v1.size(), v1.data(), e1.data(), v2.data(),
                           e2.data());
       } else {
-        // TODO Do we need to write this differently if the two
-        // operands are the same? For example, error1 = error1 * (var2
-        // * var2) + var1 * var1 * error2;
+        // TODO Do we need to write this differently if the two operands
+        // are the same? For example, error1 = error1 * (var2 * var2) +
+        // var1 * var1 * error2;
         error1 *= (var2 * var2);
         error1 += var1 * var1 * error2;
-        // TODO: Catch errors from unit propagation here and give a
-        // better error message.
+        // TODO: Catch errors from unit propagation here and give a better
+        // error message.
         var1 *= var2;
       }
     } else {
       // No variance found, continue without.
       var1 *= var2;
     }
+  } else if (var2.tag() == Data::Variance) {
+    // Do nothing, math for variance is done when processing corresponding
+    // value.
+  } else {
+    var1 *= var2;
   }
 }
 
@@ -397,62 +402,7 @@ template <class T1, class T2> T1 &times_equals(T1 &dataset, const T2 &other) {
       } else if (var1.isData()) {
         auto slice1 = dataset.subset(var1.name());
         auto slice2 = other.subset(var2.name());
-        if (slice1.contains(Data::Variance, var1.name()) !=
-            slice2.contains(Data::Variance, var2.name())) {
-          throw std::runtime_error("Either both or none of the operands must "
-                                   "have a variance for their values.");
-        }
-        if (var2.tag() == Data::Variance) {
-          if (!slice1.contains(Data::Value, var1.name()) ||
-              !slice2.contains(Data::Value, var2.name())) {
-            throw std::runtime_error("Cannot multiply datasets that contain a "
-                                     "variance but no corresponding value.");
-          }
-        }
-        // Data variables are added
-        if (var2.tag() == Data::Value) {
-          if (dataset.contains(Data::Variance, var2.name())) {
-            auto error1 = slice1(Data::Variance, var1.name());
-            const auto &error2 = slice2(Data::Variance, var2.name());
-            if ((var1.dimensions() == var2.dimensions()) &&
-                (var1.dimensions() == error1.dimensions()) &&
-                (var1.dimensions() == error2.dimensions())) {
-              // Optimization if all dimensions match, avoiding allocation of
-              // temporaries and redundant streaming from memory of large array.
-              error1.setUnit(var2.unit() * var2.unit() * error1.unit() +
-                             var1.unit() * var1.unit() * error2.unit());
-              var1.setUnit(var1.unit() * var2.unit());
-
-              // TODO We are working with VariableSlice here, so get<> returns a
-              // view, not a span, i.e., it is less efficient. May need to do
-              // this differently for optimal performance.
-              auto v1 = var1.template span<double>();
-              const auto v2 = var2.template span<double>();
-              auto e1 = error1.template span<double>();
-              const auto e2 = error2.template span<double>();
-              // TODO Need to ensure that data is contiguous!
-              aligned::multiply(v1.size(), v1.data(), e1.data(), v2.data(),
-                                e2.data());
-            } else {
-              // TODO Do we need to write this differently if the two operands
-              // are the same? For example, error1 = error1 * (var2 * var2) +
-              // var1 * var1 * error2;
-              error1 *= (var2 * var2);
-              error1 += var1 * var1 * error2;
-              // TODO: Catch errors from unit propagation here and give a better
-              // error message.
-              var1 *= var2;
-            }
-          } else {
-            // No variance found, continue without.
-            var1 *= var2;
-          }
-        } else if (var2.tag() == Data::Variance) {
-          // Do nothing, math for variance is done when processing corresponding
-          // value.
-        } else {
-          var1 *= var2;
-        }
+        multiply_slices(slice1, slice2, var1, var2, dataset);
       }
     } else {
       // Note that this is handled via name, i.e., there may be values and

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -201,7 +201,7 @@ TEST(Dataset, merge) {
 
   Dataset copy(merged);
 
- // We can merge twice, it is idempotent.
+  // We can merge twice, it is idempotent.
   EXPECT_NO_THROW(merged.merge(d));
   EXPECT_EQ(copy, merged);
 
@@ -626,10 +626,10 @@ TEST(Dataset, operator_times_equal_uncertainty_failures) {
                    "Either both or none of the operands must have a variance "
                    "for their values.");
   EXPECT_THROW_MSG(c *= c, std::runtime_error,
-                   "Cannot multiply datasets that contain a variance but no "
+                   "Cannot operate on datasets that contain a variance but no "
                    "corresponding value.");
   EXPECT_THROW_MSG(a *= c, std::runtime_error,
-                   "Cannot multiply datasets that contain a variance but no "
+                   "Cannot operate on datasets that contain a variance but no "
                    "corresponding value.");
 }
 
@@ -1437,10 +1437,6 @@ TEST(Dataset, binary_operations_with_identical_lhs_rhs_operand_structures) {
 }
 
 TEST(Dataset, binary_operations_with_non_identical_lhs_rhs_operand_structures) {
-
-  // Test Rule op([a, b], [a]) -> [op(a,a), b]
-  // Test Rule op([a], [b]) -> [op(a,a)]
-
   auto plus = [](auto i, auto j) { return i + j; };
   auto minus = [](auto i, auto j) { return i - j; };
   auto mult = [](auto i, auto j) { return i * j; };
@@ -1453,14 +1449,10 @@ TEST(Dataset, binary_operations_with_non_identical_lhs_rhs_operand_structures) {
 
   auto c = a + b;
   binary_test<double>(plus, input, c, "u");
-  // swap operands - demonstrates non-commutitive behaviour. Though binary
-  // operation is itself commutative. TODO. Fix
   c = b + a;
   binary_test<double>(plus, input, c, "v"); // output contains 'v' no 'u'
-
   c = a - b;
   binary_test<double>(minus, input, c, "u");
-
   c = a * b;
   binary_test<double>(mult, input, c, "u");
 }

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -580,15 +580,6 @@ TEST(Dataset, operator_times_equal_uncertainty_failures) {
   EXPECT_THROW_MSG(a *= c, std::runtime_error,
                    "Cannot multiply datasets that contain a variance but no "
                    "corresponding value.");
-  EXPECT_THROW_MSG(c *= a, std::runtime_error,
-                   "Right-hand-side in addition contains variable that is not "
-                   "present in left-hand-side.");
-  EXPECT_THROW_MSG(b *= c, std::runtime_error,
-                   "Right-hand-side in addition contains variable that is not "
-                   "present in left-hand-side.");
-  EXPECT_THROW_MSG(c *= b, std::runtime_error,
-                   "Right-hand-side in addition contains variable that is not "
-                   "present in left-hand-side.");
 }
 
 TEST(Dataset, operator_times_equal_with_units) {


### PR DESCRIPTION
Specifically fix `op([a, b], [a]) = [op(a, a), op(b, a)]`, which was already supported for `+=` and `-=` operations via `binary_op_equals`, note that these changes also bring `times_op_equals` and `binary_op_equals` closer together in terms of implementation. This will help future refactoring towards a unified solution.