### PR TITLE
Use 2 cores in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
   - cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make -j2 install
   - ./test/dataset_test
-  - pip install --user --upgrade pip
   - python3 -m pip install -r ../python/requirements.txt
   - export PYTHONPATH=$PYTHONPATH:../install
   - cd ../python

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
   - make install
   - ./test/dataset_test
+  - pip install --upgrade pip
   - python3 -m pip install -r ../python/requirements.txt
   - export PYTHONPATH=$PYTHONPATH:../install
   - cd ../python

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ script:
   - mkdir -p install
   - cd build
   - cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX=../install ..
-  - make install
+  - make -j2 install
   - ./test/dataset_test
-  - pip install --upgrade pip
+  - pip install --user --upgrade pip
   - python3 -m pip install -r ../python/requirements.txt
   - export PYTHONPATH=$PYTHONPATH:../install
   - cd ../python


### PR DESCRIPTION
It would appear that the workers on the Travis build system have 2 cores (https://docs.travis-ci.com/user/reference/overview/), so we can try to speed up the builds by using `make -j2 install`