### PR TITLE
Better format for float output in table, 

### DIFF
--- a/python/table.py
+++ b/python/table.py
@@ -100,12 +100,12 @@ def table_ds(dataset):
         for i in range(length):
             tr = et.SubElement(tab, 'tr')
             for x in coords:
-                text = str(x.data[i])
+                text = value_to_string(x.data[i])
                 if is_hist:
-                    text = '[{}; {}]'.format(text, str(x.data[i+1]))
+                    text = '[{}; {}]'.format(text, value_to_string(x.data[i+1]))
                 append_with_text(tr, 'th', text)
             for x in datas:
-                append_with_text(tr, 'th', str(x.data[i]))
+                append_with_text(tr, 'th', value_to_string(x.data[i]))
 
     from IPython.display import display, HTML
     display(HTML(et.tostring(body).decode('UTF-8')))
@@ -149,3 +149,14 @@ def table(some):
     else:
         raise RuntimeError("Type {} is not supported".format(tp))
 
+
+def value_to_string(val):
+    if (type(val) is int) or (val == 0):
+        text = str(val)
+    elif abs(val) >= 1.0e4 or abs(val) <= 1.0e-4:
+        text = "{:.3e}".format(val)
+    else:
+        text = "{}".format(val)
+        if len(text) > 5 + (text[0] == '-'):
+            text = "{:.3f}".format(val)
+    return text

--- a/python/table.py
+++ b/python/table.py
@@ -151,7 +151,7 @@ def table(some):
 
 
 def value_to_string(val):
-    if (type(val) is int) or (val == 0):
+    if (type(val) is not float) or (val == 0):
         text = str(val)
     elif abs(val) >= 1.0e4 or abs(val) <= 1.0e-4:
         text = "{:.3e}".format(val)


### PR DESCRIPTION
To avoid long strings created by noise in float representation.

- `0` is printed as `0` or `0.0` depending on its type
- `Ints` are printed as is
- `floats` with an absolute value larger than 1.0e4 or smaller than 1.0e-4 are printed in scientific notation
- other `floats` are printed as is, unless the resulting string has more than 3 decimal places, in which case it is rounded off after 3 decimal places.