### PR TITLE
fix versions in python package requirements

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
-numpy
-pandas
-xarray
-matplotlib
+numpy=1.14.6
+pandas=0.24.2
+xarray= 0.11.3
+matplotlib=3.0.3
 nose
-plotly
+plotly=3.6.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
-numpy=1.14.6
-pandas=0.24.2
-xarray= 0.11.3
-matplotlib=3.0.3
+numpy==1.14.6
+pandas==0.24.2
+xarray==0.11.3
+matplotlib==3.0.3
 nose
-plotly=3.6.1
+plotly==3.6.1


### PR DESCRIPTION
Let fix the python package versions in the requirements list, at least, for now not to spend the time fighting with Travis builds failed because of xarray and other packages changes.

should fix #156 