### PR TITLE
Insert From `DatasetSlice` and `Dataset`

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -858,15 +858,7 @@ PYBIND11_MODULE(dataset, m) {
            [](SubsetHelper &self, const std::string &name,
               const DatasetSlice &data) { self.insert(name, data); })
       .def("__setitem__", [](SubsetHelper &self, const std::string &name,
-                             const Dataset &data) { self.insert(name, data); })
-      .def("__setitem__",
-           [](SubsetHelper &self,
-              const std::tuple<const Tag, const std::string &> &index,
-              const DatasetSlice &data) {
-             const auto & [ tag, name ] = index;
-             self.subset(tag, name).assign(data);
-           });
-
+                             const Dataset &data) { self.insert(name, data); });
   py::class_<DatasetSlice>(m, "DatasetSlice")
       .def(py::init<Dataset &>())
       .def_property_readonly(

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -499,6 +499,9 @@ public:
   auto subset(const Tag tag, const std::string &name) const {
     return m_data.subset(tag, name);
   }
+  template <class D> void insert(const std::string &name, D &subset) {
+    m_data.insert(name, subset);
+  }
 
 private:
   DatasetSlice m_data;
@@ -853,7 +856,9 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("__setitem__",
            [](SubsetHelper &self, const std::string &name,
-              const DatasetSlice &data) { self.subset(name).assign(data); })
+              const DatasetSlice &data) { self.insert(name, data); })
+      .def("__setitem__", [](SubsetHelper &self, const std::string &name,
+                             const Dataset &data) { self.insert(name, data); })
       .def("__setitem__",
            [](SubsetHelper &self,
               const std::tuple<const Tag, const std::string &> &index,
@@ -1040,10 +1045,6 @@ PYBIND11_MODULE(dataset, m) {
       // DatasetSlice matches the overload below for py::array_t. I have not
       // understood all details of this yet though. See also
       // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order.
-      .def("__setitem__", [](Dataset &self, const std::string &name,
-                             DatasetSlice &slice) { self.insert(name, slice); })
-      .def("__setitem__", [](Dataset &self, const std::string &name,
-                             Dataset &slice) { self.insert(name, slice); })
       .def("__setitem__",
            [](Dataset &self, const std::tuple<Dim, py::slice> &index,
               const DatasetSlice &other) {

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -1040,6 +1040,10 @@ PYBIND11_MODULE(dataset, m) {
       // DatasetSlice matches the overload below for py::array_t. I have not
       // understood all details of this yet though. See also
       // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order.
+      .def("__setitem__", [](Dataset &self, const std::string &name,
+                             DatasetSlice &slice) { self.insert(name, slice); })
+      .def("__setitem__", [](Dataset &self, const std::string &name,
+                             Dataset &slice) { self.insert(name, slice); })
       .def("__setitem__",
            [](Dataset &self, const std::tuple<Dim, py::slice> &index,
               const DatasetSlice &other) {

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -190,25 +190,21 @@ class TestDataset(unittest.TestCase):
 
         d2 = Dataset()
         # Insert from subset
-        d2["a"] = ds_slice 
+        d2.subset["a"] = ds_slice 
         self.assertEqual(len(d1), len(d2))
         self.assertEqual(d1, d2)
 
         d3 = Dataset()
         # Insert from subset
-        d3["b"] = ds_slice
+        d3.subset["b"] = ds_slice
         self.assertEqual(len(d3), 2)
         self.assertNotEqual(d1, d3) # imported names should differ
 
         d4 = Dataset()
-        d4["2a"] = ds_slice + ds_slice
+        d4.subset["2a"] = ds_slice + ds_slice
         self.assertEqual(len(d4), 2)
         self.assertNotEqual(d1, d4) 
         self.assertTrue(np.array_equal(d4[Data.Value, "2a"].numpy, ds_slice[Data.Value,"a"].numpy*2))
-
-
-
-
 
     def test_slice_dataset(self):
         for x in range(2):

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -206,6 +206,21 @@ class TestDataset(unittest.TestCase):
         self.assertNotEqual(d1, d4) 
         self.assertTrue(np.array_equal(d4[Data.Value, "2a"].numpy, ds_slice[Data.Value,"a"].numpy*2))
 
+    def test_insert_subdata_different_variable_types(self):
+        a = Dataset()
+        xcoord = Variable(Coord.X, [Dim.X], np.arange(4))
+        a[Data.Value] = ([Dim.X], np.arange(3))
+        a[Coord.X] = xcoord 
+        a[Attr.ExperimentLog] = ([], Dataset())
+
+        b = Dataset()
+        with self.assertRaises(RuntimeError ):
+            b.subset["b"] = a[Dim.X, :] # Coordinates dont match
+        b[Coord.X] = xcoord
+        b.subset["b"] = a[Dim.X, :] # Should now work 
+        self.assertEqual(len(a), len(b))
+        self.assertTrue((Attr.ExperimentLog, "b") in b)
+
     def test_slice_dataset(self):
         for x in range(2):
             view = self.dataset[Dim.X, x]

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -182,6 +182,34 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(view.dimensions[Dim.Z], 4)
         self.assertEqual(len(view), 4)
 
+    def test_insert_subdata(self):
+        d1 = Dataset()
+        d1[Data.Value, "a"] = ([Dim.X], np.arange(10, dtype="double"))
+        d1[Data.Variance, "a"] = ([Dim.X], np.arange(10, dtype="double"))
+        ds_slice = d1.subset["a"]
+
+        d2 = Dataset()
+        # Insert from subset
+        d2["a"] = ds_slice 
+        self.assertEqual(len(d1), len(d2))
+        self.assertEqual(d1, d2)
+
+        d3 = Dataset()
+        # Insert from subset
+        d3["b"] = ds_slice
+        self.assertEqual(len(d3), 2)
+        self.assertNotEqual(d1, d3) # imported names should differ
+
+        d4 = Dataset()
+        d4["2a"] = ds_slice + ds_slice
+        self.assertEqual(len(d4), 2)
+        self.assertNotEqual(d1, d4) 
+        self.assertTrue(np.array_equal(d4[Data.Value, "2a"].numpy, ds_slice[Data.Value,"a"].numpy*2))
+
+
+
+
+
     def test_slice_dataset(self):
         for x in range(2):
             view = self.dataset[Dim.X, x]

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -87,22 +87,6 @@ void Dataset::insert(Variable variable) {
   }
 }
 
-void Dataset::insert(const ConstDatasetSlice &slice) {
-  // TODO. better transactional behaviour. Either want to insert the whole slice
-  // or not at all. i.e. mergeDimensions can throw.
-  for (const auto &var : slice) {
-    this->insert(var);
-  }
-}
-
-void Dataset::insert(const std::string &name, const ConstDatasetSlice &slice) {
-  for (const auto &var : slice) {
-    Variable newVar(var);
-    newVar.setName(name);
-    this->insert(newVar);
-  }
-}
-
 // T can be Dataset or Slice.
 template <class T>
 bool contains(const T &dataset, const Tag tag, const std::string &name) {

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -87,6 +87,22 @@ void Dataset::insert(Variable variable) {
   }
 }
 
+void Dataset::insert(const ConstDatasetSlice &slice) {
+  // TODO. better transactional behaviour. Either want to insert the whole slice
+  // or not at all. i.e. mergeDimensions can throw.
+  for (const auto &var : slice) {
+    this->insert(var);
+  }
+}
+
+void Dataset::insert(const std::string &name, const ConstDatasetSlice &slice) {
+  for (const auto &var : slice) {
+    Variable newVar(var);
+    newVar.setName(name);
+    this->insert(newVar);
+  }
+}
+
 // T can be Dataset or Slice.
 template <class T>
 bool contains(const T &dataset, const Tag tag, const std::string &name) {

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -107,8 +107,14 @@ public:
     // Note the lack of atomicity
     for (const auto &var : slice) {
       Variable newVar(var);
-      if (!var.isCoord())
-        newVar.setName(name);
+      if (var.isCoord()) {
+        if (!contains(newVar.tag(), newVar.name())) {
+          throw std::runtime_error(
+              "Cannot provide new coordinate variables via subset");
+        }
+      } else {
+        newVar.setName(name); // As long as !cood var, name gets rewritten.
+      }
       this->insert(newVar);
     }
   }

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -103,7 +103,13 @@ public:
   }
 
   void insert(Variable variable);
-  void insert(const ConstDatasetSlice &slice);
+  template <class T> void insert(const std::string &name, const T &slice) {
+    for (const auto &var : slice) {
+      Variable newVar(var);
+      newVar.setName(name);
+      this->insert(newVar);
+    }
+  }
   void insert(const std::string &name, const ConstDatasetSlice &slice);
   void insert(const Tag tag, Variable variable) {
     variable.setTag(tag);

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -508,6 +508,9 @@ public:
     ret.m_slices = m_slices;
     return ret;
   }
+  template <class T> void insert(const std::string &name, const T &slice) {
+    m_mutableDataset.insert(name, slice);
+  }
 
   using ConstDatasetSlice::begin;
   using ConstDatasetSlice::end;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -110,7 +110,6 @@ public:
       this->insert(newVar);
     }
   }
-  void insert(const std::string &name, const ConstDatasetSlice &slice);
   void insert(const Tag tag, Variable variable) {
     variable.setTag(tag);
     variable.setName("");

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -104,9 +104,11 @@ public:
 
   void insert(Variable variable);
   template <class T> void insert(const std::string &name, const T &slice) {
+    // Note the lack of atomicity
     for (const auto &var : slice) {
       Variable newVar(var);
-      newVar.setName(name);
+      if (!var.isCoord())
+        newVar.setName(name);
       this->insert(newVar);
     }
   }

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -103,6 +103,8 @@ public:
   }
 
   void insert(Variable variable);
+  void insert(const ConstDatasetSlice &slice);
+  void insert(const std::string &name, const ConstDatasetSlice &slice);
   void insert(const Tag tag, Variable variable) {
     variable.setTag(tag);
     variable.setName("");

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -511,6 +511,7 @@ TEST(Dataset, insert_named_subset) {
   auto subset = a.subset("a");
 
   Dataset b;
+  b.insert(Coord::X, "a", {Dim::X, 1}, 1);
   b.insert("b", subset);
   EXPECT_NE(b, a);
   EXPECT_EQ(b.size(), 3);
@@ -524,18 +525,23 @@ TEST(Dataset, insert_named_subset_matches_coordinates) {
   Dataset a;
   a.insert(Data::Value, "a", {Dim::X, 1}, 1);
   a.insert(Data::Variance, "a", {Dim::X, 1}, 1);
-  a.insert(Coord::X, "a", {Dim::X, 1}, 1);
+  a.insert(Coord::X, {Dim::X, 1}, 1);
   auto subset = a.subset("a");
 
   Dataset b;
   b.insert(Coord::Y, {Dim::Y, 3}, 3); // Coord different from subset
+  EXPECT_THROW(b.insert("b", subset),
+               std::runtime_error);   // Insert cannot be used to
+                                      // add coordinate variables
+                                      // not already present
+  b.insert(Coord::X, {Dim::X, 1}, 1); // lhs now has X coord.
   b.insert("b", subset);
 
   EXPECT_EQ(b.size(), 4);
   EXPECT_TRUE(b.contains(Data::Value, "b"));
   EXPECT_TRUE(b.contains(Data::Variance, "b"));
-  EXPECT_TRUE(b.contains(Coord::Y));      // Original coord
-  EXPECT_TRUE(b.contains(Coord::X, "a")); // Coordinates not renamed
+  EXPECT_TRUE(b.contains(Coord::Y)); // Original coord
+  EXPECT_TRUE(b.contains(Coord::X));
 
   Dataset c;
   c.insert(Coord::X, {Dim::X, 3}, 3);

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -201,7 +201,7 @@ TEST(Dataset, merge) {
 
   Dataset copy(merged);
 
- // We can merge twice, it is idempotent.
+  // We can merge twice, it is idempotent.
   EXPECT_NO_THROW(merged.merge(d));
   EXPECT_EQ(copy, merged);
 
@@ -501,24 +501,6 @@ TEST(Dataset, operator_plus_equal) {
   a += a;
   EXPECT_EQ(a.get(Coord::X)[0], 0.1);
   EXPECT_EQ(a.get(Data::Value)[0], 4.4);
-}
-
-TEST(Dataset, insert_subset) {
-  Dataset a;
-  a.insert(Data::Value, "a", {Dim::X, 1}, 1);
-  a.insert(Data::Variance, "a", {Dim::X, 1}, 1);
-  auto subset = a.subset("a");
-
-  Dataset b;
-  b.insert(subset);
-  EXPECT_EQ(b, a);
-  EXPECT_EQ(b.size(), 2);
-
-  Dataset c;
-  c.insert(Data::Value, "c", {Dim::X, 1}, 1);
-  c.insert(subset);
-  EXPECT_NE(a, c);
-  EXPECT_EQ(c.size(), 3);
 }
 
 TEST(Dataset, insert_named_subset) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -503,6 +503,39 @@ TEST(Dataset, operator_plus_equal) {
   EXPECT_EQ(a.get(Data::Value)[0], 4.4);
 }
 
+TEST(Dataset, insert_subset) {
+  Dataset a;
+  a.insert(Data::Value, "a", {Dim::X, 1}, 1);
+  a.insert(Data::Variance, "a", {Dim::X, 1}, 1);
+  auto subset = a.subset("a");
+
+  Dataset b;
+  b.insert(subset);
+  EXPECT_EQ(b, a);
+  EXPECT_EQ(b.size(), 2);
+
+  Dataset c;
+  c.insert(Data::Value, "c", {Dim::X, 1}, 1);
+  c.insert(subset);
+  EXPECT_NE(a, c);
+  EXPECT_EQ(c.size(), 3);
+}
+
+TEST(Dataset, insert_named_subset) {
+  Dataset a;
+  a.insert(Data::Value, "a", {Dim::X, 1}, 1);
+  a.insert(Data::Variance, "a", {Dim::X, 1}, 1);
+  auto subset = a.subset("a");
+
+  Dataset b;
+  b.insert("b", subset);
+  EXPECT_NE(b, a);
+  EXPECT_EQ(b.size(), 2);
+
+  EXPECT_TRUE(b.contains(Data::Value, "b"));
+  EXPECT_TRUE(b.contains(Data::Variance, "b"));
+}
+
 TEST(Dataset, operator_plus_equal_broadcast) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});


### PR DESCRIPTION
Fixes #125 

**Tester**
The python unit tests should give a good indication about how this behaves. Note that `__setitem__` on `SubsetHelper` no longer calls `Dataset::assign` the semantics of assign did not seem to fit. Happy to discuss this point if not clear.