### PR TITLE
String axis in 1d plotting

### DIFF
--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -138,7 +138,7 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None):
                                    "dimensions, use plot_sliceviewer."
                                    .format(len(v[0].dimensions)))
 
-            # Define y: try to see if coordinate contains numbers
+            # Define y: try to see if array contains numbers
             try:
                 y = v[0].numpy
             # If .numpy fails, try to extract as an array of strings

--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -138,8 +138,12 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None):
                                    "dimensions, use plot_sliceviewer."
                                    .format(len(v[0].dimensions)))
 
-            # Define y
-            y = v[0].numpy
+            # Define y: try to see if coordinate contains numbers
+            try:
+                y = v[0].numpy
+            # If .numpy fails, try to extract as an array of strings
+            except RuntimeError:
+                y = np.array(v[0].data, dtype=np.str)
             name = axis_label(v[0])
             # TODO: getting the shape of the dimension array is done in two
             # steps here because v.dimensions.shape[0] returns garbage. One of
@@ -154,7 +158,10 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None):
             coord = item[axes_copy[0]]
             xdims = coord.dimensions
             nx = xdims.shape[0]
-            x = coord.numpy
+            try:
+                x = coord.numpy
+            except RuntimeError:
+                x = np.array(coord.data, dtype=np.str)
             # Check for bin edges
             histogram = False
             if nx == ny + 1:


### PR DESCRIPTION
If coordinate or data contains strings instead of numbers, we catch the error from `.numpy` which says it is not implemented and convert the `.data` to a `numpy` array of strings.

The following is now possible:
```Python
d = Dataset()
d[Coord.Row] = ([Dim.Row], ['January', 'February', 'March'])
d[Data.Value] = ([Dim.Row], [1.0,1.1,1.2])
plot(d)
```
and you can even do this!
```Python
d2 = Dataset()
d2[Coord.Row] = ([Dim.Row], ['January', 'February', 'March'])
d2[Data.Value, "a"] = ([Dim.Row], ['a','b','c'])
d2[Data.Value, "b"] = ([Dim.Row], [1.0,1.1,1.2])
plot(d2)
```

Fixes #82 