### PR TITLE
Copied the normalization by beam monitor into a new dataset

### DIFF
--- a/python/examples/demo-part3.py
+++ b/python/examples/demo-part3.py
@@ -113,7 +113,8 @@ d
 #| ### Solution 1
 #| The binning of the monitor does not match that of the data, so we need to rebin it before the division:
 
-d.subset['sample'] /= ds.rebin(d[Coord.Monitor, 'beam'].scalar, d[Coord.Tof])
+sample_over_beam = d.subset['sample'] /= ds.rebin(d[Coord.Monitor, 'beam'].scalar, d[Coord.Tof])
+sample_over_beam
 
 #-------------------------------
 


### PR DESCRIPTION
The last cell in demo 3
```Python
normalized = d.subset['sample'] / d.subset['vanadium']
```
was failing because `d.subset['sample']` was already dimensionless by virtue of
```Python
d.subset['sample'] /= ds.rebin(d[Coord.Monitor, 'beam'].scalar, d[Coord.Tof])
```
so we copied it into a new dataset