### PR TITLE
Dataset binary with variable

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -853,7 +853,17 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("__setitem__",
            [](SubsetHelper &self, const std::string &name,
+              const Dataset &data) { self.subset(name).assign(data); })
+      .def("__setitem__",
+           [](SubsetHelper &self, const std::string &name,
               const DatasetSlice &data) { self.subset(name).assign(data); })
+      .def("__setitem__",
+           [](SubsetHelper &self,
+              const std::tuple<const Tag, const std::string &> &index,
+              const Dataset &data) {
+             const auto & [ tag, name ] = index;
+             self.subset(tag, name).assign(data);
+           })
       .def("__setitem__",
            [](SubsetHelper &self,
               const std::tuple<const Tag, const std::string &> &index,

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -920,6 +920,21 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::Tag>)
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::TagName>)
+      .def("__iadd__",
+           [](DatasetSlice &self, const Variable &other) {
+             return self += Dataset({other});
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__isub__",
+           [](DatasetSlice &self, const Variable &other) {
+             return self -= Dataset({other});
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__imul__",
+           [](DatasetSlice &self, const Variable &other) {
+             return self *= Dataset({other});
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())
@@ -1119,6 +1134,21 @@ PYBIND11_MODULE(dataset, m) {
       .def("__ne__",
            [](const Dataset &self, const DatasetSlice &other) {
              return self != other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__iadd__",
+           [](Dataset &self, const Variable &other) {
+             return self += Dataset({other});
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__isub__",
+           [](Dataset &self, const Variable &other) {
+             return self -= Dataset({other});
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__imul__",
+           [](Dataset &self, const Variable &other) {
+             return self *= Dataset({other});
            },
            py::call_guard<py::gil_scoped_release>())
       .def("__iadd__",

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -65,14 +65,14 @@ template <class T> std::string element_to_string(const T &item) {
 template <class T> std::string array_to_string(const T &arr) {
   const gsl::index size = arr.size();
   if (size == 0)
-   return std::string("[]");
+    return std::string("[]");
   std::string s = "[";
   for (gsl::index i = 0; i < arr.size(); ++i) {
-   if (i == 4 && size > 8) {
-     s += "..., ";
-     i = size - 4;
-   }
-   s += element_to_string(arr[i]);
+    if (i == 4 && size > 8) {
+      s += "..., ";
+      i = size - 4;
+    }
+    s += element_to_string(arr[i]);
   }
   s.resize(s.size() - 2);
   s += "]";
@@ -85,11 +85,12 @@ template <class T> void declare_span(py::module &m, const std::string &suffix) {
            py::return_value_policy::reference)
       .def("size", &gsl::span<T>::size)
       .def("__len__", &gsl::span<T>::size)
-      .def("__iter__", [](const gsl::span<T> &self) {
-        return py::make_iterator(self.begin(), self.end());
-      })
+      .def("__iter__",
+           [](const gsl::span<T> &self) {
+             return py::make_iterator(self.begin(), self.end());
+           })
       .def("__repr__",
-       [](const gsl::span<T> &self) { return array_to_string(self); });
+           [](const gsl::span<T> &self) { return array_to_string(self); });
   mutable_span_methods<T>::add(span);
 }
 
@@ -1014,13 +1015,28 @@ PYBIND11_MODULE(dataset, m) {
              return self -= other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__isub__",
+           [](const DatasetSlice &self, const Variable &other) {
+             return self -= other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__imul__",
            [](const DatasetSlice &self, const Dataset &other) {
              return self *= other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__imul__",
+           [](const DatasetSlice &self, const Variable &other) {
+             return self *= other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__itruediv__",
            [](const DatasetSlice &self, const Dataset &other) {
+             return self /= other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__itruediv__",
+           [](const DatasetSlice &self, const Variable &other) {
              return self /= other;
            },
            py::call_guard<py::gil_scoped_release>())
@@ -1205,23 +1221,40 @@ PYBIND11_MODULE(dataset, m) {
              return self += other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__iadd__",
+           [](Dataset &self, const Variable &other) { return self += other; },
+           py::call_guard<py::gil_scoped_release>())
       .def("__isub__",
            [](Dataset &self, const DatasetSlice &other) {
              return self -= other;
            },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__isub__",
+           [](Dataset &self, const Variable &other) { return self -= other; },
            py::call_guard<py::gil_scoped_release>())
       .def("__imul__",
            [](Dataset &self, const DatasetSlice &other) {
              return self *= other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__imul__",
+           [](Dataset &self, const Variable &other) { return self *= other; },
+           py::call_guard<py::gil_scoped_release>())
       .def("__itruediv__",
            [](Dataset &self, const DatasetSlice &other) {
              return self /= other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__itruediv__",
+           [](Dataset &self, const Variable &other) { return self /= other; },
+           py::call_guard<py::gil_scoped_release>())
       .def("__add__",
            [](const Dataset &self, const DatasetSlice &other) {
+             return self + other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__add__",
+           [](const Dataset &self, const Variable &other) {
              return self + other;
            },
            py::call_guard<py::gil_scoped_release>())
@@ -1230,13 +1263,28 @@ PYBIND11_MODULE(dataset, m) {
              return self - other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__sub__",
+           [](const Dataset &self, const Variable &other) {
+             return self - other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__mul__",
            [](const Dataset &self, const DatasetSlice &other) {
              return self * other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__mul__",
+           [](const Dataset &self, const Variable &other) {
+             return self * other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__truediv__",
            [](const Dataset &self, const DatasetSlice &other) {
+             return self / other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__truediv__",
+           [](const Dataset &self, const Variable &other) {
              return self / other;
            },
            py::call_guard<py::gil_scoped_release>())

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -985,8 +985,18 @@ PYBIND11_MODULE(dataset, m) {
              return self + other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__add__",
+           [](const DatasetSlice &self, const Variable &other) {
+             return self + other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__sub__",
            [](const DatasetSlice &self, const Dataset &other) {
+             return self - other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__sub__",
+           [](const DatasetSlice &self, const Variable &other) {
              return self - other;
            },
            py::call_guard<py::gil_scoped_release>())
@@ -995,8 +1005,18 @@ PYBIND11_MODULE(dataset, m) {
              return self * other;
            },
            py::call_guard<py::gil_scoped_release>())
+      .def("__mul__",
+           [](const DatasetSlice &self, const Variable &other) {
+             return self * other;
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("__truediv__",
            [](const DatasetSlice &self, const Dataset &other) {
+             return self / other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__truediv__",
+           [](const DatasetSlice &self, const Variable &other) {
              return self / other;
            },
            py::call_guard<py::gil_scoped_release>())

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -661,8 +661,14 @@ PYBIND11_MODULE(dataset, m) {
       .def(py::init(&detail::makeVariableDefaultInit), py::arg("tag"),
            py::arg("labels"), py::arg("shape"),
            py::arg("dtype") = py::dtype::of<Empty>())
+      .def(py::init([](const int64_t data, const Unit &unit) {
+             auto var = makeVariable<int64_t>(Data::NoTag, {}, {data});
+             var.setUnit(unit);
+             return var;
+           }),
+           py::arg("data"), py::arg("unit") = Unit(units::dimensionless))
       .def(py::init([](const double data, const Unit &unit) {
-             Variable var(Data::Value, {}, {data});
+             Variable var(Data::NoTag, {}, {data});
              var.setUnit(unit);
              return var;
            }),
@@ -920,21 +926,6 @@ PYBIND11_MODULE(dataset, m) {
            })
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::Tag>)
       .def("__setitem__", detail::setData<DatasetSlice, detail::Key::TagName>)
-      .def("__iadd__",
-           [](DatasetSlice &self, const Variable &other) {
-             return self += Dataset({other});
-           },
-           py::call_guard<py::gil_scoped_release>())
-      .def("__isub__",
-           [](DatasetSlice &self, const Variable &other) {
-             return self -= Dataset({other});
-           },
-           py::call_guard<py::gil_scoped_release>())
-      .def("__imul__",
-           [](DatasetSlice &self, const Variable &other) {
-             return self *= Dataset({other});
-           },
-           py::call_guard<py::gil_scoped_release>())
       .def(py::self + py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self - py::self, py::call_guard<py::gil_scoped_release>())
       .def(py::self += py::self, py::call_guard<py::gil_scoped_release>())
@@ -976,6 +967,11 @@ PYBIND11_MODULE(dataset, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("__iadd__",
            [](const DatasetSlice &self, const Dataset &other) {
+             return self += other;
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("__iadd__",
+           [](const DatasetSlice &self, const Variable &other) {
              return self += other;
            },
            py::call_guard<py::gil_scoped_release>())
@@ -1134,21 +1130,6 @@ PYBIND11_MODULE(dataset, m) {
       .def("__ne__",
            [](const Dataset &self, const DatasetSlice &other) {
              return self != other;
-           },
-           py::call_guard<py::gil_scoped_release>())
-      .def("__iadd__",
-           [](Dataset &self, const Variable &other) {
-             return self += Dataset({other});
-           },
-           py::call_guard<py::gil_scoped_release>())
-      .def("__isub__",
-           [](Dataset &self, const Variable &other) {
-             return self -= Dataset({other});
-           },
-           py::call_guard<py::gil_scoped_release>())
-      .def("__imul__",
-           [](Dataset &self, const Variable &other) {
-             return self *= Dataset({other});
            },
            py::call_guard<py::gil_scoped_release>())
       .def("__iadd__",

--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -856,26 +856,6 @@ PYBIND11_MODULE(dataset, m) {
               const std::tuple<const Tag, const std::string &> &index) {
              const auto & [ tag, name ] = index;
              return self.subset(tag, name);
-           })
-      .def("__setitem__",
-           [](SubsetHelper &self, const std::string &name,
-              const Dataset &data) { self.subset(name).assign(data); })
-      .def("__setitem__",
-           [](SubsetHelper &self, const std::string &name,
-              const DatasetSlice &data) { self.subset(name).assign(data); })
-      .def("__setitem__",
-           [](SubsetHelper &self,
-              const std::tuple<const Tag, const std::string &> &index,
-              const Dataset &data) {
-             const auto & [ tag, name ] = index;
-             self.subset(tag, name).assign(data);
-           })
-      .def("__setitem__",
-           [](SubsetHelper &self,
-              const std::tuple<const Tag, const std::string &> &index,
-              const DatasetSlice &data) {
-             const auto & [ tag, name ] = index;
-             self.subset(tag, name).assign(data);
            });
 
   py::class_<DatasetSlice>(m, "DatasetSlice")

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -274,9 +274,15 @@ class TestDataset(unittest.TestCase):
                 np.testing.assert_array_equal(view[Data.Value, "data2"].numpy, self.reference_data2[z:z+delta,:,:])
                 np.testing.assert_array_equal(view[Data.Value, "data3"].numpy, self.reference_data3[z:z+delta,:])
 
-    def _apply_test_op(self, op, a, b, data, lh_var_name="i", rh_var_name="j"):
+    def _apply_test_op_rhs_dataset(self, op, a, b, data, lh_var_name="i", rh_var_name="j"):
         # Assume numpy operations are correct as comparitor
         op(data,b[Data.Value, rh_var_name].numpy)
+        op(a,b)
+        np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
+        
+    def _apply_test_op_rhs_variable(self, op, a, b, data, lh_var_name="i", rh_var_name="j"):
+        # Assume numpy operations are correct as comparitor
+        op(data,b.numpy)
         op(a,b)
         np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
 
@@ -302,21 +308,21 @@ class TestDataset(unittest.TestCase):
         self.assertTrue(np.array_equal(c[Data.Variance, "i"].numpy, variance + variance))
 
         c = a * b
-        # Variables "a" and "b" subtracted despite different names
+        # Variables "a" and "b" multiplied despite different names
         self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data * data))
         self.assertTrue(np.array_equal(c[Data.Variance, "i"].numpy, variance*(data*data)*2))
 
         c = a / b
-        # Variables "a" and "b" subtracted despite different names
+        # Variables "a" and "b" divided despite different names
         with np.errstate(invalid="ignore"):
             np.testing.assert_equal(c[Data.Value, "i"].numpy, data / data) 
         np.testing.assert_equal(c[Data.Variance, "i"].numpy, variance*(data*data)*2) 
 
-        self._apply_test_op(operator.iadd, a, b, data)
-        self._apply_test_op(operator.isub, a, b, data)
-        self._apply_test_op(operator.imul, a, b, data)
+        self._apply_test_op_rhs_dataset(operator.iadd, a, b, data)
+        self._apply_test_op_rhs_dataset(operator.isub, a, b, data)
+        self._apply_test_op_rhs_dataset(operator.imul, a, b, data)
         with np.errstate(invalid="ignore"):
-            self._apply_test_op(operator.itruediv, a, b, data)
+            self._apply_test_op_rhs_dataset(operator.itruediv, a, b, data)
 
     def test_binary_variable_rhs_operations(self):
         data = np.ones(10, dtype='float64')
@@ -329,7 +335,18 @@ class TestDataset(unittest.TestCase):
         
         c = a + b_var
         self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data + data))
-
+        c = a - b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data - data))
+        c = a * b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data * data))
+        c = a / b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data / data))
+        
+        self._apply_test_op_rhs_variable(operator.iadd, a, b_var, data)
+        self._apply_test_op_rhs_variable(operator.isub, a, b_var, data)
+        self._apply_test_op_rhs_variable(operator.imul, a, b_var, data)
+        with np.errstate(invalid="ignore"):
+            self._apply_test_op_rhs_variable(operator.itruediv, a, b_var, data)
 
     def test_binary_float_operations(self):
         a = Dataset()

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -280,7 +280,7 @@ class TestDataset(unittest.TestCase):
         op(a,b)
         np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
 
-    def test_binary_operations(self):
+    def test_binary_dataset_rhs_operations(self):
         a = Dataset()
         a[Coord.X] = ([Dim.X], np.arange(10))
         a[Data.Value, "i"] = ([Dim.X], np.arange(10, dtype='float64'))
@@ -317,6 +317,19 @@ class TestDataset(unittest.TestCase):
         self._apply_test_op(operator.imul, a, b, data)
         with np.errstate(invalid="ignore"):
             self._apply_test_op(operator.itruediv, a, b, data)
+
+    def test_binary_variable_rhs_operations(self):
+        data = np.ones(10, dtype='float64')
+
+        a = Dataset()
+        a[Coord.X] = ([Dim.X], np.arange(10))
+        a[Data.Value, "i"] = ([Dim.X], data)
+
+        b_var = Variable(Data.Value, [Dim.X], data)
+        
+        c = a + b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "i"].numpy, data + data))
+
 
     def test_binary_float_operations(self):
         a = Dataset()

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -80,7 +80,8 @@ class TestDatasetSlice(unittest.TestCase):
 
     def _apply_test_op(self, op, a, b, data, lh_var_name="a", rh_var_name="b"):
         # Assume numpy operations are correct as comparitor
-        op(data,b[Data.Value, rh_var_name].numpy)
+        with np.errstate(invalid='ignore'):
+            op(data,b[Data.Value, rh_var_name].numpy)
         op(a,b)
         np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
 

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -228,13 +228,13 @@ class TestDatasetSlice(unittest.TestCase):
         d1[Data.Value, "A"] = ([Dim.X, Dim.Y], arr1)
         d1 = d1[Dim.X, 1:2]
         self.assertEqual(list(d1[Data.Value, "A"].data), [5.0, 6.0, 7.0, 8.0])
-        
+
     def test_set_dataset_slice_items(self):
         d = self._d.copy()
         d[Data.Value, "a"][Dim.X, 0:2] += d[Data.Value, "b"][Dim.X, 1:3]
         self.assertEqual(list(d[Data.Value, "a"].data), [1, 3, 2, 3, 4, 5, 6, 7, 8, 9])
         d[Data.Value, "a"][Dim.X, 6] += d[Data.Value, "b"][Dim.X, 8]
         self.assertEqual(list(d[Data.Value, "a"].data), [1, 3, 2, 3, 4, 5, 14, 7, 8, 9])
-                
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -78,14 +78,20 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertNotEqual(s1[Data.Value, "A"], s2[Data.Value, "A"])
         self.assertNotEqual(s3[Data.Value, "A"], s2[Data.Value, "A"])
 
-    def _apply_test_op(self, op, a, b, data, lh_var_name="a", rh_var_name="b"):
+    def _apply_test_op_rhs_ds_slice(self, op, a, b, data, lh_var_name="a", rh_var_name="b"):
         # Assume numpy operations are correct as comparitor
         with np.errstate(invalid='ignore'):
             op(data,b[Data.Value, rh_var_name].numpy)
         op(a,b)
         np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
 
-    def test_binary_operations(self):
+    def _apply_test_op_rhs_variable(self, op, a, b, data, lh_var_name="a", rh_var_name="b"):
+        # Assume numpy operations are correct as comparitor
+        op(data,b.numpy)
+        op(a,b)
+        np.testing.assert_equal(a[Data.Value, lh_var_name].numpy, data) # Desired nan comparisons
+
+    def test_binary_slice_rhs_operations(self):
         d = Dataset()
         d[Coord.X] = ([Dim.X], np.arange(10))
         d[Data.Value, "a"] = ([Dim.X], np.arange(10, dtype='float64'))
@@ -108,20 +114,46 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertTrue(np.array_equal(c[Data.Variance, "a"].numpy, variance + variance))
 
         c = a * b
-        # Variables "a" and "b" subtracted despite different names
+        # Variables "a" and "b" multiplied despite different names
         self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data * data))
         self.assertTrue(np.array_equal(c[Data.Variance, "a"].numpy, variance*(data*data)*2))
 
         c = a / b
-        # Variables "a" and "b" subtracted despite different names
+        # Variables "a" and "b" divided despite different names
         with np.errstate(invalid='ignore'):
             np.testing.assert_equal(c[Data.Value, "a"].numpy, data / data) 
         np.testing.assert_equal(c[Data.Variance, "a"].numpy, variance*(data*data)*2) 
 
-        self._apply_test_op(operator.iadd, a, b, data)
-        self._apply_test_op(operator.isub, a, b, data)
-        self._apply_test_op(operator.imul, a, b, data)
-        self._apply_test_op(operator.itruediv, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.iadd, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.isub, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.imul, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.itruediv, a, b, data)
+
+    def test_binary_variable_rhs_operations(self):
+        data = np.ones(10, dtype='float64')
+        d = Dataset()
+        d[Data.Value, "a"] = ([Dim.X], data)
+        d[Data.Variance, "a"] = ([Dim.X], data)
+        a = d.subset[Data.Value, "a"]
+        b_var = Variable(Data.Value, [Dim.X], data)
+
+        c = a + b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data + data))
+
+        c = a - b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data - data))
+
+        c = a * b_var
+        self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data * data))
+
+        c = a / b_var
+        with np.errstate(invalid='ignore'):
+            np.testing.assert_equal(c[Data.Value, "a"].numpy, data / data) 
+
+        self._apply_test_op_rhs_variable(operator.iadd, a, b_var, data)
+        self._apply_test_op_rhs_variable(operator.isub, a, b_var, data)
+        self._apply_test_op_rhs_variable(operator.imul, a, b_var, data)
+        self._apply_test_op_rhs_variable(operator.itruediv, a, b_var, data)
 
     def test_binary_float_operations(self):
         d = Dataset()
@@ -149,10 +181,10 @@ class TestDatasetSlice(unittest.TestCase):
         c = 2.0 * a
         self.assertTrue(np.array_equal(c[Data.Value, "a"].numpy, data * 2.0))
 
-        self._apply_test_op(operator.iadd, a, b, data)
-        self._apply_test_op(operator.isub, a, b, data)
-        self._apply_test_op(operator.imul, a, b, data)
-        self._apply_test_op(operator.itruediv, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.iadd, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.isub, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.imul, a, b, data)
+        self._apply_test_op_rhs_ds_slice(operator.itruediv, a, b, data)
         
 
     def test_equal_not_equal(self):

--- a/python/test/test_datasetslice.py
+++ b/python/test/test_datasetslice.py
@@ -161,6 +161,14 @@ class TestDatasetSlice(unittest.TestCase):
         self.assertNotEqual(a, c)
         self.assertNotEqual(a, a3)
 
+    def test_binary_ops_with_variable(self):
+        d = Dataset()
+        d[Coord.X] = ([Dim.X], np.arange(10))
+        d[Data.Value, "a"] = ([Dim.X], np.arange(10))
+        d[Data.Variance, "a"] = ([Dim.X], np.arange(10))
+
+        d += Variable(2)
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -712,6 +712,16 @@ DatasetSlice DatasetSlice::operator-=(const ConstDatasetSlice &other) const {
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
 }
+
+DatasetSlice DatasetSlice::operator-=(const Variable &other) const {
+  if (other.tag() != Data::NoTag)
+    return *this -= Dataset({other});
+  else
+    for (const auto var : *this)
+      if (var.tag() == Data::Value)
+        var -= other;
+  return *this;
+}
 DatasetSlice DatasetSlice::operator-=(const double value) const {
   for (auto var : *this)
     if (var.tag() == Data::Value)
@@ -724,6 +734,15 @@ DatasetSlice DatasetSlice::operator*=(const Dataset &other) const {
 }
 DatasetSlice DatasetSlice::operator*=(const ConstDatasetSlice &other) const {
   return op_equals(*this, other, &aligned::multiply, &aligned::multiply);
+}
+DatasetSlice DatasetSlice::operator*=(const Variable &other) const {
+  if (other.tag() != Data::NoTag)
+    return *this *= Dataset({other});
+  else
+    for (const auto var : *this)
+      if (var.tag() == Data::Value)
+        var *= other;
+  return *this;
 }
 DatasetSlice DatasetSlice::operator*=(const double value) const {
   for (auto var : *this)
@@ -738,6 +757,15 @@ DatasetSlice DatasetSlice::operator/=(const Dataset &other) const {
 }
 DatasetSlice DatasetSlice::operator/=(const ConstDatasetSlice &other) const {
   return op_equals(*this, other, &aligned::divide, &aligned::divide);
+}
+DatasetSlice DatasetSlice::operator/=(const Variable &other) const {
+  if (other.tag() != Data::NoTag)
+    return *this /= Dataset({other});
+  else
+    for (const auto var : *this)
+      if (var.tag() == Data::Value)
+        var /= other;
+  return *this;
 }
 DatasetSlice DatasetSlice::operator/=(const double value) const {
   for (auto var : *this)

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -543,9 +543,6 @@ Dataset &Dataset::operator+=(const Variable &other) {
   else
     for (auto &var : m_variables)
       // TODO Should this operate also on events etc.?
-
-      // What about lhs variance?, under existing rules even via dataset,
-      // nothing would be done (as rhs-variance unknown).
       if (var.tag() == Data::Value)
         var += other;
   return *this;
@@ -566,6 +563,18 @@ Dataset &Dataset::operator-=(const ConstDatasetSlice &other) {
   return binary_op_equals(
       [](VariableSlice &a, const ConstVariableSlice &b) { return a -= b; },
       *this, other);
+}
+
+Dataset &Dataset::operator-=(const Variable &other) {
+  if (other.tag() != Data::NoTag)
+    // For variable of known tag, simply wrap rhs with Dataset
+    return *this -= Dataset({other});
+  else
+    for (auto &var : m_variables)
+      // TODO Should this operate also on events etc.?
+      if (var.tag() == Data::Value)
+        var -= other;
+  return *this;
 }
 Dataset &Dataset::operator-=(const double value) {
   for (auto &var : m_variables)

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -444,10 +444,14 @@ Dataset &Dataset::operator+=(const ConstDatasetSlice &other) {
 }
 Dataset &Dataset::operator+=(const Variable &other) {
   if (other.tag() != Data::NoTag)
+    // For variable of known tag, simply wrap rhs with Dataset
     return *this += Dataset({other});
   else
     for (auto &var : m_variables)
       // TODO Should this operate also on events etc.?
+
+      // What about lhs variance?, under existing rules even via dataset,
+      // nothing would be done (as rhs-variance unknown).
       if (var.tag() == Data::Value)
         var += other;
   return *this;

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -794,6 +794,10 @@ Dataset operator*(Dataset a, const ConstDatasetSlice &b) {
 Dataset operator/(Dataset a, const ConstDatasetSlice &b) {
   return std::move(a /= b);
 }
+Dataset operator+(Dataset a, const Variable &b) { return std::move(a += b); }
+Dataset operator-(Dataset a, const Variable &b) { return std::move(a -= b); }
+Dataset operator*(Dataset a, const Variable &b) { return std::move(a *= b); }
+Dataset operator/(Dataset a, const Variable &b) { return std::move(a /= b); }
 Dataset operator+(Dataset a, const double b) { return std::move(a += b); }
 Dataset operator-(Dataset a, const double b) { return std::move(a -= b); }
 Dataset operator*(Dataset a, const double b) { return std::move(a *= b); }

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -14,6 +14,11 @@
 #include "except.h"
 #include "tag_util.h"
 
+Dataset::Dataset(std::vector<Variable> vars) {
+  for (auto &var : vars)
+    insert(std::move(var));
+}
+
 Dataset::Dataset(const ConstDatasetSlice &view) {
   for (const auto &var : view)
     insert(var);

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -597,11 +597,35 @@ Dataset &Dataset::operator*=(const double value) {
       var *= value * value;
   return *this;
 }
+
+Dataset &Dataset::operator*=(const Variable &other) {
+  if (other.tag() != Data::NoTag)
+    // For variable of known tag, simply wrap rhs with Dataset
+    return *this *= Dataset({other});
+  else
+    for (auto &var : m_variables)
+      // TODO Should this operate also on events etc.?
+      if (var.tag() == Data::Value)
+        var *= other;
+  return *this;
+}
 Dataset &Dataset::operator/=(const Dataset &other) {
   return op_equals(*this, other, &aligned::divide, &aligned::divide);
 }
 Dataset &Dataset::operator/=(const ConstDatasetSlice &other) {
   return op_equals(*this, other, &aligned::divide, &aligned::divide);
+}
+
+Dataset &Dataset::operator/=(const Variable &other) {
+  if (other.tag() != Data::NoTag)
+    // For variable of known tag, simply wrap rhs with Dataset
+    return *this /= Dataset({other});
+  else
+    for (auto &var : m_variables)
+      // TODO Should this operate also on events etc.?
+      if (var.tag() == Data::Value)
+        var /= other;
+  return *this;
 }
 Dataset &Dataset::operator/=(const double value) {
   for (auto &var : m_variables)

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -604,7 +604,6 @@ Dataset &Dataset::operator*=(const Variable &other) {
     return *this *= Dataset({other});
   else
     for (auto &var : m_variables)
-      // TODO Should this operate also on events etc.?
       if (var.tag() == Data::Value)
         var *= other;
   return *this;
@@ -622,7 +621,6 @@ Dataset &Dataset::operator/=(const Variable &other) {
     return *this /= Dataset({other});
   else
     for (auto &var : m_variables)
-      // TODO Should this operate also on events etc.?
       if (var.tag() == Data::Value)
         var /= other;
   return *this;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -539,12 +539,15 @@ public:
   DatasetSlice operator+=(const double value) const;
   DatasetSlice operator-=(const Dataset &other) const;
   DatasetSlice operator-=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator-=(const Variable &other) const;
   DatasetSlice operator-=(const double value) const;
   DatasetSlice operator*=(const Dataset &other) const;
   DatasetSlice operator*=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator*=(const Variable &other) const;
   DatasetSlice operator*=(const double value) const;
   DatasetSlice operator/=(const Dataset &other) const;
   DatasetSlice operator/=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator/=(const Variable &other) const;
   DatasetSlice operator/=(const double value) const;
 
   VariableSlice operator()(const Tag tag, const std::string &name = "") const;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -247,6 +247,7 @@ public:
   Dataset &operator+=(const double value);
   Dataset &operator-=(const Dataset &other);
   Dataset &operator-=(const ConstDatasetSlice &other);
+  Dataset &operator-=(const Variable &other);
   Dataset &operator-=(const double value);
   Dataset &operator*=(const Dataset &other);
   Dataset &operator*=(const ConstDatasetSlice &other);

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -228,6 +228,7 @@ public:
   Dataset operator-() const;
   Dataset &operator+=(const Dataset &other);
   Dataset &operator+=(const ConstDatasetSlice &other);
+  Dataset &operator+=(const Variable &other);
   Dataset &operator+=(const double value);
   Dataset &operator-=(const Dataset &other);
   Dataset &operator-=(const ConstDatasetSlice &other);
@@ -510,6 +511,7 @@ public:
   DatasetSlice assign(const ConstDatasetSlice &other) const;
   DatasetSlice operator+=(const Dataset &other) const;
   DatasetSlice operator+=(const ConstDatasetSlice &other) const;
+  DatasetSlice operator+=(const Variable &other) const;
   DatasetSlice operator+=(const double value) const;
   DatasetSlice operator-=(const Dataset &other) const;
   DatasetSlice operator-=(const ConstDatasetSlice &other) const;

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -32,6 +32,7 @@ private:
 
 public:
   Dataset() = default;
+  Dataset(std::vector<Variable> vars);
   // Allowing implicit construction from views facilitates calling functions
   // that do not explicitly support views. It is open for discussion whether
   // this is a good idea or not.

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -558,18 +558,22 @@ private:
 
 Dataset operator+(Dataset a, const Dataset &b);
 Dataset operator+(Dataset a, const ConstDatasetSlice &b);
+Dataset operator+(Dataset a, const Variable &b);
 Dataset operator+(Dataset a, const double b);
 Dataset operator+(const double a, Dataset b);
 Dataset operator-(Dataset a, const Dataset &b);
 Dataset operator-(Dataset a, const ConstDatasetSlice &b);
+Dataset operator-(Dataset a, const Variable &b);
 Dataset operator-(Dataset a, const double b);
 Dataset operator-(const double a, Dataset b);
 Dataset operator*(Dataset a, const Dataset &b);
 Dataset operator*(Dataset a, const ConstDatasetSlice &b);
+Dataset operator*(Dataset a, const Variable &b);
 Dataset operator*(Dataset a, const double b);
 Dataset operator*(const double a, Dataset b);
 Dataset operator/(Dataset a, const double b);
 Dataset operator/(Dataset a, const ConstDatasetSlice &b);
+Dataset operator/(Dataset a, const Variable &b);
 Dataset operator/(Dataset a, const double b);
 std::vector<Dataset> split(const Dataset &d, const Dim dim,
                            const std::vector<gsl::index> &indices);

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -252,8 +252,10 @@ public:
   Dataset &operator*=(const Dataset &other);
   Dataset &operator*=(const ConstDatasetSlice &other);
   Dataset &operator*=(const double value);
+  Dataset &operator*=(const Variable &other);
   Dataset &operator/=(const Dataset &other);
   Dataset &operator/=(const ConstDatasetSlice &other);
+  Dataset &operator/=(const Variable &other);
   Dataset &operator/=(const double value);
 
 private:

--- a/src/except.cpp
+++ b/src/except.cpp
@@ -114,6 +114,8 @@ std::string do_to_string(const Tag tag) {
     return "Coord::Mask";
   case Coord::Position.value():
     return "Coord::Position";
+  case Data::NoTag.value():
+    return "Data::NoTag";
   case Data::Events.value():
     return "Data::Events";
   case Data::Value.value():

--- a/src/tags.h
+++ b/src/tags.h
@@ -220,6 +220,10 @@ struct CoordDef {
 };
 
 struct DataDef {
+  struct NoTag {
+    using type = double;
+    static constexpr auto unit = units::dimensionless;
+  };
   struct Tof {
     using type = double;
     static constexpr auto unit = units::us;
@@ -261,8 +265,8 @@ struct DataDef {
     static constexpr auto unit = units::dimensionless;
   };
 
-  using tags = std::tuple<Tof, PulseTime, Value, Variance, StdDev, Int, String,
-                          Events, EventTofs, EventPulseTimes>;
+  using tags = std::tuple<NoTag, Tof, PulseTime, Value, Variance, StdDev, Int,
+                          String, Events, EventTofs, EventPulseTimes>;
 };
 
 struct AttrDef {
@@ -350,6 +354,7 @@ struct Coord {
 };
 
 struct Data {
+  using NoTag_t = detail::TagImpl<detail::DataDef::NoTag>;
   using Tof_t = detail::TagImpl<detail::DataDef::Tof>;
   using PulseTime_t = detail::TagImpl<detail::DataDef::PulseTime>;
   using Value_t = detail::TagImpl<detail::DataDef::Value>;
@@ -364,6 +369,7 @@ struct Data {
   using EventTofs_t = detail::TagImpl<detail::DataDef::EventTofs>;
   using EventPulseTimes_t = detail::TagImpl<detail::DataDef::EventPulseTimes>;
 
+  static constexpr NoTag_t NoTag{};
   static constexpr Tof_t Tof{};
   static constexpr PulseTime_t PulseTime{};
   static constexpr Value_t Value{};

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -1822,26 +1822,27 @@ TEST(DatasetSlice, binary_with_scalar) {
   EXPECT_TRUE(equals(fraction.get(Data::Variance, "b"), {24}));
 }
 
-TEST(DatasetSlice, operator_plus_with_variable) {
+TEST(DatasetSlice, binary_operator_equals_with_variable) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});
   a.insert(Data::Value, "a", {Dim::X, 1}, {25});
-  a.insert(Data::Variance, "a", {Dim::X, 1}, {5});
 
   DatasetSlice a_slice = a.subset("a");
   Variable bvar(Data::Value, {Dim::X, 1}, {5});
 
   a_slice += bvar;
-  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 30);
-  EXPECT_EQ(a_slice(Data::Variance, "a").get(Data::Variance).data()[0],
-            5); // Variance unchanged. Probably not something we can solve.
+  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 25 + 5);
+  a_slice -= bvar;
+  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 25);
+  a_slice *= bvar;
+  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 25 * 5);
+  a_slice /= bvar;
+  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 25);
 
   // Test notag treated as data value
-  Variable cvar(Data::NoTag, {Dim::X, 1}, {10});
+  Variable cvar(Data::NoTag, {Dim::X, 1}, {5});
   a_slice += cvar;
-  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 40);
-  EXPECT_EQ(a_slice(Data::Variance, "a").get(Data::Variance).data()[0],
-            5); // Variance unchanged. Probably not something we can solve.
+  EXPECT_EQ(a_slice(Data::Value, "a").get(Data::Value).data()[0], 25 + 5);
 }
 
 TEST(Dataset, counts_toDensity_fromDensity) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -654,24 +654,26 @@ TEST(Dataset, binary_operator_equal_with_variable) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});
   a.insert(Data::Value, "a", {Dim::X, 1}, {25});
-  a.insert(Data::Variance, "a", {Dim::X, 1}, {5});
+
   auto a_copy(a);
   Variable bvar(Data::Value, {Dim::X, 1}, {5});
 
   a += bvar;
-  EXPECT_EQ(a.get(Data::Value, "a")[0], 30);
-  EXPECT_EQ(a.get(Data::Variance, "a")[0],
-            5); // Variance unchanged. Probably not something we can solve.
+  EXPECT_EQ(a.get(Data::Value, "a")[0], 25 + 5);
 
-  a -= bvar;
+  a -= bvar; // TODO this test setup should throw since only one
+  EXPECT_EQ(a.get(Data::Value, "a")[0], 25);
+
+  a *= bvar;
+  EXPECT_EQ(a.get(Data::Value, "a")[0], 25 * 5);
+
+  a /= bvar;
   EXPECT_EQ(a.get(Data::Value, "a")[0], 25);
 
   // Test notag treated as data value
   Variable cvar(Data::NoTag, {Dim::X, 1}, {10});
   a_copy += cvar;
   EXPECT_EQ(a_copy.get(Data::Value, "a")[0], 35);
-  EXPECT_EQ(a_copy.get(Data::Variance, "a")[0],
-            5); // Variance unchanged. Probably not something we can solve.
 }
 
 TEST(Dataset, operator_times_equal) {

--- a/test/dataset_test.cpp
+++ b/test/dataset_test.cpp
@@ -650,12 +650,12 @@ TEST(Dataset, operator_plus_equal_with_attributes) {
   EXPECT_EQ(a.get(Attr::ExperimentLog)[0], logs);
 }
 
-TEST(Dataset, operator_plus_equal_with_variable) {
+TEST(Dataset, binary_operator_equal_with_variable) {
   Dataset a;
   a.insert(Coord::X, {Dim::X, 1}, {0.1});
   a.insert(Data::Value, "a", {Dim::X, 1}, {25});
   a.insert(Data::Variance, "a", {Dim::X, 1}, {5});
-
+  auto a_copy(a);
   Variable bvar(Data::Value, {Dim::X, 1}, {5});
 
   a += bvar;
@@ -663,11 +663,14 @@ TEST(Dataset, operator_plus_equal_with_variable) {
   EXPECT_EQ(a.get(Data::Variance, "a")[0],
             5); // Variance unchanged. Probably not something we can solve.
 
+  a -= bvar;
+  EXPECT_EQ(a.get(Data::Value, "a")[0], 25);
+
   // Test notag treated as data value
   Variable cvar(Data::NoTag, {Dim::X, 1}, {10});
-  a += cvar;
-  EXPECT_EQ(a.get(Data::Value, "a")[0], 40);
-  EXPECT_EQ(a.get(Data::Variance, "a")[0],
+  a_copy += cvar;
+  EXPECT_EQ(a_copy.get(Data::Value, "a")[0], 35);
+  EXPECT_EQ(a_copy.get(Data::Variance, "a")[0],
             5); // Variance unchanged. Probably not something we can solve.
 }
 
@@ -802,8 +805,7 @@ TEST(Dataset, operator_divide_equal_with_units) {
   a.insert(variances);
   a /= a;
   EXPECT_EQ(a(Data::Value).unit(), units::dimensionless);
-  EXPECT_EQ(a(Data::Variance).unit(),
-            units::dimensionless);
+  EXPECT_EQ(a(Data::Variance).unit(), units::dimensionless);
   EXPECT_EQ(a.get(Data::Variance)[0], 36.0);
 }
 


### PR DESCRIPTION
Test that all unit tests pass in addition to key notebooks relating to demos. Also pay attention to [this](https://github.com/mantidproject/dataset/pull/164/commits/6bce766373240eaa3d7b9843c18343ab839949fa) which does not affect any testing.

Note that I will include the inplace binary op_equals of form  `op(Dataset&, const Variable&)` and `op(DatasetSlice&, const Variable&)` implementations found in `dataset.cpp` in the refactoring issue already open as the majority of the implementation can be shared between operators.