### PR TITLE
Correct behavior for units divide operator:

### DIFF
--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -70,11 +70,11 @@ Unit operator*(const Unit &a, const Unit &b) {
 Unit operator/(const Unit &a, const Unit &b) {
   return Unit(std::visit(
       [](auto x, auto y) -> Unit::unit_t {
-        auto z{x / y};
         // It is done here to have the si::dimensionless then the units are
         // the same, but is the si::dimensionless valid for non si types? TODO
         if constexpr (std::is_same_v<decltype(x), decltype(y)>)
           return dimensionless;
+        auto z{x / y};
         if constexpr (isKnownUnit(z))
           return z;
         throw std::runtime_error("Unsupported unit as result of division: (" +

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -57,6 +57,11 @@ Unit operator*(const Unit &a, const Unit &b) {
         // Creation of z needed here because putting x*y inside the call to
         // isKnownUnit(x*y) leads to error: temporary of non-literal type in
         // a constant expression
+
+        // It is done here to have the si::dimensionless then the units are
+        // the same, but is the si::dimensionless valid for non si types? TODO
+        if constexpr (std::is_same_v<decltype(x), decltype(y)>)
+          return dimensionless;
         auto z{x * y};
         if constexpr (isKnownUnit(z))
           return z;

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -57,11 +57,6 @@ Unit operator*(const Unit &a, const Unit &b) {
         // Creation of z needed here because putting x*y inside the call to
         // isKnownUnit(x*y) leads to error: temporary of non-literal type in
         // a constant expression
-
-        // It is done here to have the si::dimensionless then the units are
-        // the same, but is the si::dimensionless valid for non si types? TODO
-        if constexpr (std::is_same_v<decltype(x), decltype(y)>)
-          return dimensionless;
         auto z{x * y};
         if constexpr (isKnownUnit(z))
           return z;
@@ -76,6 +71,10 @@ Unit operator/(const Unit &a, const Unit &b) {
   return Unit(std::visit(
       [](auto x, auto y) -> Unit::unit_t {
         auto z{x / y};
+        // It is done here to have the si::dimensionless then the units are
+        // the same, but is the si::dimensionless valid for non si types? TODO
+        if constexpr (std::is_same_v<decltype(x), decltype(y)>)
+          return dimensionless;
         if constexpr (isKnownUnit(z))
           return z;
         throw std::runtime_error("Unsupported unit as result of division: (" +


### PR DESCRIPTION
for custom unit x, x / x should return dimensionless