### PR TITLE
broken_tmp_sliced_keep_alive

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -672,7 +672,7 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::init(&detail::makeVariable), py::arg("tag"), py::arg("labels"),
            py::arg("data"), py::arg("dtype") = py::dtype::of<Empty>())
       .def(py::init<const VariableSlice &>())
-      .def("__getitem__", detail::pySlice<Variable>)
+      .def("__getitem__", detail::pySlice<Variable>, py::keep_alive<0, 1> ())
       .def("__copy__", [](Variable &self) { return Variable(self); })
       .def("__deepcopy__",
            [](Variable &self, py::dict) { return Variable(self); })
@@ -1024,7 +1024,7 @@ PYBIND11_MODULE(dataset, m) {
            [](Dataset &self, const std::tuple<Dim, gsl::index> &index) {
              return getItemBySingleIndex(self, index);
            })
-      .def("__getitem__", &detail::pySlice<Dataset>)
+      .def("__getitem__", &detail::pySlice<Dataset>, py::keep_alive<0, 1> ())
       .def("__getitem__",
            [](Dataset &self, const Tag &tag) { return self(tag); })
       .def("__getitem__",

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -166,6 +166,17 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertNotEqual(a, c)
         self.assertNotEqual(a, a3)
 
+    def test_correct_temporaries(self):
+        N = 6
+        M = 4
+        d1 = Dataset()
+        d1[Coord.X] = ([Dim.X], np.arange(N+1).astype(np.float64))
+        d1[Coord.Y] = ([Dim.Y], np.arange(M+1).astype(np.float64))
+        arr1 = np.arange(N*M).reshape(N,M).astype(np.float64) + 1
+        d1[Data.Value, "A"] = ([Dim.X, Dim.Y], arr1)
+        d1 = d1[Dim.X, 1:2]
+        self.assertEqual(list(d1[Data.Value, "A"].data), [5.0, 6.0, 7.0, 8.0])
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_variableslice.py
+++ b/python/test/test_variableslice.py
@@ -76,5 +76,11 @@ class TestVariableSlice(unittest.TestCase):
         self.assertNotEqual(a, c)
         self.assertNotEqual(c, a)
 
+    def test_correct_temporaries(self):
+        v = Variable(Data.Value, [Dim.X], np.arange(100).astype(np.float32))
+        b = sqrt(v)[Dim.X, 0:10]
+        self.assertEqual(len(b.data), 10)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`keep_alive` makes slicing temporaries correct. While it is not effective in terms of memory usage

fixes #108