### PR TITLE
Small plotting fixes

### DIFF
--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -271,7 +271,6 @@ def plot_image(input_data, axes=None, contours=False, cb=None, plot=True):
 
         # Apply colorbar parameters
         cbcount = (cbar["min"] is not None) + (cbar["max"] is not None)
-        print("cbcount is",cbcount)
         if cbcount == 2:
             data[0]["zmin"] = cbar["min"]
             data[0]["zmax"] = cbar["max"]


### PR DESCRIPTION
- Using only one of min or max in the colorbar (`cb`) is now possible: `cb={'log':True, 'max':100}`
- Also throwing an error if we are trying to use coordinates which have more than 1 dimension, as this is currently not supported. The user is advised to use `rebin` to re-sample the data to a common axis.