### PR TITLE
Plotting entire Datasets

### DIFF
--- a/exports/dataset.cpp
+++ b/exports/dataset.cpp
@@ -1247,6 +1247,8 @@ PYBIND11_MODULE(dataset, m) {
       // to double.
       .def("__setitem__", detail::insert_0D<int64_t, detail::Key::Tag>)
       .def("__setitem__", detail::insert_0D<int64_t, detail::Key::TagName>)
+      .def("__setitem__", detail::insert_0D<double, detail::Key::Tag>)
+      .def("__setitem__", detail::insert_0D<double, detail::Key::TagName>)
       .def("__setitem__", detail::insert_0D<std::string, detail::Key::Tag>)
       .def("__setitem__", detail::insert_0D<std::string, detail::Key::TagName>)
       .def("__setitem__", detail::insert_0D<Dataset, detail::Key::Tag>)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,9 +1,8 @@
 from .dataset import *
-from .dataset_plotting import plot, plot_1d, plot_image, plot_sliceviewer, plot_waterfall
 from .table import table
-# Following fix for problem described here https://stackoverflow.com/questions/21784641/installation-issue-with-matplotlib-python
-import platform
-if platform.system() == 'Darwin':
-    import matplotlib
-    # Switch backends
-    matplotlib.use('TkAgg')
+try:
+    from .dataset_plotting import plot, plot_1d, plot_image, plot_sliceviewer, plot_waterfall
+except ImportError:
+    print("Warning: the plotting module for Dataset was not imported. Check "
+          "that plotly is installed on your system. You can still use Dataset "
+          "without its plotting functionality enabled.")

--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -66,26 +66,25 @@ def plot(input_data, axes=None, waterfall=None, collapse=None, **kwargs):
         values, ndims = check_input(input_data, check_multiple_values=False)
         if len(values) > 1:
             # Search through the variables and group the 1D datasets that have
-            # the same coordinate axis
-            if np.amin(ndims) == 1:
-                # tobeplotted is a dict that holds pairs of
-                # [number_of_dimensions, DatasetSlice], or
-                # [number_of_dimensions, [List of DatasetSlices]] in the case of
-                # 1d data.
-                # TODO: 0D data is currently ignored. Find a nice way of
-                # displaying it?
-                tobeplotted = dict()
-                for i in range(len(values)):
-                    if ndims[i] == 1:
-                        dims = values[i].dimensions
-                        labs = dims.labels
-                        key = str(labs[0])
-                        if key in tobeplotted.keys():
-                            tobeplotted[key][1].append(input_data.subset[values[i].name])
-                        else:
-                            tobeplotted[key] = [ndims[i], [input_data.subset[values[i].name]]]
-                    elif ndims[i] > 1:
-                        tobeplotted[values[i].name] = [ndims[i], input_data.subset[values[i].name]]
+            # the same coordinate axis.
+            # tobeplotted is a dict that holds pairs of
+            # [number_of_dimensions, DatasetSlice], or
+            # [number_of_dimensions, [List of DatasetSlices]] in the case of
+            # 1d data.
+            # TODO: 0D data is currently ignored -> find a nice way of
+            # displaying it?
+            tobeplotted = dict()
+            for i in range(len(values)):
+                if ndims[i] == 1:
+                    dims = values[i].dimensions
+                    labs = dims.labels
+                    key = str(labs[0])
+                    if key in tobeplotted.keys():
+                        tobeplotted[key][1].append(input_data.subset[values[i].name])
+                    else:
+                        tobeplotted[key] = [ndims[i], [input_data.subset[values[i].name]]]
+                elif ndims[i] > 1:
+                    tobeplotted[values[i].name] = [ndims[i], input_data.subset[values[i].name]]
 
             # Plot all the subsets
             color_count = 0

--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -72,6 +72,8 @@ def plot(input_data, axes=None, waterfall=None, collapse=None, **kwargs):
                 # [number_of_dimensions, DatasetSlice], or
                 # [number_of_dimensions, [List of DatasetSlices]] in the case of
                 # 1d data.
+                # TODO: 0D data is currently ignored. Find a nice way of
+                # displaying it?
                 tobeplotted = dict()
                 for i in range(len(values)):
                     if ndims[i] == 1:
@@ -82,7 +84,7 @@ def plot(input_data, axes=None, waterfall=None, collapse=None, **kwargs):
                             tobeplotted[key][1].append(input_data.subset[values[i].name])
                         else:
                             tobeplotted[key] = [ndims[i], [input_data.subset[values[i].name]]]
-                    else:
+                    elif ndims[i] > 1:
                         tobeplotted[values[i].name] = [ndims[i], input_data.subset[values[i].name]]
 
             # Plot all the subsets
@@ -127,7 +129,7 @@ def plot_auto(input_data, ndim=0, axes=None, waterfall=None, collapse=None,
 # Plot a 1D spectrum.
 #
 # Inputs can be either a Dataset(Slice) or a list of Dataset(Slice)s.
-# If bars=True, then a bar plot is produced instead of a standard line.
+# If the coordinate of the x-axis contains bin edges, then a bar plot is made.
 #
 # TODO: find a more general way of handling arguments to be sent to plotly,
 # probably via a dictionay of arguments

--- a/python/dataset_plotting.py
+++ b/python/dataset_plotting.py
@@ -9,7 +9,6 @@ from dataset import Dataset, Data, dataset, dimensionCoord, coordDimension, sqrt
 
 # Plotly imports
 from plotly.offline import init_notebook_mode, iplot
-from plotly.tools import make_subplots
 try:
     # Re-direct the output of init_notebook_mode to hide it from the unit tests
     with redirect_stdout(io.StringIO()):
@@ -66,9 +65,13 @@ def plot(input_data, axes=None, waterfall=None, collapse=None, **kwargs):
     else:
         values, ndims = check_input(input_data, check_multiple_values=False)
         if len(values) > 1:
-            # Search through the variables and group the 1D datasets that have the
-            # same coordinate axis
+            # Search through the variables and group the 1D datasets that have
+            # the same coordinate axis
             if np.amin(ndims) == 1:
+                # tobeplotted is a dict that holds pairs of
+                # [number_of_dimensions, DatasetSlice], or
+                # [number_of_dimensions, [List of DatasetSlices]] in the case of
+                # 1d data.
                 tobeplotted = dict()
                 for i in range(len(values)):
                     if ndims[i] == 1:
@@ -102,15 +105,18 @@ def plot(input_data, axes=None, waterfall=None, collapse=None, **kwargs):
 
 # Function to automaticall dispatch the input dataset to the appropriate
 # plotting function depending on its dimensions
-def plot_auto(input_data, ndim=0, axes=None, waterfall=None, collapse=None, **kwargs):
+def plot_auto(input_data, ndim=0, axes=None, waterfall=None, collapse=None,
+              **kwargs):
 
     if ndim == 1:
         return plot_1d(input_data, axes=axes, **kwargs)
     elif ndim == 2:
         if collapse is not None:
-            return plot_1d(plot_waterfall(input_data, dim=collapse, axes=axes, plot=False), **kwargs)
+            return plot_1d(plot_waterfall(input_data, dim=collapse, axes=axes,
+                                          plot=False), **kwargs)
         elif waterfall is not None:
-            return plot_waterfall(input_data, dim=waterfall, axes=axes, **kwargs)
+            return plot_waterfall(input_data, dim=waterfall, axes=axes,
+                                  **kwargs)
         else:
             return plot_image(input_data, axes=axes, **kwargs)
     else:
@@ -126,7 +132,7 @@ def plot_auto(input_data, ndim=0, axes=None, waterfall=None, collapse=None, **kw
 # TODO: find a more general way of handling arguments to be sent to plotly,
 # probably via a dictionay of arguments
 def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None,
-            plot=True, color=None):
+            color=None):
 
     entries = []
     # Case of a single dataset
@@ -264,10 +270,7 @@ def plot_1d(input_data, logx=False, logy=False, logxy=False, axes=None,
     if logy or logxy:
         layout["yaxis"]["type"] = "log"
 
-    if plot:
-        return iplot(dict(data=data, layout=layout))
-    else:
-        return data, layout
+    return iplot(dict(data=data, layout=layout))
 
 #===============================================================================
 


### PR DESCRIPTION
It is now possible to plot all the Variables in a `Dataset` in one go.
There is no longer a warning if the `Dataset` contains more than one `Value`, it simply makes one plot for each `Variable`.

Example:
```Python
d = ds.Dataset()
d[Coord.X] = ([Dim.X], np.arange(11.0))
d[Coord.Y] = ([Dim.Y], np.arange(11.0))
d[Coord.Z] = ([Dim.Z], np.arange(11.0))
d[Coord.Tof] = ([Dim.Tof], np.arange(300.0))
d[Coord.Energy] = ([Dim.Energy], np.arange(5.0))
d[Coord.Qx] = ([Dim.Qx], np.arange(201.0))
d[Data.Value, "alice"] = ([Dim.Z, Dim.Y, Dim.X], np.random.rand(10, 10, 10))
d[Data.Variance, "alice"] = d[Data.Value, "alice"]
d[Data.Value, "bob"] = ([Dim.X, Dim.Z], np.arange(0.0, 10.0, 0.1).reshape(10, 10))
d[Data.Variance, "bob"] = d[Data.Value, "bob"]
d[Data.Value, "sample"] = ([Dim.Tof], np.random.rand(300))
d[Data.Value, "background"] = ([Dim.Tof], np.random.rand(300))
d[Data.Value, "energy"] = ([Dim.Energy], np.random.rand(5))
d[Data.Variance, "energy"] = ([Dim.Energy], 0.1*np.random.rand(5))
d[Data.Value, "Qx1"] = ([Dim.Qx], np.random.rand(200))
d[Data.Variance, "Qx1"] = ([Dim.Qx], 0.1*np.random.rand(200))
d[Data.Variance, "Qx1"] = ([Dim.Qx], 0.1*np.random.rand(200))
d[Data.Value, "Qx2"] = ([Dim.Qx], np.random.rand(200))
plot(d)
```

In addition, the python `__init__.py` was changed so that `Dataset` can still be used from `Python` even if `plotly` is not installed on the user's system (the plotting functionality will then be disabled).

Finally, a small fix to the python exports has also been added: a Dataset `__setitem__` for a 0D variable with a `double` was added. Until now, only `int64` was supported.

